### PR TITLE
Removing _chirps from Pulse

### DIFF
--- a/pulser/pulse.py
+++ b/pulser/pulse.py
@@ -15,7 +15,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-from pulser.waveforms import Waveform, ConstantWaveform, RampWaveform
+from pulser.waveforms import Waveform, ConstantWaveform
 
 
 class Pulse:

--- a/pulser/pulse.py
+++ b/pulser/pulse.py
@@ -137,14 +137,14 @@ class Pulse:
             if start_det is None or start_det == self.detuning.first_value:
                 return 0
             else:
-                chirps = np.zeros(self.duration / clock_t, dtype=float)
+                chirps = np.zeros(self.duration // clock_t, dtype=float)
                 second_value = self.detuning.first_value
 
         elif isinstance(self.detuning, RampWaveform):
             if start_det is None or start_det == self.detuning.first_value:
                 return self.detuning.slope
             else:
-                chirps = np.full(self.duration / clock_t, self.detuning.slope)
+                chirps = np.full(self.duration // clock_t, self.detuning.slope)
                 second_value = self.detuning.slope * clock_t
         else:
             samples = self.detuning.samples

--- a/pulser/pulse.py
+++ b/pulser/pulse.py
@@ -152,6 +152,7 @@ class Pulse:
             chirps = chirps / clock_t
             if start_det is None or start_det == samples[0]:
                 return chirps
+            second_value = samples[clock_t-1]
 
         chirps[0] = (second_value - start_det) / clock_t
         return chirps

--- a/pulser/pulse.py
+++ b/pulser/pulse.py
@@ -145,7 +145,8 @@ class Pulse:
                 return self.detuning.slope
             else:
                 chirps = np.full(self.duration // clock_t, self.detuning.slope)
-                second_value = self.detuning.slope * clock_t
+                second_value = (self.detuning.slope * clock_t
+                                + self.detuning.first_value)
         else:
             samples = self.detuning.samples
             chirps = samples[clock_t-1::clock_t] - samples[:-clock_t+1:clock_t]

--- a/pulser/pulse.py
+++ b/pulser/pulse.py
@@ -120,39 +120,3 @@ class Pulse:
         return (f"Pulse(amp={self.amplitude!r}, detuning={self.detuning!r}, " +
                 f"phase={self.phase:.3g}, " +
                 f"post_phase_shift={self.post_phase_shift:.3g})")
-
-    def _chirps(self, end_det=None):
-        """Describes the detuning waveform as a series of linear chirps.
-
-        Turns the detuning into segments of linear frequency chirps, with a
-        length of 4ns. If the chirp rate is constant through the entire pulse,
-        returns a single value.
-
-        Returns:
-            float, np.ndarray: The chirp rate, or an array of chirp rates,
-                describing the detuning waveform (in MHz/ns).
-        """
-        clock_t = 4  # ns
-        if isinstance(self.detuning, ConstantWaveform):
-            if end_det is None or end_det == self.detuning.last_value:
-                return 0
-            else:
-                chirps = np.zeros(self.duration // clock_t, dtype=float)
-                last_value = self.detuning.last_value
-
-        elif isinstance(self.detuning, RampWaveform):
-            if end_det is None or end_det == self.detuning.last_value:
-                return self.detuning.slope
-            else:
-                chirps = np.full(self.duration // clock_t, self.detuning.slope)
-                last_value = self.detuning.last_value
-        else:
-            samples = self.detuning.samples
-            chirps = samples[clock_t::clock_t] - samples[:-clock_t:clock_t]
-            chirps = np.append(chirps / clock_t, 0.)
-            if end_det is None or end_det == samples[-1]:
-                return chirps
-            last_value = samples[-1]
-
-        chirps[-1] = (end_det - last_value) / clock_t
-        return chirps

--- a/pulser/tests/test_pulse.py
+++ b/pulser/tests/test_pulse.py
@@ -74,11 +74,3 @@ def test_draw():
     pls_ = Pulse.ConstantDetuning(bwf, -10, 1, post_phase_shift=-np.pi)
     with patch('matplotlib.pyplot.show'):
         pls_.draw()
-
-
-def test_chirps():
-    assert pls4._chirps() == 0
-    assert Pulse.ConstantAmplitude(1, rwf, 1)._chirps() == 1/200
-    samples = bwf.samples
-    chirps = (samples[3::4] - samples[:-3:4]) / 4
-    assert np.all(pls._chirps() == chirps)


### PR DESCRIPTION
Following our discussion, this PR serves to eliminate the `_chirps` method from the `Pulse` class, as it doesn't have any use inside Pulser. 

Closes #75 .