### PR TITLE
Centralising version tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pulser is a framework for composing, simulating and executing **pulse** sequences for neutral-atom quantum devices.
 
-Pulser documentation is available at https://pulser.readthedocs.io.
+**Documentation** for the [latest release](https://pypi.org/project/pulser/) of `pulser` is available at https://pulser.readthedocs.io (for the docs tracking the `master` branch of this repository, visit https://pulser.readthedocs.io/en/latest instead).
 
 The source code can be found at https://github.com/pasqal-io/Pulser.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,8 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../../pulser'))
 
+__version__ = ''
+exec(open('../../pulser/_version.py').read())
 
 # -- Project information -----------------------------------------------------
 
@@ -22,7 +24,7 @@ copyright = '2020, Pulser Development Team'
 author = 'Pulser Development Team'
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+release = __version__
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,14 +1,15 @@
 Pulser
 ==================================
 
-**Pulser** is an open-source Python software package. It provides easy-to-use 
+**Pulser** is an open-source Python software package. It provides easy-to-use
 libraries for designing and simulating pulse sequences that act on
 programmable arrays of neutral atoms, a promising platform for quantum computation
 and simulation.
 
 **Online documentation**: `<https://pulser.readthedocs.io>`_
 
-**Source code repository**: `<https://github.com/pasqal-io/Pulser>`_
+**Source code repository** (go `here <https://pulser.readthedocs.io/en/latest/>`_
+for the latest docs): `<https://github.com/pasqal-io/Pulser>`_
 
 **License**: Apache 2.0 -- see `LICENSE <https://github.com/pasqal-io/Pulser/blob/master/LICENSE>`_
 for details

--- a/pulser/_version.py
+++ b/pulser/_version.py
@@ -12,14 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A pulse-level composer for Pasqal's quantum devices."""
-
-from pulser._version import __version__
-
-from pulser.pulse import Pulse
-
-from pulser.register import Register
-
-from pulser.sequence import Sequence
-
-from pulser.simulation import Simulation
+__version__ = "0.1.0.dev"

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,12 @@
 
 from setuptools import setup, find_packages
 
+__version__ = ''
+exec(open('pulser/_version.py').read())
+
 setup(
     name="pulser",
-    version="0.1.0",
+    version=__version__,
     install_requires=[
         "matplotlib",
         "numpy",


### PR DESCRIPTION
I noticed that the docs version was not up-to-date with the version of `pulser`, and then I remember that there's a version parameter in `conf.py` that I forgot about. 
This is not a big deal and I don't think it warrants sending out a new release, but I thought it would be good to have the version information in a single place and then get if from there, wherever it is needed. I'm also updating it with the `dev` suffix to distinguish if from the released package. This way, for the next release, we just bump it to the next version (say, `v0.1.1`), upload the package to PyPI and then bump it again (to `v0.1.1.dev`) to keep working on it here. 

Also, calling `pulser.__version__` now returns the version, which is expected behaviour that we did not have.

I also took the chance to have two versions of the docs, one for the `stable` version (which will be the default when visiting https://pulser.readthedocs.io/) and then the `latest` that tracks the `master` branch. I'm including links for this in the docs homepage and the `README`.