### PR TITLE
Interaction coefficient and Rydberg blockade radius from device

### DIFF
--- a/pulser/devices/_pasqal_device.py
+++ b/pulser/devices/_pasqal_device.py
@@ -24,7 +24,18 @@ from pulser.register import Register
 
 @dataclass(frozen=True, repr=False)
 class PasqalDevice:
-    """Definition of a Pasqal Device."""
+    """Definition of a Pasqal Device.
+
+    Attributes:
+        name: The name of the device.
+        dimensions: Whether it supports 2D or 3D arrays.
+        max_atom_num: Maximum number of atoms supported in an array.
+        max_radial_distance: The furthest away an atom can be from the center
+            of the array (in um).
+        min_atom_distance: The closest together two atoms can be (in um).
+        interaction_coeff: C_6/hbar (in MHz.um^6), which sets the van der Waals
+            interaction strength between atoms in the Rydberg state.
+    """
 
     name: str
     dimensions: int
@@ -32,6 +43,7 @@ class PasqalDevice:
     max_radial_distance: int
     min_atom_distance: int
     _channels: Tuple[Tuple[str, Channel]]
+    interaction_coeff: float = 5008713.
 
     @property
     def channels(self):
@@ -65,6 +77,17 @@ class PasqalDevice:
 
     def __repr__(self):
         return self.name
+
+    def rydberg_blockade_radius(self, rabi_frequency):
+        """Calculates the Rydberg blockade radius for a given Rabi frequency.
+
+        Args:
+            rabi_frequency(float): The rabi frequency, in MHz.
+
+        Returns:
+            float: The rydberg blockade radius, in um.
+        """
+        return (self.interaction_coeff/rabi_frequency)**(1/6)
 
     def validate_register(self, register):
         """Checks if 'register' is compatible with this device.

--- a/pulser/tests/test_devices.py
+++ b/pulser/tests/test_devices.py
@@ -15,6 +15,7 @@
 from dataclasses import FrozenInstanceError
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 
 import pulser
@@ -28,6 +29,7 @@ def test_init():
         assert dev.max_atom_num > 10
         assert dev.max_radial_distance > 10
         assert dev.min_atom_distance > 0
+        assert dev.interaction_coeff > 0
         assert isinstance(dev.channels, dict)
         with pytest.raises(FrozenInstanceError):
             dev.name = "something else"
@@ -43,6 +45,7 @@ def test_mock():
     assert dev.dimensions == 2
     assert dev.max_atom_num > 1000
     assert dev.min_atom_distance <= 1
+    assert dev.interaction_coeff == 5008713
     names = ['Rydberg', 'Raman']
     basis = ['ground-rydberg', 'digital']
     for ch in dev.channels.values():
@@ -55,6 +58,11 @@ def test_mock():
             assert ch.retarget_time == 0
             assert ch.max_targets > 1
             assert ch.max_targets == int(ch.max_targets)
+
+
+def test_rydberg_blockade():
+    dev = pulser.devices.MockDevice
+    assert np.isclose(dev.rydberg_blockade_radius(3*np.pi), 9)
 
 
 def test_validate_register():


### PR DESCRIPTION
Makes `C_6/hbar` a device characteristic and introduces a method to calculate the Rydberg blockade radius for a particular Rabi frequency value.

Also specifies the attributes of `PasqalDevice` in its docstring.

Closes #57.