### PR TITLE
Fixing compatibility issue with latest version of QuTiP

### DIFF
--- a/pulser/simresults.py
+++ b/pulser/simresults.py
@@ -125,7 +125,7 @@ class SimulationResults:
 
         N = self._size
         self.N_samples = N_samples
-        probs = np.abs(self._states[-1])**2
+        probs = np.abs(self._states[-1].data.toarray())**2
         if self._dim == 2:
             if meas_basis == self._basis_name:
                 # State vector ordered with r first for 'ground_rydberg'


### PR DESCRIPTION
The latest version of `qutip` (4.5.3) does not allow a direct call of `np.abs` on a `QObj`, so this is a fix where the data is explicitly retrieved and turned into a `np.ndarray` beforehand.

@sebgrijalva : Before we merge this, can you think of anywhere else where something like this might be happening?