### PR TITLE
Fixing a bug in Register.from_coordinates

### DIFF
--- a/pulser/register.py
+++ b/pulser/register.py
@@ -53,7 +53,7 @@ class Register:
                 (e.g. prefix='q' -> IDs: 'q0', 'q1', 'q2', ...).
         """
         if center:
-            coords -= np.mean(coords, axis=0)      # Centers the array
+            coords = coords - np.mean(coords, axis=0)      # Centers the array
         if prefix is not None:
             pre = str(prefix)
             qubits = {pre+str(i): pos for i, pos in enumerate(coords)}

--- a/pulser/tests/test_register.py
+++ b/pulser/tests/test_register.py
@@ -32,10 +32,11 @@ def test_creation():
     reg2 = Register.from_coordinates(coords, center=False, prefix='q')
     assert reg1.qubits == reg2.qubits
 
-    reg3 = Register.from_coordinates(coords, prefix='foo')
+    reg3 = Register.from_coordinates(np.array(coords), prefix='foo')
     coords_ = np.array([(-0.5, 0), (0.5, 0)])
     assert reg3._ids == ['foo0', 'foo1']
     assert np.all(reg3._coords == coords_)
+    assert not np.all(coords_ == coords)
 
     reg4 = Register.rectangle(1, 2, spacing=1)
     assert np.all(reg4._coords == coords_)


### PR DESCRIPTION
The `Register.from_coordinates` class method did two things wrong: Changed the input in-place and raised an error when the type of the `coords` array was not a float. This tiny PR fixes both these mistakes and also tightens up the related test.