### PR TITLE
Disallow untyped defs outside of tests

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -3,8 +3,12 @@ files = pulser
 warn_return_any = True
 warn_redundant_casts = True
 warn_unused_ignores = True
+disallow_untyped_defs = True
 
 # 3rd-party libs without type hints nor stubs
 [mypy-matplotlib.*,scipy.*,qutip.*]
 follow_imports = silent
 ignore_missing_imports = true
+
+[mypy-pulser.tests.*]
+disallow_untyped_defs = False

--- a/pulser/json/utils.py
+++ b/pulser/json/utils.py
@@ -17,12 +17,12 @@ from __future__ import annotations
 from typing import Any, Optional
 
 
-def obj_to_dict(obj, *args,
+def obj_to_dict(obj: object, *args: Any,
                 _build: bool = True,
                 _module: Optional[str] = None,
                 _name: Optional[str] = None,
                 _submodule: Optional[str] = None,
-                **kwargs) -> dict[str, Any]:
+                **kwargs: Any) -> dict[str, Any]:
     """Encodes an object in a dictionary for serialization.
 
     Args:

--- a/pulser/parametrized/decorators.py
+++ b/pulser/parametrized/decorators.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from functools import wraps
 from itertools import chain
+from typing import Any
 
 from pulser.parametrized import Parametrized, ParamObj
 
@@ -29,7 +30,7 @@ def parametrize(func: Callable) -> Callable:
         is not supported, and in regular functions is not tested.
     """
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         for x in chain(args, kwargs.values()):
             if isinstance(x, Parametrized):
                 return ParamObj(func, *args, **kwargs)

--- a/pulser/parametrized/paramabc.py
+++ b/pulser/parametrized/paramabc.py
@@ -31,7 +31,7 @@ class Parametrized(ABC):
         pass
 
     @abstractmethod
-    def build(self):
+    def build(self) -> Any:
         """Builds the object."""
         pass
 

--- a/pulser/parametrized/paramobj.py
+++ b/pulser/parametrized/paramobj.py
@@ -90,7 +90,7 @@ class ParamObj(Parametrized, OpSupport):
     def variables(self) -> dict[str, Variable]:
         return self._variables
 
-    def build(self):
+    def build(self) -> Any:
         """Builds the object with its variables last assigned values."""
         vars_state = {key: var._count for key, var in self._variables.items()}
         if vars_state != self._vars_state:
@@ -100,13 +100,15 @@ class ParamObj(Parametrized, OpSupport):
                      for arg in self.args]
             kwargs_ = {key: val.build() if isinstance(val, Parametrized)
                        else val for key, val in self.kwargs.items()}
-            obj = (self.cls.build() if isinstance(self.cls, ParamObj)
-                   else self.cls)
+            if isinstance(self.cls, ParamObj):
+                obj = self.cls.build()
+            else:
+                obj = self.cls
             self._instance = obj(*args_, **kwargs_)
         return self._instance
 
     def _to_dict(self) -> dict[str, Any]:
-        def class_to_dict(cls):
+        def class_to_dict(cls: Callable) -> dict[str, Any]:
             return obj_to_dict(self, _build=False, _name=cls.__name__,
                                _module=cls.__module__)
 

--- a/pulser/parametrized/variable.py
+++ b/pulser/parametrized/variable.py
@@ -49,6 +49,8 @@ class Variable(Parametrized, OpSupport):
             raise TypeError("Given variable 'size' is not of type 'int'.")
         elif self.size < 1:
             raise ValueError("Variables must be of size 1 or larger.")
+
+        self._count: int
         self.__dict__["_count"] = -1      # Counts the updates
         self._clear()
 

--- a/pulser/pulse.py
+++ b/pulser/pulse.py
@@ -56,7 +56,7 @@ class Pulse:
             (see ``Sequence.phase_shift()`` for more information).
     """
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, **kwargs):      # type: ignore
         for x in itertools.chain(args, kwargs.values()):
             if isinstance(x, Parametrized):
                 return ParamObj(cls, *args, **kwargs)

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -69,7 +69,7 @@ _Call = namedtuple("_Call", ['name', 'args', 'kwargs'])
 def _screen(func: Callable) -> Callable:
     """Blocks the call to a function if the Sequence is parametrized."""
     @wraps(func)
-    def wrapper(self, *args, **kwargs):
+    def wrapper(self: Sequence, *args: Any, **kwargs: Any) -> Any:
         if self.is_parametrized():
             raise RuntimeError(f"Sequence.{func.__name__} can't be called in"
                                + " parametrized sequences.")
@@ -80,8 +80,8 @@ def _screen(func: Callable) -> Callable:
 def _store(func: Callable) -> Callable:
     """Stores any Sequence building call for deferred execution."""
     @wraps(func)
-    def wrapper(self, *args, **kwargs):
-        def verify_variable(x):
+    def wrapper(self: Sequence, *args: Any, **kwargs: Any) -> Any:
+        def verify_variable(x: Any) -> None:
             if isinstance(x, Parametrized):
                 # If not already, the sequence becomes parametrized
                 self._building = False

--- a/pulser/tests/__init__.py
+++ b/pulser/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Pulser Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests."""

--- a/pulser/waveforms.py
+++ b/pulser/waveforms.py
@@ -36,7 +36,7 @@ from pulser.json.utils import obj_to_dict
 class Waveform(ABC):
     """The abstract class for a pulse's waveform."""
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, **kwargs):      # type: ignore
         for x in itertools.chain(args, kwargs.values()):
             if isinstance(x, Parametrized):
                 return ParamObj(cls, *args, **kwargs)


### PR DESCRIPTION
Now that almost all the source code is covered by type hints, we can configure `mypy` to disallow untyped definitions, which will enforce typing on all `def` statements.

This PR adds the few missing type hints (though mostly were redundant) so that this setting can be enabled without errors.

As the unit tests are not being typed, an exception is made for them. In order to do so, `pulser.tests` had to be seen as a module, so a `pulser/tests/__init__.py` was added.