### PR TITLE
Type annotation fixes

### DIFF
--- a/pulser/channels.py
+++ b/pulser/channels.py
@@ -59,7 +59,7 @@ class Channel:
 
     @classmethod
     def Local(cls, max_abs_detuning: float, max_amp: float,
-              retarget_time: int = 220, **kwargs) -> Channel:
+              retarget_time: int = 220, **kwargs: int) -> Channel:
         """Initializes the channel with local addressing.
 
         Args:
@@ -74,7 +74,7 @@ class Channel:
 
     @classmethod
     def Global(cls, max_abs_detuning: float,
-               max_amp: float, **kwargs) -> Channel:
+               max_amp: float, **kwargs: int) -> Channel:
         """Initializes the channel with global addressing.
 
         Args:

--- a/pulser/devices/_device_datacls.py
+++ b/pulser/devices/_device_datacls.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Tuple, Dict, Set, Any
+from typing import Tuple, Set, Any
 
 import numpy as np
 from scipy.spatial.distance import pdist
@@ -53,7 +53,7 @@ class Device:
         self.__dict__["__doc__"] = self._specs(for_docs=True)
 
     @property
-    def channels(self) -> Dict[str, Channel]:
+    def channels(self) -> dict[str, Channel]:
         """Dictionary of available channels on this device."""
         return dict(self._channels)
 
@@ -173,6 +173,6 @@ class Device:
 
         return "\n".join(lines + ch_lines)
 
-    def _to_dict(self) -> Dict[str, Any]:
+    def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(self, _build=False, _module="pulser.devices",
                            _name=self.name)

--- a/pulser/devices/_device_datacls.py
+++ b/pulser/devices/_device_datacls.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Tuple, Set, Any
+from typing import Any
 
 import numpy as np
 from scipy.spatial.distance import pdist
@@ -45,7 +45,7 @@ class Device:
     max_atom_num: int
     max_radial_distance: int
     min_atom_distance: int
-    _channels: Tuple[Tuple[str, Channel], ...]
+    _channels: tuple[tuple[str, Channel], ...]
     interaction_coeff: float = 5008713.
 
     def __post_init__(self) -> None:
@@ -58,7 +58,7 @@ class Device:
         return dict(self._channels)
 
     @property
-    def supported_bases(self) -> Set[str]:
+    def supported_bases(self) -> set[str]:
         """Available electronic transitions for control and measurement."""
         return {ch.basis for ch in self.channels.values()}
 

--- a/pulser/devices/_device_datacls.py
+++ b/pulser/devices/_device_datacls.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Any
 

--- a/pulser/json/coders.py
+++ b/pulser/json/coders.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import importlib
 import inspect
 from json import JSONEncoder, JSONDecoder
-from typing import Dict, Any, cast
+from typing import Any, cast
 
 import numpy as np
 
@@ -25,7 +25,7 @@ from pulser.parametrized import Variable
 
 
 class PulserEncoder(JSONEncoder):
-    def default(self, o: Any) -> Dict[str, Any]:
+    def default(self, o: Any) -> dict[str, Any]:
         if hasattr(o, "_to_dict"):
             return cast(dict, o._to_dict())
         elif type(o) == type:
@@ -41,10 +41,10 @@ class PulserEncoder(JSONEncoder):
 class PulserDecoder(JSONDecoder):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         # TODO: Check version compatibility (stored at the Sequence level)
-        self.vars: Dict[str, Variable] = {}
+        self.vars: dict[str, Variable] = {}
         super().__init__(object_hook=self.object_hook, *args, **kwargs)
 
-    def object_hook(self, obj: Dict[str, Any]) -> Any:
+    def object_hook(self, obj: dict[str, Any]) -> Any:
         try:
             build = obj["_build"]
             obj_name = obj["__name__"]

--- a/pulser/json/coders.py
+++ b/pulser/json/coders.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
+
 import importlib
 import inspect
 from json import JSONEncoder, JSONDecoder

--- a/pulser/json/utils.py
+++ b/pulser/json/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
+
 from typing import Any, Optional
 
 

--- a/pulser/json/utils.py
+++ b/pulser/json/utils.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional
+
+from __future__ import annotations
+from typing import Any, Optional
 
 
 def obj_to_dict(obj, *args,
@@ -19,7 +21,7 @@ def obj_to_dict(obj, *args,
                 _module: Optional[str] = None,
                 _name: Optional[str] = None,
                 _submodule: Optional[str] = None,
-                **kwargs) -> Dict[str, Any]:
+                **kwargs) -> dict[str, Any]:
     """Encodes an object in a dictionary for serialization.
 
     Args:

--- a/pulser/parametrized/decorators.py
+++ b/pulser/parametrized/decorators.py
@@ -11,9 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+from collections.abc import Callable
 from functools import wraps
 from itertools import chain
-from typing import Callable, Any
+from typing import Any
 
 from pulser.parametrized import Parametrized, ParamObj
 

--- a/pulser/parametrized/decorators.py
+++ b/pulser/parametrized/decorators.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from functools import wraps
 from itertools import chain
-from typing import Any
 
 from pulser.parametrized import Parametrized, ParamObj
 
@@ -30,7 +29,7 @@ def parametrize(func: Callable) -> Callable:
         is not supported, and in regular functions is not tested.
     """
     @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
+    def wrapper(*args, **kwargs):
         for x in chain(args, kwargs.values()):
             if isinstance(x, Parametrized):
                 return ParamObj(func, *args, **kwargs)

--- a/pulser/parametrized/decorators.py
+++ b/pulser/parametrized/decorators.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import annotations
+
 from collections.abc import Callable
 from functools import wraps
 from itertools import chain

--- a/pulser/parametrized/paramabc.py
+++ b/pulser/parametrized/paramabc.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Any, TYPE_CHECKING
 

--- a/pulser/parametrized/paramabc.py
+++ b/pulser/parametrized/paramabc.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from typing import Dict, Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pulser.parametrized import Variable  # pragma: no cover
@@ -25,7 +25,7 @@ class Parametrized(ABC):
 
     @property
     @abstractmethod
-    def variables(self) -> Dict[str, Variable]:
+    def variables(self) -> dict[str, Variable]:
         """All the variables involved with this object."""
         pass
 
@@ -35,6 +35,6 @@ class Parametrized(ABC):
         pass
 
     @abstractmethod
-    def _to_dict(self) -> Dict[str, Any]:
+    def _to_dict(self) -> dict[str, Any]:
         """Serializes the object in a dictionary."""
         pass

--- a/pulser/parametrized/paramobj.py
+++ b/pulser/parametrized/paramobj.py
@@ -18,7 +18,7 @@ from itertools import chain
 import inspect
 import operator
 import warnings
-from typing import Callable, Dict, Any, Union, TYPE_CHECKING
+from typing import Callable, Any, Union, TYPE_CHECKING
 
 from pulser.json.utils import obj_to_dict
 from pulser.parametrized import Parametrized
@@ -73,7 +73,7 @@ class ParamObj(Parametrized, OpSupport):
             kwargs: The kwargs for calling `cls`.
         """
         self.cls = cls
-        self._variables: Dict[str, Variable] = {}
+        self._variables: dict[str, Variable] = {}
         if isinstance(self.cls, Parametrized):
             self._variables.update(self.cls.variables)
         for x in chain(args, kwargs.values()):
@@ -82,10 +82,10 @@ class ParamObj(Parametrized, OpSupport):
         self.args = args
         self.kwargs = kwargs
         self._instance = None
-        self._vars_state: Dict[str, int] = {}
+        self._vars_state: dict[str, int] = {}
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def variables(self) -> dict[str, Variable]:
         return self._variables
 
     def build(self):
@@ -103,7 +103,7 @@ class ParamObj(Parametrized, OpSupport):
             self._instance = obj(*args_, **kwargs_)
         return self._instance
 
-    def _to_dict(self) -> Dict[str, Any]:
+    def _to_dict(self) -> dict[str, Any]:
         def class_to_dict(cls):
             return obj_to_dict(self, _build=False, _name=cls.__name__,
                                _module=cls.__module__)

--- a/pulser/parametrized/paramobj.py
+++ b/pulser/parametrized/paramobj.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
+
 from collections.abc import Callable
 from functools import partialmethod
 from itertools import chain

--- a/pulser/parametrized/paramobj.py
+++ b/pulser/parametrized/paramobj.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 from __future__ import annotations
+from collections.abc import Callable
 from functools import partialmethod
 from itertools import chain
 import inspect
 import operator
 import warnings
-from typing import Callable, Any, Union, TYPE_CHECKING
+from typing import Any, Union, TYPE_CHECKING
 
 from pulser.json.utils import obj_to_dict
 from pulser.parametrized import Parametrized

--- a/pulser/parametrized/variable.py
+++ b/pulser/parametrized/variable.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 import dataclasses
-from typing import Union, Dict, Any, cast, Iterable, Sequence
+from typing import Union, Any, cast, Iterable, Sequence
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -51,7 +51,7 @@ class Variable(Parametrized, OpSupport):
         self._clear()
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def variables(self) -> dict[str, Variable]:
         return {self.name: self}
 
     def _clear(self) -> None:
@@ -81,7 +81,7 @@ class Variable(Parametrized, OpSupport):
             raise ValueError(f"No value assigned to variable '{self.name}'.")
         return self.value
 
-    def _to_dict(self) -> Dict[str, Any]:
+    def _to_dict(self) -> dict[str, Any]:
         d = obj_to_dict(self, _build=False)
         d.update(dataclasses.asdict(self))
         return d
@@ -112,14 +112,14 @@ class _VariableItem(Parametrized, OpSupport):
     key: Union[int, slice]
 
     @property
-    def variables(self) -> Dict[str, Variable]:
+    def variables(self) -> dict[str, Variable]:
         return self.var.variables
 
     def build(self) -> Union[ArrayLike, str, float, int]:
         """Return the variable's item(s) values."""
         return cast(Sequence, self.var.build())[self.key]
 
-    def _to_dict(self) -> Dict[str, Any]:
+    def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(self, self.var, self.key,
                            _module="operator", _name="getitem")
 

--- a/pulser/parametrized/variable.py
+++ b/pulser/parametrized/variable.py
@@ -35,7 +35,7 @@ class Variable(Parametrized, OpSupport):
         size (int=1): The number of values stored. Defaults to a single value.
     """
     name: str
-    dtype: type
+    dtype: Union[type[float], type[int], type[str]]
     size: int = 1
 
     def __post_init__(self) -> None:

--- a/pulser/parametrized/variable.py
+++ b/pulser/parametrized/variable.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
+
 import dataclasses
 from typing import Union, Any, cast, Iterable, Sequence
 

--- a/pulser/pulse.py
+++ b/pulser/pulse.py
@@ -25,7 +25,7 @@ from pulser.parametrized.decorators import parametrize
 from pulser.waveforms import Waveform, ConstantWaveform
 from pulser.json.utils import obj_to_dict
 
-from typing import Any, cast, Dict, Union
+from typing import Any, cast, Union
 
 
 class Pulse:
@@ -159,7 +159,7 @@ class Pulse:
         fig.tight_layout()
         plt.show()
 
-    def _to_dict(self) -> Dict[str, Any]:
+    def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(self, self.amplitude, self.detuning, self.phase,
                            post_phase_shift=self.post_phase_shift)
 

--- a/pulser/pulse.py
+++ b/pulser/pulse.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import functools
 import itertools
+from typing import Any, cast, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -24,8 +25,6 @@ from pulser.parametrized import Parametrized, ParamObj
 from pulser.parametrized.decorators import parametrize
 from pulser.waveforms import Waveform, ConstantWaveform
 from pulser.json.utils import obj_to_dict
-
-from typing import Any, cast, Union
 
 
 class Pulse:

--- a/pulser/register.py
+++ b/pulser/register.py
@@ -14,13 +14,13 @@
 
 
 from __future__ import annotations
-
+from collections.abc import Mapping
 import matplotlib.pyplot as plt
 from matplotlib import collections as mc
 import numpy as np
 from numpy.typing import ArrayLike
 from scipy.spatial import KDTree
-from typing import Any, Iterable, Optional, Mapping, cast
+from typing import Any, Iterable, Optional, cast
 
 import pulser
 from pulser.json.utils import obj_to_dict

--- a/pulser/register.py
+++ b/pulser/register.py
@@ -20,7 +20,7 @@ from matplotlib import collections as mc
 import numpy as np
 from numpy.typing import ArrayLike
 from scipy.spatial import KDTree
-from typing import Any, Dict, Iterable, Optional, Mapping, cast
+from typing import Any, Iterable, Optional, Mapping, cast
 
 import pulser
 from pulser.json.utils import obj_to_dict
@@ -53,7 +53,7 @@ class Register:
         self._coords = coords
 
     @property
-    def qubits(self) -> Dict[Any, np.ndarray]:
+    def qubits(self) -> dict[Any, np.ndarray]:
         """Dictionary of the qubit names and their position coordinates."""
         return dict(zip(self._ids, self._coords))
 

--- a/pulser/register.py
+++ b/pulser/register.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from __future__ import annotations
+
 from collections.abc import Mapping
 import matplotlib.pyplot as plt
 from matplotlib import collections as mc

--- a/pulser/register.py
+++ b/pulser/register.py
@@ -20,10 +20,12 @@ from matplotlib import collections as mc
 import numpy as np
 from numpy.typing import ArrayLike
 from scipy.spatial import KDTree
-from typing import Any, Iterable, Optional, cast
+from typing import Any, cast, Iterable, Optional, Union
 
 import pulser
 from pulser.json.utils import obj_to_dict
+
+QubitId = Union[int, str]
 
 
 class Register:
@@ -53,7 +55,7 @@ class Register:
         self._coords = coords
 
     @property
-    def qubits(self) -> dict[Any, np.ndarray]:
+    def qubits(self) -> dict[QubitId, np.ndarray]:
         """Dictionary of the qubit names and their position coordinates."""
         return dict(zip(self._ids, self._coords))
 
@@ -362,7 +364,8 @@ class Register:
         self._coords = [rot @ v for v in self._coords]
 
     def draw(self, with_labels: bool = True,
-             blockade_radius: Optional[float] = None, draw_graph: bool = True,
+             blockade_radius: Optional[float] = None,
+             draw_graph: bool = True,
              draw_half_radius: bool = False) -> None:
         """Draws the entire register.
 
@@ -442,6 +445,6 @@ class Register:
 
         plt.show()
 
-    def _to_dict(self) -> dict:
+    def _to_dict(self) -> dict[str, Any]:
         qs = dict(zip(self._ids, map(np.ndarray.tolist, self._coords)))
         return obj_to_dict(self, qs)

--- a/pulser/simulation/simresults.py
+++ b/pulser/simulation/simresults.py
@@ -27,7 +27,7 @@ class SimulationResults:
         """Initializes a new SimulationResults instance.
 
         Args:
-            run_output (List[qutip.Qobj]): List of ``qutip.Qobj`` corresponding
+            run_output (list[qutip.Qobj]): List of ``qutip.Qobj`` corresponding
                 to the states at each time step after the evolution has been
                 simulated.
             dim (int): The dimension of the local space of each atom (2 or 3).

--- a/pulser/waveforms.py
+++ b/pulser/waveforms.py
@@ -20,7 +20,7 @@ import inspect
 import itertools
 import sys
 from types import FunctionType
-from typing import Any, cast, Dict, List, Optional, Tuple, Union
+from typing import Any, cast, List, Optional, Tuple, Union
 import warnings
 
 from matplotlib.axes import Axes
@@ -114,7 +114,7 @@ class Waveform(ABC):
                                   " modifications to its duration.")
 
     @abstractmethod
-    def _to_dict(self) -> Dict[str, Any]:
+    def _to_dict(self) -> dict[str, Any]:
         pass
 
     @abstractmethod
@@ -220,7 +220,7 @@ class CompositeWaveform(Waveform):
             raise TypeError(f"{waveform!r} is not a valid waveform. "
                             "Please provide a valid Waveform.")
 
-    def _to_dict(self) -> Dict[str, Any]:
+    def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(self, *self._waveforms)
 
     def __str__(self) -> str:
@@ -264,7 +264,7 @@ class CustomWaveform(Waveform):
         """
         return self._samples
 
-    def _to_dict(self) -> Dict[str, Any]:
+    def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(self, self._samples)
 
     def __str__(self) -> str:
@@ -327,7 +327,7 @@ class ConstantWaveform(Waveform):
         """
         return ConstantWaveform(new_duration, self._value)
 
-    def _to_dict(self) -> Dict[str, Any]:
+    def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(self, self._duration, self._value)
 
     def __str__(self) -> str:
@@ -400,7 +400,7 @@ class RampWaveform(Waveform):
         """
         return RampWaveform(new_duration, self._start, self._stop)
 
-    def _to_dict(self) -> Dict[str, Any]:
+    def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(self, self._duration, self._start, self._stop)
 
     def __str__(self) -> str:
@@ -507,7 +507,7 @@ class BlackmanWaveform(Waveform):
         """
         return BlackmanWaveform(new_duration, self._area)
 
-    def _to_dict(self) -> Dict[str, Any]:
+    def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(self, self._duration, self._area)
 
     def __str__(self) -> str:

--- a/pulser/waveforms.py
+++ b/pulser/waveforms.py
@@ -20,7 +20,7 @@ import inspect
 import itertools
 import sys
 from types import FunctionType
-from typing import Any, cast, List, Optional, Tuple, Union
+from typing import Any, cast, Optional, Tuple, Union
 import warnings
 
 from matplotlib.axes import Axes
@@ -211,7 +211,7 @@ class CompositeWaveform(Waveform):
         return self._waveforms[-1].last_value
 
     @property
-    def waveforms(self) -> List[Waveform]:
+    def waveforms(self) -> list[Waveform]:
         """The waveforms encapsulated in the composite waveform."""
         return list(self._waveforms)
 


### PR DESCRIPTION
- Makes existing type hints PEP 585 compliant, namely by using built-in generics whenever possible
- Further specifies some existing type annotations
- Normalizes style for `from __future__ import annotations` to be always separated by a blank line from the rest of the imports