### PR TITLE
XY simulation

### DIFF
--- a/pulser/simulation/simresults.py
+++ b/pulser/simulation/simresults.py
@@ -49,13 +49,13 @@ class SimulationResults:
         self._states = run_output
         self._dim = dim
         self._size = size
-        if basis_name not in {'ground-rydberg', 'digital', 'all'}:
+        if basis_name not in {'ground-rydberg', 'digital', 'all', 'XY'}:
             raise ValueError(
                 "`basis_name` must be 'ground-rydberg', 'digital' or 'all'."
                 )
         self._basis_name = basis_name
         if meas_basis:
-            if meas_basis not in {'ground-rydberg', 'digital'}:
+            if meas_basis not in {'ground-rydberg', 'digital', 'XY'}:
                 raise ValueError(
                     "`meas_basis` must be 'ground-rydberg' or 'digital'."
                     )
@@ -95,6 +95,7 @@ class SimulationResults:
             full = final_state.full()
             global_ph = float(np.angle(full[np.argmax(np.abs(full))]))
             final_state *= np.exp(-1j * global_ph)
+
         if self._dim != 3:
             if reduce_to_basis not in [None, self._basis_name]:
                 raise TypeError(f"Can't reduce a system in {self._basis_name}"
@@ -102,11 +103,13 @@ class SimulationResults:
         elif reduce_to_basis is not None:
             if reduce_to_basis == "ground-rydberg":
                 ex_state = "2"
+            elif reduce_to_basis == "XY":
+                ex_state = "2"
             elif reduce_to_basis == "digital":
                 ex_state = "0"
             else:
                 raise ValueError("'reduce_to_basis' must be 'ground-rydberg' "
-                                 + f"or 'digital', not '{reduce_to_basis}'.")
+                                 + f"'digital' or 'XY', not '{reduce_to_basis}'.")
             ex_inds = [i for i in range(3**self._size) if ex_state in
                        np.base_repr(i, base=3).zfill(self._size)]
             ex_probs = np.abs(final_state.extract_states(ex_inds).full()) ** 2
@@ -181,9 +184,9 @@ class SimulationResults:
                     )
             meas_basis = self._meas_basis
 
-        if meas_basis not in {'ground-rydberg', 'digital'}:
+        if meas_basis not in {'ground-rydberg', 'digital', 'XY'}:
             raise ValueError(
-                "'meas_basis' can only be 'ground-rydberg' or 'digital'."
+                "'meas_basis' can only be 'ground-rydberg', digital' or 'XY'."
                 )
 
         N = self._size

--- a/pulser/simulation/simulation.py
+++ b/pulser/simulation/simulation.py
@@ -284,7 +284,7 @@ class Simulation:
                 dist = np.linalg.norm(
                     self._qdict[q1] - self._qdict[q2])
                 cosine = 0.
-                U = 0.5 * 7950e1 * \
+                U = 0.5 * 3700 * \
                     (1 - 3 * cosine ** 2) / dist**3
                 xy += U * self._build_general_operator(
                     ['sigma_du', 'sigma_ud'], [q1, q2]

--- a/pulser/tests/test_simulation.py
+++ b/pulser/tests/test_simulation.py
@@ -198,7 +198,7 @@ def test_empty_sequences():
     with pytest.raises(ValueError, match='no declared channels'):
         Simulation(seq)
     seq.declare_channel("ch0", "mw_global")
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError, match='No instructions given'):
         Simulation(seq)
 
     seq = Sequence(reg, MockDevice)


### PR DESCRIPTION
Here is the implementation of the XY simulation on the Mock Device for the `mw_global`channel. There is a joined notebook for the implementation of the examples.

A few remarks:
- the dependency of C_3 with the angle is not implemented yet.
- the specific tests are not implemented yet.
- only the global pulses are available (no local adressing of the atoms)

[test_pulser.pdf](https://github.com/pasqal-io/Pulser/files/6571168/test_pulser.pdf)
