### PR TITLE
Enhanced max_connectivity() under 7 atoms

### DIFF
--- a/pulser/register.py
+++ b/pulser/register.py
@@ -339,11 +339,12 @@ class Register:
                              f" {device.min_atom_distance} or above.")
 
         if n_qubits < 7:
-            hex_coords = np.array([(0.0, 0.0), (1.0, 0.0), (0.5, np.sqrt(3/4)),
-                                   (1.5, np.sqrt(3/4)), (2.0, 0.0),
-                                   (0.5, -np.sqrt(3/4))])
+            crest_y = np.sqrt(3) / 2.0
+            hex_coords = np.array([(0.0, 0.0), (-0.5, crest_y), (0.5, crest_y),
+                                   (1.0, 0.0), (0.5, -crest_y),
+                                   (-0.5, -crest_y)])
             return cls.from_coordinates(spacing * hex_coords[:n_qubits],
-                                        prefix=prefix)
+                                        prefix=prefix, center=False)
 
         full_layers = int((-3.0 + np.sqrt(9 + 12 * (n_qubits - 1))) / 6.0)
         atoms_left = n_qubits - 1 - (full_layers**2 + full_layers) * 3

--- a/pulser/tests/test_register.py
+++ b/pulser/tests/test_register.py
@@ -168,12 +168,13 @@ def test_max_connectivity():
     assert(np.all(np.isclose(atoms[0], [0.0, 0.0])))
 
     # Check for less than 7 atoms:
-    for i in range(1, 6):
-        hex_coords = np.array([(0.0, 0.0), (1.0, 0.0), (0.5, np.sqrt(3/4)),
-                               (1.5, np.sqrt(3/4)), (2.0, 0.0),
-                               (0.5, -np.sqrt(3/4))])
+    for i in range(1, 7):
+        hex_coords = np.array([(0.0, 0.0), (-0.5, crest_y), (0.5, crest_y),
+                               (1.0, 0.0), (0.5, -crest_y),
+                               (-0.5, -crest_y)])
         reg = Register.max_connectivity(i, device)
-        reg2 = Register.from_coordinates(4 * hex_coords[:i])  # Use min spacing
+        reg2 = Register.from_coordinates(
+            spacing * hex_coords[:i], center=False)
         assert (len(reg.qubits) == i)
         atoms = list(reg.qubits.values())
         atoms2 = list(reg2.qubits.values())


### PR DESCRIPTION
Extends the range of the test to N = 6 atoms.

Disables centering in order to leave the innermost atom on (0,0).

Changes the order of atoms for consistency with N >= 7 atoms (spiral pattern).

Uses `device.min_atom_distance` instead of constant `4` in tests.

