### PR TITLE
Small changes in the documentation (rectangle vs. square) and typo on "neutral"

### DIFF
--- a/docs/source/introduction_rydberg_blockade.ipynb
+++ b/docs/source/introduction_rydberg_blockade.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following walkthrough highlights some of Pulser's core features and uses them to display a crucial physical effect for netural atom devices: the **Rydberg blockade**. Bear in mind that it is not meant to be a comprehensive step-by-step guide on how to use Pulser, but rather a showcase of Pulser in action. \n",
+    "The following walkthrough highlights some of Pulser's core features and uses them to display a crucial physical effect for neutral atom devices: the **Rydberg blockade**. Bear in mind that it is not meant to be a comprehensive step-by-step guide on how to use Pulser, but rather a showcase of Pulser in action. \n",
     "\n",
     "For a more detailed introduction to Pulser, check the tutorials on [Pulse Sequence Creation](creating.nblink) and [Simulation of Sequences](simulating.nblink). To better understand neutral atom devices and how they serve as quantum computers and simulators, check the pages in [Quantum Computing with Neutral Atoms](review.rst)."
    ]

--- a/tutorials/applications/Preparing state with antiferromagnetic order in the Ising model.ipynb
+++ b/tutorials/applications/Preparing state with antiferromagnetic order in the Ising model.ipynb
@@ -87,7 +87,7 @@
     "R_interatomic = Chadoq2.rydberg_blockade_radius(U)\n",
     "\n",
     "N_side = 3\n",
-    "reg = Register.rectangle(N_side, N_side, R_interatomic, prefix='q')\n",
+    "reg = Register.square(N_side, R_interatomic, prefix='q')\n",
     "print(f'Interatomic Radius is: {R_interatomic}µm.')\n",
     "reg.draw()"
    ]


### PR DESCRIPTION
Uses `square(N_side, ...)` instead of `rectangle(N_side, N_side, ...)`

Corrects typo: `neutral` instead of `netural`
