### PR TITLE
Increasing robustness of Register initialisation

### DIFF
--- a/pulser/devices/_pasqal_device.py
+++ b/pulser/devices/_pasqal_device.py
@@ -105,10 +105,10 @@ class PasqalDevice:
         if len(atoms) > self.max_atom_num:
             raise ValueError("Too many atoms in the array, the device accepts "
                              "at most {} atoms.".format(self.max_atom_num))
-        for pos in atoms:
-            if len(pos) != self.dimensions:
-                raise ValueError("All qubit positions must be {}D "
-                                 "vectors.".format(self.dimensions))
+
+        if register._dim != self.dimensions:
+            raise ValueError("All qubit positions must be {}D "
+                             "vectors.".format(self.dimensions))
 
         if len(atoms) > 1:
             distances = pdist(atoms)  # Pairwise distance between atoms

--- a/pulser/register.py
+++ b/pulser/register.py
@@ -33,7 +33,13 @@ class Register:
             raise TypeError("The qubits have to be stored in a dictionary "
                             "matching qubit ids to position coordinates.")
         self._ids = list(qubits.keys())
-        self._coords = list(qubits.values())
+        coords = [np.array(v, dtype=float) for v in qubits.values()]
+        self._dim = coords[0].size
+        if (any(c.shape != (self._dim,) for c in coords) or
+           (self._dim != 2 and self._dim != 3)):
+            raise ValueError("All coordinates must be specified as vectors of"
+                             " size 2 or 3.")
+        self._coords = coords
 
     @property
     def qubits(self):
@@ -130,6 +136,8 @@ class Register:
         Args:
             degrees (float): The angle of rotation in degrees.
         """
+        if self._dim != 2:
+            raise NotImplementedError("Can only rotate arrays in 2D.")
         theta = np.deg2rad(degrees)
         rot = np.array([[np.cos(theta), -np.sin(theta)],
                         [np.sin(theta), np.cos(theta)]])
@@ -157,6 +165,8 @@ class Register:
             This representation is preferred over drawing the full Rydberg
             radius because it helps in seeing the interactions between atoms.
         """
+        if self._dim != 2:
+            raise NotImplementedError("Can only draw register layouts in 2D.")
         pos = np.array(self._coords)
         diffs = np.max(pos, axis=0) - np.min(pos, axis=0)
         diffs[diffs < 9] *= 1.5

--- a/pulser/tests/test_devices.py
+++ b/pulser/tests/test_devices.py
@@ -82,7 +82,7 @@ def test_validate_register():
         Chadoq2.validate_register(Register.from_coordinates(coords))
 
     with pytest.raises(ValueError, match='must be 2D vectors'):
-        coords += [(-10, 4, 0)]
+        coords = [(-10, 4, 0), (0, 0, 0)]
         Chadoq2.validate_register(Register(dict(enumerate(coords))))
 
     with pytest.raises(ValueError, match="don't respect the minimal distance"):

--- a/pulser/tests/test_register.py
+++ b/pulser/tests/test_register.py
@@ -28,9 +28,16 @@ def test_creation():
         Register(coords)
         Register(ids)
 
+    with pytest.raises(ValueError, match="vectors of size 2 or 3"):
+        Register.from_coordinates([(0, 1, 0, 1)])
+
+    with pytest.raises(ValueError, match="vectors of size 2 or 3"):
+        Register.from_coordinates([((1, 0),), ((-1, 0),)])
+
     reg1 = Register(qubits)
     reg2 = Register.from_coordinates(coords, center=False, prefix='q')
-    assert reg1.qubits == reg2.qubits
+    assert np.all(np.array(reg1._coords) == np.array(reg2._coords))
+    assert reg1._ids == reg2._ids
 
     reg3 = Register.from_coordinates(np.array(coords), prefix='foo')
     coords_ = np.array([(-0.5, 0), (0.5, 0)])
@@ -52,6 +59,9 @@ def test_creation():
 
 
 def test_rotation():
+    with pytest.raises(NotImplementedError):
+        reg_ = Register.from_coordinates([(1, 0, 0), (0, 1, 4)])
+        reg_.rotate(20)
     reg = Register.square(2, spacing=np.sqrt(2))
     reg.rotate(45)
     coords_ = np.array([(0, -1), (1, 0), (-1, 0), (0, 1)], dtype=float)
@@ -59,6 +69,9 @@ def test_rotation():
 
 
 def test_drawing():
+    with pytest.raises(NotImplementedError, match="register layouts in 2D."):
+        reg_ = Register.from_coordinates([(1, 0, 0), (0, 1, 4)])
+        reg_.draw()
     reg = Register.triangular_lattice(3, 8)
     with patch('matplotlib.pyplot.show'):
         reg.draw()
@@ -74,5 +87,5 @@ def test_drawing():
         reg.draw(draw_half_radius=True)
 
     reg = Register.square(1)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match="Needs more than one atom"):
         reg.draw(blockade_radius=5, draw_half_radius=True)


### PR DESCRIPTION
There we no checks on the atom coordinates given to a Register upon initialisation and although these were verified by `PasqalDevice.validate_register()`, it still gave rise to bugs when calling the register methods e.g. when drawing a register with 3D coordinates or even 2D coordinates of type `int`.

These changes look out for invalid inputs, standardise how the information is stored and make the whole class less prone to spurious errors.