### PR TITLE
Supporting parametrized arguments in BlackmanWaveform.from_max_val

### DIFF
--- a/pulser/tests/test_waveforms.py
+++ b/pulser/tests/test_waveforms.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 
 from pulser._json_coders import PulserEncoder, PulserDecoder
+from pulser.parametrized import Variable, ParamObj
 from pulser.waveforms import (ConstantWaveform, RampWaveform, BlackmanWaveform,
                               CustomWaveform, CompositeWaveform)
 
@@ -152,6 +153,12 @@ def test_blackman():
     wf = BlackmanWaveform.from_max_val(-10, -np.pi)
     assert np.isclose(wf.integral, -np.pi)
     assert np.min(wf.samples) > -10
+
+    var = Variable("var", float)
+    wf_var = BlackmanWaveform.from_max_val(-10, var)
+    assert isinstance(wf_var, ParamObj)
+    var._assign(-np.pi)
+    assert wf_var.build() == wf
 
 
 def test_ops():

--- a/pulser/waveforms.py
+++ b/pulser/waveforms.py
@@ -415,6 +415,10 @@ class BlackmanWaveform(Waveform):
                 sign of `area`.
             area (float): The area under the waveform.
         """
+
+        if isinstance(max_val, Parametrized) or isinstance(area, Parametrized):
+            return ParamObj(cls.from_max_val, max_val, area)
+
         if np.sign(max_val) != np.sign(area):
             raise ValueError("The maximum value and the area must have "
                              "matching signs.")


### PR DESCRIPTION
I stumbled upon the fact that `Waveform` or `Pulse`, created through a `classmethod` that processes the input arguments somehow, will most likely not support `Parametrized` arguments unless specifically stated.

So far, this is the only case where that happens, but should other cases appear, perhaps we should make a standard decorator to deal with this systematically. 