### PR TITLE
Add phase and area text to pulse plot [unitaryHACK]

### DIFF
--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -106,8 +106,9 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
     time_scale = 1e3 if seq._total_duration > 1e4 else 1
 
     # Boxes for qubit and phase text
-    q_box = dict(boxstyle="round", facecolor='orange', alpha=0.7)
-    ph_box = dict(boxstyle="round", facecolor='ghostwhite', alpha=0.7)
+    q_box = dict(boxstyle="round", facecolor='orange')
+    ph_box = dict(boxstyle="round", facecolor='ghostwhite')
+    area_ph_box = dict(boxstyle='round', facecolor='ghostwhite')
 
     fig = plt.figure(constrained_layout=False, figsize=(20, 4.5*n_channels))
     gs = fig.add_gridspec(n_channels, 1, hspace=0.075)
@@ -202,6 +203,7 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
         b.set_ylabel(r'$\delta$ (rad/µs)', fontsize=14)
 
         if draw_phase_area:
+            top = False  # Variable to track position of box, top or center.
             for pulse_num, seq_ in enumerate(seq._schedule[ch]):
                 # Select only `Pulse` objects
                 if isinstance(seq_.type, Pulse):
@@ -210,11 +212,13 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
                     x_plot = (seq_.ti + seq_.tf) / 2
                     if (
                         seq._schedule[ch][pulse_num-1].type == "target"
-                        or pulse_num % 2 == 0
+                        or not top
                     ):
                         y_plot = np.max(seq_.type.amplitude.samples) / 2
-                    else:
+                        top = True  # Next box at the top.
+                    elif top:
                         y_plot = np.max(seq_.type.amplitude.samples)
+                        top = False  # Next box at the center.
                     if phase_val == 0:
                         txt = fr"A: {area_val:.2g}$\pi$"
                     else:
@@ -223,7 +227,7 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
                         txt = "\n".join([phase_fmt, area_fmt])
                     a.text(
                         x_plot, y_plot, txt, fontsize=10,
-                        ha="center", va="center", bbox=ph_box,
+                        ha="center", va="center", bbox=area_ph_box,
                     )
 
         target_regions = []     # [[start1, [targets1], end1],...]

--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -108,7 +108,7 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
     # Boxes for qubit and phase text
     q_box = dict(boxstyle="round", facecolor='orange')
     ph_box = dict(boxstyle="round", facecolor='ghostwhite')
-    area_ph_box = dict(boxstyle='round', facecolor='ghostwhite')
+    area_ph_box = dict(boxstyle='round', facecolor='ghostwhite', alpha=0.7)
 
     fig = plt.figure(constrained_layout=False, figsize=(20, 4.5*n_channels))
     gs = fig.add_gridspec(n_channels, 1, hspace=0.075)
@@ -212,9 +212,9 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
                 # Select only `Pulse` objects
                 if isinstance(seq_.type, Pulse):
                     if sampling_rate:
-                        area_val = np.sum(
-                            np.abs(yaeff[int(seq_.ti):int(seq_.tf)])
-                        ) / 1e3 / np.pi
+                        area_val = np.sum(cs_amp(
+                            np.arange(seq_.ti, seq_.tf)
+                        )) * 1e-3 / np.pi
                     else:
                         area_val = seq_.type.amplitude.integral / np.pi
                     phase_val = seq_.type.phase / np.pi
@@ -228,7 +228,8 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
                     elif top:
                         y_plot = np.max(seq_.type.amplitude.samples)
                         top = False  # Next box at the center.
-                    area_fmt = fr"A: {area_val:.2g}$\pi$"
+                    area_fmt = (r"A: $\pi$" if round(area_val, 2) == 1
+                                else fr"A: {area_val:.2g}$\pi$")
                     if not draw_phase:
                         txt = area_fmt
                     else:

--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -16,6 +16,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from pulser.waveforms import ConstantWaveform
+from pulser.pulse import Pulse
 from scipy.interpolate import CubicSpline
 
 
@@ -107,10 +108,13 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
 
     # Boxes for qubit and phase text
     q_box = dict(boxstyle="round", facecolor='orange')
-    ph_box = dict(boxstyle="round", facecolor='ghostwhite')
+    ph_box = dict(boxstyle="round", facecolor='ghostwhite', alpha=0.5)
 
     fig = plt.figure(constrained_layout=False, figsize=(20, 4.5*n_channels))
-    gs = fig.add_gridspec(n_channels, 1, hspace=0.1)
+    gs = fig.add_gridspec(n_channels, 1, hspace=0.075)
+
+    if draw_phase_area:
+        fig.suptitle(r"$\phi$: Phase, A: Area", fontsize=14)
 
     ch_axes = {}
     for i, (ch, gs_) in enumerate(zip(seq._channels, gs)):
@@ -202,22 +206,18 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
         b.set_ylabel(r'$\delta$ (rad/µs)', fontsize=14)
 
         if draw_phase_area:
-            a.set_title(r"Phase: $\phi$, Area: A", fontsize=16)
             for seq_ in seq._schedule[ch]:
                 # Select only `Pulse` objects
-                if not isinstance(seq_.type, str):
+                if isinstance(seq_.type, Pulse):
                     phase_val = seq_.type.phase / np.pi
                     area_val = seq_.type.amplitude.integral / np.pi
                     # X and Y coordinates for placing text
                     x_plot = (seq_.ti + seq_.tf) / 2
-                    y_plot = np.max(seq_.type.amplitude.samples)
+                    y_plot = np.max(seq_.type.amplitude.samples) / 2
                     a.text(
-                        x_plot, y_plot+8, fr"$\phi$ = {phase_val:.3g}$\pi$",
-                        fontsize=14, ha="center", va="center",
-                    )
-                    a.text(
-                        x_plot, y_plot+2, fr"A = {area_val:3g}$\pi$",
-                        fontsize=14, ha="center", va="center",
+                        x_plot, y_plot, fr"$\phi$: {phase_str(phase_val)}"
+                        + "\n" + fr"A: {area_val:.2g}$\pi$", fontsize=10,
+                        ha="center", va="center", bbox=ph_box,
                     )
 
         target_regions = []     # [[start1, [targets1], end1],...]

--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -212,9 +212,11 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
                 # Select only `Pulse` objects
                 if isinstance(seq_.type, Pulse):
                     if sampling_rate:
-                        area_val = np.sum(cs_amp(
-                            np.arange(seq_.ti, seq_.tf)
-                        )) * 1e-3 / np.pi
+                        area_val = (
+                            np.sum(
+                                cs_amp(np.arange(seq_.ti, seq_.tf)/time_scale)
+                            ) * 1e-3 / np.pi
+                        )
                     else:
                         area_val = seq_.type.amplitude.integral / np.pi
                     phase_val = seq_.type.phase / np.pi

--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -112,9 +112,6 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
     fig = plt.figure(constrained_layout=False, figsize=(20, 4.5*n_channels))
     gs = fig.add_gridspec(n_channels, 1, hspace=0.075)
 
-    if draw_phase_area:
-        fig.suptitle(r"$\phi$: Phase, A: Area", fontsize=14)
-
     ch_axes = {}
     for i, (ch, gs_) in enumerate(zip(seq._channels, gs)):
         ax = fig.add_subplot(gs_)
@@ -211,13 +208,21 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
                     phase_val = seq_.type.phase / np.pi
                     area_val = seq_.type.amplitude.integral / np.pi
                     x_plot = (seq_.ti + seq_.tf) / 2
-                    if pulse_num % 2 == 0:
+                    if (
+                        seq._schedule[ch][pulse_num-1].type == "target"
+                        or pulse_num % 2 == 0
+                    ):
                         y_plot = np.max(seq_.type.amplitude.samples) / 2
                     else:
                         y_plot = np.max(seq_.type.amplitude.samples)
+                    if phase_val == 0:
+                        txt = fr"A: {area_val:.2g}$\pi$"
+                    else:
+                        phase_fmt = fr"$\phi$: {phase_str(phase_val)}"
+                        area_fmt = fr"A: {area_val:.2g}$\pi$"
+                        txt = "\n".join([phase_fmt, area_fmt])
                     a.text(
-                        x_plot, y_plot, fr"$\phi$: {phase_str(phase_val)}"
-                        + "\n" + fr"A: {area_val:.2g}$\pi$", fontsize=10,
+                        x_plot, y_plot, txt, fontsize=10,
                         ha="center", va="center", bbox=ph_box,
                     )
 

--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -213,7 +213,7 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
                 if isinstance(seq_.type, Pulse):
                     if sampling_rate:
                         area_val = np.sum(
-                            yaeff[int(seq_.ti*1e-3):int(seq_.tf*1e-3)]
+                            np.abs(yaeff[int(seq_.ti):int(seq_.tf)])
                         ) / 1e3 / np.pi
                     else:
                         area_val = seq_.type.amplitude.integral / np.pi

--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -204,6 +204,10 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
 
         if draw_phase_area:
             top = False  # Variable to track position of box, top or center.
+            draw_phase = any(
+                seq_.type.phase != 0 for seq_ in seq._schedule[ch]
+                if isinstance(seq_.type, Pulse)
+            )
             for pulse_num, seq_ in enumerate(seq._schedule[ch]):
                 # Select only `Pulse` objects
                 if isinstance(seq_.type, Pulse):
@@ -219,7 +223,7 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
                     elif top:
                         y_plot = np.max(seq_.type.amplitude.samples)
                         top = False  # Next box at the center.
-                    if phase_val == 0:
+                    if not draw_phase:
                         txt = fr"A: {area_val:.2g}$\pi$"
                     else:
                         phase_fmt = fr"$\phi$: {phase_str(phase_val)}"

--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -14,7 +14,6 @@
 
 import matplotlib.pyplot as plt
 import numpy as np
-
 from pulser.waveforms import ConstantWaveform
 from pulser.pulse import Pulse
 from scipy.interpolate import CubicSpline
@@ -107,8 +106,8 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
     time_scale = 1e3 if seq._total_duration > 1e4 else 1
 
     # Boxes for qubit and phase text
-    q_box = dict(boxstyle="round", facecolor='orange')
-    ph_box = dict(boxstyle="round", facecolor='ghostwhite', alpha=0.5)
+    q_box = dict(boxstyle="round", facecolor='orange', alpha=0.7)
+    ph_box = dict(boxstyle="round", facecolor='ghostwhite', alpha=0.7)
 
     fig = plt.figure(constrained_layout=False, figsize=(20, 4.5*n_channels))
     gs = fig.add_gridspec(n_channels, 1, hspace=0.075)
@@ -206,14 +205,16 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
         b.set_ylabel(r'$\delta$ (rad/µs)', fontsize=14)
 
         if draw_phase_area:
-            for seq_ in seq._schedule[ch]:
+            for pulse_num, seq_ in enumerate(seq._schedule[ch]):
                 # Select only `Pulse` objects
                 if isinstance(seq_.type, Pulse):
                     phase_val = seq_.type.phase / np.pi
                     area_val = seq_.type.amplitude.integral / np.pi
-                    # X and Y coordinates for placing text
                     x_plot = (seq_.ti + seq_.tf) / 2
-                    y_plot = np.max(seq_.type.amplitude.samples) / 2
+                    if pulse_num % 2 == 0:
+                        y_plot = np.max(seq_.type.amplitude.samples) / 2
+                    else:
+                        y_plot = np.max(seq_.type.amplitude.samples)
                     a.text(
                         x_plot, y_plot, fr"$\phi$: {phase_str(phase_val)}"
                         + "\n" + fr"A: {area_val:.2g}$\pi$", fontsize=10,

--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -211,9 +211,14 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
             for pulse_num, seq_ in enumerate(seq._schedule[ch]):
                 # Select only `Pulse` objects
                 if isinstance(seq_.type, Pulse):
+                    if sampling_rate:
+                        area_val = np.sum(
+                            yaeff[seq_.ti*time_scale:seq_.tf*time_scale+1]
+                        ) / time_scale / np.pi
+                    else:
+                        area_val = seq_.type.amplitude.integral / np.pi
                     phase_val = seq_.type.phase / np.pi
-                    area_val = seq_.type.amplitude.integral / np.pi
-                    x_plot = (seq_.ti + seq_.tf) / 2
+                    x_plot = (seq_.ti + seq_.tf) / 2 / time_scale
                     if (
                         seq._schedule[ch][pulse_num-1].type == "target"
                         or not top
@@ -223,11 +228,11 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
                     elif top:
                         y_plot = np.max(seq_.type.amplitude.samples)
                         top = False  # Next box at the center.
+                    area_fmt = fr"A: {area_val:.2g}$\pi$"
                     if not draw_phase:
-                        txt = fr"A: {area_val:.2g}$\pi$"
+                        txt = area_fmt
                     else:
                         phase_fmt = fr"$\phi$: {phase_str(phase_val)}"
-                        area_fmt = fr"A: {area_val:.2g}$\pi$"
                         txt = "\n".join([phase_fmt, area_fmt])
                     a.text(
                         x_plot, y_plot, txt, fontsize=10,

--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -86,7 +86,7 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
             the solver. If present, plots the effective pulse alongside the
             input pulse.
         draw_phase_area (bool): Whether phase and area values need to be shown
-            as text on the plot.
+            as text on the plot, defaults to False.
     """
 
     def phase_str(phi):
@@ -202,16 +202,23 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
         b.set_ylabel(r'$\delta$ (rad/µs)', fontsize=14)
 
         if draw_phase_area:
-            a.set_title(fr"Phase: $\phi$, Area: A", fontsize=16)
+            a.set_title(r"Phase: $\phi$, Area: A", fontsize=16)
             for seq_ in seq._schedule[ch]:
-                if not isinstance(seq_.type, str):  # Select only `Pulse` objects
+                # Select only `Pulse` objects
+                if not isinstance(seq_.type, str):
                     phase_val = seq_.type.phase / np.pi
                     area_val = seq_.type.amplitude.integral / np.pi
                     # X and Y coordinates for placing text
                     x_plot = (seq_.ti + seq_.tf) / 2
                     y_plot = np.max(seq_.type.amplitude.samples)
-                    a.text(x_plot, y_plot+8, fr"$\phi$ = {phase_val:.3g}$\pi$", fontsize=14, ha="center", va="center")  # remove: replace redundant ha, va with a dict??
-                    a.text(x_plot, y_plot+2, fr"A = {area_val:3g}$\pi$", fontsize=14, ha="center", va="center")
+                    a.text(
+                        x_plot, y_plot+8, fr"$\phi$ = {phase_val:.3g}$\pi$",
+                        fontsize=14, ha="center", va="center",
+                    )
+                    a.text(
+                        x_plot, y_plot+2, fr"A = {area_val:3g}$\pi$",
+                        fontsize=14, ha="center", va="center",
+                    )
 
         target_regions = []     # [[start1, [targets1], end1],...]
         for coords in data[ch]['target']:

--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -213,8 +213,8 @@ def draw_sequence(seq, sampling_rate=None, draw_phase_area=False):
                 if isinstance(seq_.type, Pulse):
                     if sampling_rate:
                         area_val = np.sum(
-                            yaeff[seq_.ti*time_scale:seq_.tf*time_scale+1]
-                        ) / time_scale / np.pi
+                            yaeff[int(seq_.ti*1e-3):int(seq_.tf*1e-3)]
+                        ) / 1e3 / np.pi
                     else:
                         area_val = seq_.type.amplitude.integral / np.pi
                     phase_val = seq_.type.phase / np.pi

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -643,10 +643,10 @@ class Sequence:
         return json.loads(obj, cls=PulserDecoder, **kwargs)
 
     @_screen
-    def draw(self, sampling_rate=None, draw_phase_area=False):
+    def draw(self, draw_phase_area=False):
         """Draws the sequence in its current state."""
         draw_sequence(
-            self, sampling_rate=sampling_rate, draw_phase_area=draw_phase_area,
+            self, draw_phase_area=draw_phase_area,
         )
 
     def _target(self, qubits, channel):

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -644,7 +644,12 @@ class Sequence:
 
     @_screen
     def draw(self, draw_phase_area=False):
-        """Draws the sequence in its current state."""
+        """Draws the sequence in its current state.
+
+        Keyword args:
+            draw_phase_area (bool): Whether phase and area values need
+                to be shown as text on the plot, defaults to False.
+        """
         draw_sequence(
             self, draw_phase_area=draw_phase_area,
         )

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -310,12 +310,12 @@ class Sequence:
         are dependent on the involved variables.
 
         Args:
-            name(str): The name for the variable. Must be unique within a
+            name (str): The name for the variable. Must be unique within a
                 Sequence.
 
         Keyword Args:
-            size(int=1): The number of entries stored in the variable.
-            dtype(default=float): The type of the data that will be assigned
+            size (int=1): The number of entries stored in the variable.
+            dtype (default=float): The type of the data that will be assigned
                 to the variable. Must be ``float``, ``int`` or ``str``.
 
         Returns:
@@ -502,7 +502,7 @@ class Sequence:
                 phase shift.
 
         Keyword Args:
-            basis(str): The basis (i.e. electronic transition) to associate
+            basis (str): The basis (i.e. electronic transition) to associate
                 the phase shift to. Must correspond to the basis of a declared
                 channel.
         """
@@ -621,7 +621,7 @@ class Sequence:
         """Deserializes a JSON formatted string.
 
         Args:
-            obj(str): The JSON formatted string to deserialize, coming from the
+            obj (str): The JSON formatted string to deserialize, coming from the
                 serialization of a ``Sequence`` through
                 ``Sequence.serialize()``.
 
@@ -643,9 +643,9 @@ class Sequence:
         return json.loads(obj, cls=PulserDecoder, **kwargs)
 
     @_screen
-    def draw(self):
+    def draw(self, sampling_rate=None, draw_phase_area=False):
         """Draws the sequence in its current state."""
-        draw_sequence(self)
+        draw_sequence(self, sampling_rate=sampling_rate, draw_phase_area=draw_phase_area)
 
     def _target(self, qubits, channel):
         self._validate_channel(channel)

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -621,8 +621,8 @@ class Sequence:
         """Deserializes a JSON formatted string.
 
         Args:
-            obj (str): The JSON formatted string to deserialize, coming from the
-                serialization of a ``Sequence`` through
+            obj (str): The JSON formatted string to deserialize, coming from
+                the serialization of a ``Sequence`` through
                 ``Sequence.serialize()``.
 
         Other Parameters:
@@ -645,7 +645,9 @@ class Sequence:
     @_screen
     def draw(self, sampling_rate=None, draw_phase_area=False):
         """Draws the sequence in its current state."""
-        draw_sequence(self, sampling_rate=sampling_rate, draw_phase_area=draw_phase_area)
+        draw_sequence(
+            self, sampling_rate=sampling_rate, draw_phase_area=draw_phase_area,
+        )
 
     def _target(self, qubits, channel):
         self._validate_channel(channel)

--- a/pulser/simulation/simulation.py
+++ b/pulser/simulation/simulation.py
@@ -116,10 +116,16 @@ class Simulation:
             raise ValueError("`evaluation_times` must be a list of times "
                              "or `Full` or `Minimal`")
 
-    def draw(self):
-        """Draws the input sequence and the one used in QuTip."""
+    def draw(self, draw_phase_area=False):
+        """Draws the input sequence and the one used in QuTip.
 
-        draw_sequence(self._seq, self.sampling_rate)
+        Keyword args:
+            draw_phase_area (bool): Whether phase and area values need
+                to be shown as text on the plot, defaults to False.
+        """
+        draw_sequence(
+            self._seq, self.sampling_rate, draw_phase_area=draw_phase_area
+        )
 
     def _extract_samples(self):
         """Populate samples dictionary with every pulse in the sequence."""

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -293,7 +293,7 @@ def test_sequence():
     seq.measure(basis='digital')
 
     with patch('matplotlib.pyplot.show'):
-        seq.draw()
+        seq.draw(draw_phase_area=True)
 
     s = seq.serialize()
     assert json.loads(s)["__version__"] == pulser.__version__

--- a/pulser/tests/test_simulation.py
+++ b/pulser/tests/test_simulation.py
@@ -242,7 +242,7 @@ def test_single_atom_simulation():
 def test_run():
     sim = Simulation(seq, sampling_rate=0.01)
     with patch('matplotlib.pyplot.show'):
-        sim.draw()
+        sim.draw(draw_phase_area=True)
     bad_initial = np.array([1.])
     good_initial_array = np.r_[1, np.zeros(sim.dim**sim._size - 1)]
     good_initial_qobj = qutip.tensor([qutip.basis(sim.dim, 0)


### PR DESCRIPTION
This pull request attempts to address #149.

**Details**

- It adds a condition `draw_phase_area` (default to `False`) in the `draw` method of a `Sequence` object. The `draw_sequence` function also has this argument.
- Based on this argument, it would allow to plot phase and area for each of the waveforms, where the values are in multiples of `pi`.
- Instead of writing "Phase" and "Area", it is written once in the title and then the symbols are used throughout to avoid consuming large space on the plot.

Since this is currently a draft, there is still some work to do regarding the placement of the text.

The output of running:

```
seq.draw(draw_phase_area=True)
```

on a sample sequence (the same sequence as shown in the issue) currently looks like this:

![sequence](https://user-images.githubusercontent.com/68844397/118856807-f82a8800-b8f4-11eb-99b1-ef5d0afc61ca.png)

I would love to get any thoughts on this.

Thanks!