### PR TITLE
Removing Pasqal mentions + Relaxing restrictions on allowed devices for Sequences

### DIFF
--- a/docs/source/introduction_rydberg_blockade.ipynb
+++ b/docs/source/introduction_rydberg_blockade.ipynb
@@ -97,7 +97,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Each pulse acts on a set of atoms at a certain moment of time. The entire **Sequence** is stored by Pulser and can then be either simulated or sent to a real device (such as those built by [Pasqal](https://pasqal.io/)). Below is the example of a sequence sending the same $\\pi$-pulse to two atoms, sequentially, using the same channel."
+    "Each pulse acts on a set of atoms at a certain moment of time. The entire **Sequence** is stored by Pulser and can then be either simulated or sent to a real device. Below is the example of a sequence sending the same $\\pi$-pulse to two atoms, sequentially, using the same channel."
    ]
   },
   {

--- a/docs/source/pulser.rst
+++ b/docs/source/pulser.rst
@@ -14,7 +14,7 @@ Devices
 
 Structure of a Pasqal Device
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The :class:`PasqalDevice` class sets the structure of every device instance.
+The :class:`Device` class sets the structure of every device instance.
 
 .. automodule:: pulser.devices._pasqal_device
    :members:

--- a/docs/source/pulser.rst
+++ b/docs/source/pulser.rst
@@ -12,16 +12,16 @@ Channels
 Devices
 ---------------------
 
-Structure of a Pasqal Device
+Structure of a Device
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The :class:`Device` class sets the structure of every device instance.
 
-.. automodule:: pulser.devices._pasqal_device
+.. automodule:: pulser.devices._device_datacls
    :members:
 
 Physical Devices
 ^^^^^^^^^^^^^^^^^^^
-Each device instance holds the characteristics of one of Pasqal's physical devices,
+Each device instance holds the characteristics of a physical device,
 which when associated with a :class:`pulser.Sequence` condition its development.
 
 .. autodata:: pulser.devices.Chadoq2

--- a/pulser/__init__.py
+++ b/pulser/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A pulse-level composer for Pasqal's quantum devices."""
+"""A pulse-level composer for neutral-atom quantum devices."""
 
 from pulser._version import __version__
 

--- a/pulser/devices/_device_datacls.py
+++ b/pulser/devices/_device_datacls.py
@@ -25,7 +25,7 @@ from pulser.utils import obj_to_dict
 
 @dataclass(frozen=True, repr=False)
 class Device:
-    r"""Definition of a Pasqal Device.
+    r"""Definition of a neutral-atom device.
 
     Attributes:
         name: The name of the device.

--- a/pulser/devices/_devices.py
+++ b/pulser/devices/_devices.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Definitions of Pasqal's devices."""
+"""Definitions of real devices."""
 import numpy as np
 
-from pulser.devices._pasqal_device import Device
+from pulser.devices._device_datacls import Device
 from pulser.channels import Raman, Rydberg
 
 

--- a/pulser/devices/_devices.py
+++ b/pulser/devices/_devices.py
@@ -14,11 +14,11 @@
 """Definitions of Pasqal's devices."""
 import numpy as np
 
-from pulser.devices._pasqal_device import PasqalDevice
+from pulser.devices._pasqal_device import Device
 from pulser.channels import Raman, Rydberg
 
 
-Chadoq2 = PasqalDevice(
+Chadoq2 = Device(
     name="Chadoq2",
     dimensions=2,
     max_atom_num=100,

--- a/pulser/devices/_mock_device.py
+++ b/pulser/devices/_mock_device.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pulser.devices._pasqal_device import PasqalDevice
+from pulser.devices._pasqal_device import Device
 from pulser.channels import Rydberg, Raman
 
 
-MockDevice = PasqalDevice(
+MockDevice = Device(
             name="MockDevice",
             dimensions=2,
             max_atom_num=2000,

--- a/pulser/devices/_mock_device.py
+++ b/pulser/devices/_mock_device.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pulser.devices._pasqal_device import Device
+from pulser.devices._device_datacls import Device
 from pulser.channels import Rydberg, Raman
 
 

--- a/pulser/devices/_pasqal_device.py
+++ b/pulser/devices/_pasqal_device.py
@@ -24,7 +24,7 @@ from pulser.utils import obj_to_dict
 
 
 @dataclass(frozen=True, repr=False)
-class PasqalDevice:
+class Device:
     r"""Definition of a Pasqal Device.
 
     Attributes:

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -25,6 +25,7 @@ import numpy as np
 import pulser
 from pulser.pulse import Pulse
 from pulser.devices import MockDevice
+from pulser.devices._device_datacls import Device
 from pulser._json_coders import PulserEncoder, PulserDecoder
 from pulser.parametrized import Parametrized, Variable
 from pulser._seq_drawer import draw_sequence
@@ -116,14 +117,19 @@ class Sequence:
     """
     def __init__(self, register, device):
         """Initializes a new pulse sequence."""
+        if not isinstance(device, Device):
+            raise TypeError("'device' must be of type 'Device'. Import a valid"
+                            " device from 'pulser.devices'.")
         cond1 = device not in pulser.devices._valid_devices
         cond2 = device != MockDevice
         if cond1 and cond2:
             names = [d.name for d in pulser.devices._valid_devices]
-            error_msg = ("The Sequence's device has to be imported from "
-                         + "pulser.devices. Choose 'MockDevice' or between the"
-                         + " following real devices:\n" + "\n".join(names))
-            raise ValueError(error_msg)
+            warns_msg = ("The Sequence's device should be imported from "
+                         + "'pulser.devices'. Correct operation is not ensured"
+                         + " for custom devices. Choose 'MockDevice' or one of"
+                         + " the following real devices:\n" + "\n".join(names))
+            warnings.warn(warns_msg)
+
         # Checks if register is compatible with the device
         device.validate_register(register)
 

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -107,8 +107,8 @@ class Sequence:
 
     Args:
         register(Register): The atom register on which to apply the pulses.
-        device(PasqalDevice): A valid device in which to execute the Sequence
-            (import it from ``pulser.devices``).
+        device(Device): A valid device in which to execute the Sequence (import
+            it from ``pulser.devices``).
 
     Note:
         The register and device do not support variable parameters. As such,

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -121,7 +121,7 @@ class Sequence:
         if cond1 and cond2:
             names = [d.name for d in pulser.devices._valid_devices]
             error_msg = ("The Sequence's device has to be imported from "
-                         + "pasqal.devices. Choose 'MockDevice' or between the"
+                         + "pulser.devices. Choose 'MockDevice' or between the"
                          + " following real devices:\n" + "\n".join(names))
             raise ValueError(error_msg)
         # Checks if register is compatible with the device

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -20,7 +20,7 @@ import pytest
 import pulser
 from pulser import Sequence, Pulse, Register
 from pulser.devices import Chadoq2, MockDevice
-from pulser.devices._pasqal_device import PasqalDevice
+from pulser.devices._pasqal_device import Device
 from pulser.sequence import _TimeSlot
 from pulser.waveforms import BlackmanWaveform
 
@@ -29,7 +29,7 @@ device = Chadoq2
 
 
 def test_init():
-    fake_device = PasqalDevice("fake", 2, 10, 10, 1, Chadoq2._channels)
+    fake_device = Device("fake", 2, 10, 10, 1, Chadoq2._channels)
     with pytest.raises(ValueError, match='imported from pasqal.devices'):
         Sequence(reg, fake_device)
 

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -20,7 +20,7 @@ import pytest
 import pulser
 from pulser import Sequence, Pulse, Register
 from pulser.devices import Chadoq2, MockDevice
-from pulser.devices._pasqal_device import Device
+from pulser.devices._device_datacls import Device
 from pulser.sequence import _TimeSlot
 from pulser.waveforms import BlackmanWaveform
 
@@ -30,7 +30,7 @@ device = Chadoq2
 
 def test_init():
     fake_device = Device("fake", 2, 10, 10, 1, Chadoq2._channels)
-    with pytest.raises(ValueError, match='imported from pasqal.devices'):
+    with pytest.raises(ValueError, match='imported from pulser.devices'):
         Sequence(reg, fake_device)
 
     seq = Sequence(reg, device)

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -29,8 +29,11 @@ device = Chadoq2
 
 
 def test_init():
-    fake_device = Device("fake", 2, 10, 10, 1, Chadoq2._channels)
-    with pytest.raises(ValueError, match='imported from pulser.devices'):
+    with pytest.raises(TypeError, match="must be of type 'Device'"):
+        Sequence(reg, Device)
+
+    fake_device = Device("fake", 2, 100, 100, 1, Chadoq2._channels)
+    with pytest.warns(UserWarning, match="imported from 'pulser.devices'"):
         Sequence(reg, fake_device)
 
     seq = Sequence(reg, device)

--- a/tutorials/applications/Building 1D Rydberg Crystals.ipynb
+++ b/tutorials/applications/Building 1D Rydberg Crystals.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following notebook shows a study of many-body dynamics on a 1D system. It is based on [1707.04344](https://arxiv.org/abs/1707.04344). The authors of that paper studied the preparation of symmetry-breaking states in antiferromagnetic Ising chains, by tuning the interaction and driving parameters accross the phase diagram. In this notebook, we reproduce some results of this paper. Since this is a particular experiment not based on Pasqal's certified devices, we will use the `MockDevice` class to allow for a wide range of configuration settings."
+    "The following notebook shows a study of many-body dynamics on a 1D system. It is based on [1707.04344](https://arxiv.org/abs/1707.04344). The authors of that paper studied the preparation of symmetry-breaking states in antiferromagnetic Ising chains, by tuning the interaction and driving parameters accross the phase diagram. In this notebook, we reproduce some results of this paper. Since this is a particular experiment not based on certified devices, we will use the `MockDevice` class to allow for a wide range of configuration settings."
    ]
   },
   {

--- a/tutorials/applications/Control-Z Gate Sequence.ipynb
+++ b/tutorials/applications/Control-Z Gate Sequence.ipynb
@@ -62,7 +62,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1. Loading the Register on a Pasqal Device"
+    "## 1. Loading the Register on a Device"
    ]
   },
   {

--- a/tutorials/applications/Using QAOA to solve a MIS problem.ipynb
+++ b/tutorials/applications/Using QAOA to solve a MIS problem.ipynb
@@ -36,7 +36,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this tutorial, we illustrate how to solve the Maximum Independent Set (MIS) problem using the Quantum Approximate Optimization Algorithm procedure on a platform of Rydberg atoms in analog mode, using Pasqal's library Pulser. \n",
+    "In this tutorial, we illustrate how to solve the Maximum Independent Set (MIS) problem using the Quantum Approximate Optimization Algorithm procedure on a platform of Rydberg atoms in analog mode, using Pulser. \n",
     "\n",
     "For more details about this problem and how to encode it on a Rydberg atom quantum processor, see [Pichler, et al., 2018](https://arxiv.org/abs/1808.10816), [Henriet, 2020]( https://journals.aps.org/pra/abstract/10.1103/PhysRevA.101.012335) and [Dalyac, et al., 2020]( https://arxiv.org/abs/2012.14859])."
    ]
@@ -108,7 +108,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now illustrate how one can use Pulser and a Pasqal device to find the MIS of a UD-graph. Because the quantum platform is emulated in this notebook, we restrict the number of atoms to 5, just to show a proof-of-concept.\n",
+    "We now illustrate how one can use Pulser and a neutral-atom device to find the MIS of a UD-graph. Because the quantum platform is emulated in this notebook, we restrict the number of atoms to 5, just to show a proof-of-concept.\n",
     "\n",
     "A link in the graph corresponds to two atoms that are within the Rydberg Blockade Radius (RBR) of each other. The radius of RBR is directly linked to the Rabi frequency $\\Omega$ and is obtained using `Chadoq2.rydberg_blockade_radius()`. In this notebook, $\\Omega$ is fixed to a frequency of 1 rad/µs."
    ]


### PR DESCRIPTION
- `PasqalDevice` was renamed `Device`
- Other mentions of Pasqal were omitted
- A `Sequence` no longer enforces the device to be imported from `pasqal.devices`, it just demands it be a `Device` instance. A warning is still issued in cases where the user makes their own device.