### PR TITLE
Single atom hotfix

### DIFF
--- a/pulser/simulation.py
+++ b/pulser/simulation.py
@@ -221,7 +221,7 @@ class Simulation:
             qobj_list = []
         else:
             # Van der Waals Interaction Terms
-            qobj_list = [make_vdw_term()]
+            qobj_list = [make_vdw_term()] if self._size > 1 else []
 
         # Time dependent terms:
         for addr in self.samples:

--- a/pulser/tests/test_simulation.py
+++ b/pulser/tests/test_simulation.py
@@ -19,7 +19,7 @@ import qutip
 
 from pulser import Sequence, Pulse, Register, Simulation
 from pulser.devices import Chadoq2
-from pulser.waveforms import BlackmanWaveform
+from pulser.waveforms import BlackmanWaveform, ConstantWaveform
 
 q_dict = {"control1": np.array([-4., 0.]),
           "target": np.array([0., 4.]),
@@ -194,6 +194,16 @@ def test_empty_sequences():
         seq.declare_channel('test', 'rydberg_local', 'target')
         seq.declare_channel("test2", "rydberg_global")
         Simulation(seq)
+
+
+def test_single_atom_simulation():
+    one_reg = Register.from_coordinates([(0, 0)], 'atom')
+    one_seq = Sequence(one_reg, Chadoq2)
+    one_seq.declare_channel('ch0', 'rydberg_global')
+    one_seq.add(Pulse.ConstantDetuning(ConstantWaveform(16, 1.), 1., 0), 'ch0')
+    one_sim = Simulation(seq)
+    one_res = one_sim.run()
+    assert(one_res._size == one_sim._size)
 
 
 def test_run():


### PR DESCRIPTION
Fixes a bug in case `Register` contains only one atom. Includes testing for the creation of the `SimulationResults` object.