### PR TITLE
Changing max values for Chadoq2

### DIFF
--- a/pulser/devices/_devices.py
+++ b/pulser/devices/_devices.py
@@ -12,21 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Definitions of Pasqal's devices."""
+import numpy as np
 
 from pulser.devices._pasqal_device import PasqalDevice
 from pulser.channels import Raman, Rydberg
 
 
 Chadoq2 = PasqalDevice(
-            name="Chadoq2",
-            dimensions=2,
-            max_atom_num=100,
-            max_radial_distance=50,
-            min_atom_distance=4,
-            _channels=(
-                ("rydberg_global", Rydberg.Global(50, 2.5)),
-                ("rydberg_local", Rydberg.Local(50, 10, 100)),
-                ("rydberg_local2", Rydberg.Local(50, 10, 100)),
-                ("raman_local", Raman.Local(50, 10, 100)),
-                ),
-            )
+    name="Chadoq2",
+    dimensions=2,
+    max_atom_num=100,
+    max_radial_distance=50,
+    min_atom_distance=4,
+    _channels=(
+        ("rydberg_global", Rydberg.Global(2 * np.pi * 50, 2 * np.pi * 2.5)),
+        ("rydberg_local", Rydberg.Local(2 * np.pi * 50, 2 * np.pi * 10, 100)),
+        ("rydberg_local2", Rydberg.Local(2 * np.pi * 50, 2 * np.pi * 10, 100)),
+        ("raman_local", Raman.Local(2 * np.pi * 50, 2 * np.pi * 10, 100)),
+    ),
+)

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -166,10 +166,10 @@ def test_sequence():
     with pytest.raises(TypeError):
         seq.add([1, 5, 3], 'ch0')
     with pytest.raises(ValueError, match='amplitude goes over the maximum'):
-        seq.add(Pulse.ConstantPulse(10, 10, -100, 0), 'ch2')
+        seq.add(Pulse.ConstantPulse(10, 2*np.pi*10, -2*np.pi*100, 0), 'ch2')
     with pytest.raises(ValueError,
                        match='detuning values go out of the range'):
-        seq.add(Pulse.ConstantPulse(500, 1, -100, 0), 'ch0')
+        seq.add(Pulse.ConstantPulse(500, 2*np.pi, -2*np.pi*100, 0), 'ch0')
     with pytest.raises(ValueError, match='qubits with different phase ref'):
         seq.add(pulse2, 'ch2')
     with pytest.raises(ValueError, match='Invalid protocol'):


### PR DESCRIPTION
Pull request to add the 2*pi factors in the current definition of Chadoq2. Should close issue #2.