### PR TITLE
Add type hints in `_device_datacls.py` and `coders.py` [unitaryHACK] (#16)

### DIFF
--- a/pulser/devices/_device_datacls.py
+++ b/pulser/devices/_device_datacls.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 from dataclasses import dataclass
-from typing import Tuple, Dict, Set
+from typing import Tuple, Dict, Set, Any
 
 import numpy as np
 from scipy.spatial.distance import pdist
@@ -52,12 +53,12 @@ class Device:
         self.__dict__["__doc__"] = self._specs(for_docs=True)
 
     @property
-    def channels(self) -> Dict:
+    def channels(self) -> Dict[str, Channel]:
         """Dictionary of available channels on this device."""
         return dict(self._channels)
 
     @property
-    def supported_bases(self) -> Set:
+    def supported_bases(self) -> Set[str]:
         """Available electronic transitions for control and measurement."""
         return {ch.basis for ch in self.channels.values()}
 
@@ -172,6 +173,6 @@ class Device:
 
         return "\n".join(lines + ch_lines)
 
-    def _to_dict(self) -> Dict:
+    def _to_dict(self) -> Dict[str, Any]:
         return obj_to_dict(self, _build=False, _module="pulser.devices",
                            _name=self.name)

--- a/pulser/devices/_device_datacls.py
+++ b/pulser/devices/_device_datacls.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from typing import Tuple, Dict, Set
 
 import numpy as np
-from scipy.spatial.distance import pdist #type: ignore
+from scipy.spatial.distance import pdist
 
 from pulser import Register, Pulse
 from pulser.channels import Channel
@@ -139,7 +139,7 @@ class Device:
             raise ValueError("The pulse's detuning values go out of the range "
                              "allowed for the chosen channel.")
 
-    def _specs(self, for_docs: bool=False) -> str:
+    def _specs(self, for_docs: bool = False) -> str:
         lines = [
             "\nRegister requirements:",
             f" - Dimensions: {self.dimensions}D",

--- a/pulser/json/coders.py
+++ b/pulser/json/coders.py
@@ -21,9 +21,10 @@ import numpy as np
 from pulser.json.utils import obj_to_dict
 from pulser.parametrized import Variable
 
+from typing import Dict, Any
 
 class PulserEncoder(JSONEncoder):
-    def default(self, o):
+    def default(self, o: Any) -> Dict:
         if hasattr(o, "_to_dict"):
             return o._to_dict()
         elif type(o) == type:
@@ -37,12 +38,12 @@ class PulserEncoder(JSONEncoder):
 
 
 class PulserDecoder(JSONDecoder):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         # TODO: Check version compatibility (stored at the Sequence level)
-        self.vars = {}
+        self.vars: Dict = {}
         super().__init__(object_hook=self.object_hook, *args, **kwargs)
 
-    def object_hook(self, obj):
+    def object_hook(self, obj: Dict) -> Dict:
         try:
             build = obj["_build"]
             obj_name = obj["__name__"]

--- a/pulser/json/coders.py
+++ b/pulser/json/coders.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import importlib
 import inspect
 from json import JSONEncoder, JSONDecoder
-from typing import Dict, Any
+from typing import Dict, Any, Union
 
 import numpy as np
 
@@ -25,7 +25,7 @@ from pulser.parametrized import Variable
 
 
 class PulserEncoder(JSONEncoder):
-    def default(self, o: Any) -> Dict[str, Any]:
+    def default(self, o: Any) -> Union[Dict[str, Any], Any]:
         if hasattr(o, "_to_dict"):
             return o._to_dict()
         elif type(o) == type:

--- a/pulser/json/coders.py
+++ b/pulser/json/coders.py
@@ -23,6 +23,7 @@ from pulser.parametrized import Variable
 
 from typing import Dict, Any
 
+
 class PulserEncoder(JSONEncoder):
     def default(self, o: Any) -> Dict:
         if hasattr(o, "_to_dict"):

--- a/pulser/json/coders.py
+++ b/pulser/json/coders.py
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 import importlib
 import inspect
 from json import JSONEncoder, JSONDecoder
+from typing import Dict, Any
 
 import numpy as np
 
 from pulser.json.utils import obj_to_dict
 from pulser.parametrized import Variable
 
-from typing import Dict, Any
-
 
 class PulserEncoder(JSONEncoder):
-    def default(self, o: Any) -> Dict:
+    def default(self, o: Any) -> Dict[str, Any]:
         if hasattr(o, "_to_dict"):
             return o._to_dict()
         elif type(o) == type:
@@ -41,10 +41,10 @@ class PulserEncoder(JSONEncoder):
 class PulserDecoder(JSONDecoder):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         # TODO: Check version compatibility (stored at the Sequence level)
-        self.vars: Dict = {}
+        self.vars: Dict[str, Variable] = {}
         super().__init__(object_hook=self.object_hook, *args, **kwargs)
 
-    def object_hook(self, obj: Dict) -> Dict:
+    def object_hook(self, obj: Dict[str, Any]) -> Any:
         try:
             build = obj["_build"]
             obj_name = obj["__name__"]

--- a/pulser/json/coders.py
+++ b/pulser/json/coders.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import importlib
 import inspect
 from json import JSONEncoder, JSONDecoder
-from typing import Dict, Any, Union
+from typing import Dict, Any, cast
 
 import numpy as np
 
@@ -25,9 +25,9 @@ from pulser.parametrized import Variable
 
 
 class PulserEncoder(JSONEncoder):
-    def default(self, o: Any) -> Union[Dict[str, Any], Any]:
+    def default(self, o: Any) -> Dict[str, Any]:
         if hasattr(o, "_to_dict"):
-            return o._to_dict()
+            return cast(dict, o._to_dict())
         elif type(o) == type:
             return obj_to_dict(o, _build=False, _name=o.__name__)
         elif isinstance(o, np.ndarray):
@@ -35,7 +35,7 @@ class PulserEncoder(JSONEncoder):
         elif isinstance(o, set):
             return obj_to_dict(o, list(o))
         else:
-            return JSONEncoder.default(self, o)
+            return cast(dict, JSONEncoder.default(self, o))
 
 
 class PulserDecoder(JSONDecoder):


### PR DESCRIPTION
Type checked on `_device_datacls.py` and `coders.py`. 

Was getting `Skipping analyzing module_name: found module but no type hints or library stubs` error on line 19 of `_device_datacls.py`, wasn't able to correct it, used `#type: ignore` to ignore the same.