### PR TITLE
Change instances of `.format` to f-strings [unitaryHACK]

### DIFF
--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -95,7 +95,7 @@ def draw_sequence(seq, sampling_rate=None):
         elif value == 0:
             return "0"      # pragma: no cover - just for safety
         else:
-            return r"{:.2g}$\pi$".format(value)
+            return fr"{value:.2g}$\pi$"
 
     n_channels = len(seq._channels)
     if not n_channels:

--- a/pulser/channels.py
+++ b/pulser/channels.py
@@ -109,8 +109,11 @@ class Channel:
         return _duration
 
     def __repr__(self):
-        s = ".{}(Max Absolute Detuning: {} rad/µs, Max Amplitude: {} rad/µs"
-        config = s.format(self.addressing, self.max_abs_detuning, self.max_amp)
+        config = (
+            f".{self.addressing}(Max Absolute Detuning: "
+            f"{self.max_abs_detuning} rad/µs, Max Amplitude: "
+            f"{self.max_amp} rad/µs"
+        )
         if self.addressing == 'Local':
             config += f", Target time: {self.retarget_time} ns"
             if self.max_targets > 1:

--- a/pulser/devices/_device_datacls.py
+++ b/pulser/devices/_device_datacls.py
@@ -118,7 +118,8 @@ class Device:
                                  "distance between atoms for this device.")
 
         if np.max(np.linalg.norm(atoms, axis=1)) > self.max_radial_distance:
-            raise ValueError(f"All qubits must be at most {self.max_radial_distance} μm away from the "
+            raise ValueError("All qubits must be at most "
+                             f"{self.max_radial_distance} μm away from the "
                              "center of the array.")
 
     def validate_pulse(self, pulse, channel_id):

--- a/pulser/devices/_device_datacls.py
+++ b/pulser/devices/_device_datacls.py
@@ -105,11 +105,11 @@ class Device:
         atoms = list(register.qubits.values())
         if len(atoms) > self.max_atom_num:
             raise ValueError("Too many atoms in the array, the device accepts "
-                             "at most {} atoms.".format(self.max_atom_num))
+                             f"at most {self.max_atom_num} atoms.")
 
         if register._dim != self.dimensions:
-            raise ValueError("All qubit positions must be {}D "
-                             "vectors.".format(self.dimensions))
+            raise ValueError(f"All qubit positions must be {self.dimensions}D "
+                             "vectors.")
 
         if len(atoms) > 1:
             distances = pdist(atoms)  # Pairwise distance between atoms
@@ -118,9 +118,8 @@ class Device:
                                  "distance between atoms for this device.")
 
         if np.max(np.linalg.norm(atoms, axis=1)) > self.max_radial_distance:
-            raise ValueError("All qubits must be at most {} μm away from the "
-                             "center of the array.".format(
-                                                    self.max_radial_distance))
+            raise ValueError(f"All qubits must be at most {self.max_radial_distance} μm away from the "
+                             "center of the array.")
 
     def validate_pulse(self, pulse, channel_id):
         """Checks if a pulse can be executed on a specific device channel.

--- a/pulser/pulse.py
+++ b/pulser/pulse.py
@@ -141,8 +141,10 @@ class Pulse:
                            post_phase_shift=self.post_phase_shift)
 
     def __str__(self):
-        return "Pulse(Amp={!s}, Detuning={!s}, Phase={:.3g})".format(
-            self.amplitude, self.detuning, self.phase)
+        return (
+            f"Pulse(Amp={self.amplitude!s}, Detuning={self.detuning!s}, "
+            f"Phase={self.phase:.3g})"
+        )
 
     def __repr__(self):
         return (f"Pulse(amp={self.amplitude!r}, detuning={self.detuning!r}, " +

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -370,7 +370,7 @@ class Sequence:
 
         if not isinstance(pulse, Pulse):
             raise TypeError("pulse input must be of type Pulse, not of type "
-                            "{}.".format(type(pulse)))
+                            f"{type(pulse)}.")
 
         channel_obj = self._channels[channel]
         _duration = channel_obj.validate_duration(pulse.duration)

--- a/pulser/waveforms.py
+++ b/pulser/waveforms.py
@@ -208,8 +208,8 @@ class CompositeWaveform(Waveform):
 
     def _validate(self, waveform):
         if not isinstance(waveform, Waveform):
-            raise TypeError(f"{waveform!r} is not a valid waveform. Please provide a "
-                            "valid Waveform.")
+            raise TypeError(f"{waveform!r} is not a valid waveform. "
+                            "Please provide a valid Waveform.")
 
     def _to_dict(self):
         return obj_to_dict(self, *self._waveforms)

--- a/pulser/waveforms.py
+++ b/pulser/waveforms.py
@@ -208,8 +208,8 @@ class CompositeWaveform(Waveform):
 
     def _validate(self, waveform):
         if not isinstance(waveform, Waveform):
-            raise TypeError("{!r} is not a valid waveform. Please provide a "
-                            "valid Waveform.".format(waveform))
+            raise TypeError(f"{waveform!r} is not a valid waveform. Please provide a "
+                            "valid Waveform.")
 
     def _to_dict(self):
         return obj_to_dict(self, *self._waveforms)


### PR DESCRIPTION
Hello,

This PR tries to make a small change by making strings consistent by replacing the `.format` syntax with f-strings.

Thanks!