### PR TITLE
Expand `Register.max_connectivity()` for few atoms.

### DIFF
--- a/pulser/register.py
+++ b/pulser/register.py
@@ -336,9 +336,12 @@ class Register:
             raise ValueError(f"Spacing ({spacing}) for this device must be"
                              f" {device.min_atom_distance} or above.")
 
-        if n_qubits == 1:
-            return cls.from_coordinates(np.array([(0.0, 0.0)], dtype=float),
-                                        center=False, prefix=prefix)
+        if n_qubits < 7:
+            hex_coords = np.array([(0.0, 0.0), (1.0, 0.0), (0.5, np.sqrt(3/4)),
+                                   (1.5, np.sqrt(3/4)), (2.0, 0.0),
+                                   (0.5, -np.sqrt(3/4))])
+            return cls.from_coordinates(spacing * hex_coords[:n_qubits],
+                                        prefix=prefix)
 
         full_layers = int((-3.0 + np.sqrt(9 + 12 * (n_qubits - 1))) / 6.0)
         atoms_left = n_qubits - 1 - (full_layers**2 + full_layers) * 3

--- a/pulser/tests/test_register.py
+++ b/pulser/tests/test_register.py
@@ -167,6 +167,19 @@ def test_max_connectivity():
     atoms = list(reg.qubits.values())
     assert(np.all(np.isclose(atoms[0], [0.0, 0.0])))
 
+    # Check for less than 7 atoms:
+    for i in range(1, 6):
+        hex_coords = np.array([(0.0, 0.0), (1.0, 0.0), (0.5, np.sqrt(3/4)),
+                               (1.5, np.sqrt(3/4)), (2.0, 0.0),
+                               (0.5, -np.sqrt(3/4))])
+        reg = Register.max_connectivity(i, device)
+        reg2 = Register.from_coordinates(4 * hex_coords[:i])  # Use min spacing
+        assert (len(reg.qubits) == i)
+        atoms = list(reg.qubits.values())
+        atoms2 = list(reg2.qubits.values())
+        for k in range(i):
+            assert(np.all(np.isclose(atoms[k], atoms2[k])))
+
     # Check full layers on a small hexagon (1 layer)
     reg = Register.max_connectivity(7, device)
     assert (len(reg.qubits) == 7)


### PR DESCRIPTION
I thought the `max_connectivity()` was nice enough that expanding its use for less than 7 atoms would be useful. This PR includes these cases, occupying one by one the sites of an underlying hexagon coordinate list.