### PR TITLE
Adding method to set the magnetic field on a Sequence

### DIFF
--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -228,9 +228,8 @@ class Sequence:
         The magnetic field vector is defined on the reference frame of the
         atoms in the Register (with the z-axis coming outside of the plane).
 
-
         Note:
-            Only defined in "XY Mode", the default value being (0, 0, 1) G.
+            Only defined in "XY Mode", the default value being (0, 0, 30) G.
         """
         if not self._in_xy:
             raise AttributeError("The magnetic field is only defined when the "

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -210,7 +210,8 @@ class Sequence:
         """Channels still available for declaration."""
         # Show all channels if none are declared, otherwise filter depending
         # on whether the sequence is working on XY mode
-        if not self._channels:
+        # If already in XY mode, filter right away
+        if not self._channels and not self._in_xy:
             return dict(self._device.channels)
         else:
             # MockDevice channels can be declared multiple times

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -222,7 +222,7 @@ class Sequence:
                     }
 
     @property
-    def magnetic_field(self) -> tuple[float, float, float]:
+    def magnetic_field(self) -> np.ndarray:
         """The magnetic field acting on the array of atoms.
 
         The magnetic field vector is defined on the reference frame of the
@@ -235,7 +235,7 @@ class Sequence:
         if not self._in_xy:
             raise AttributeError("The magnetic field is only defined when the "
                                  "sequence is in 'XY Mode'.")
-        return self._mag_field
+        return np.array(self._mag_field)
 
     def is_parametrized(self) -> bool:
         """States whether the sequence is parametrized.
@@ -276,7 +276,7 @@ class Sequence:
         return self._phase_ref[basis][qubit].last_phase
 
     def set_magnetic_field(self, bx: float = 0., by: float = 0.,
-                           bz: float = 1.) -> None:
+                           bz: float = 30.) -> None:
         """Sets the magnetic field acting on the entire array.
 
         The magnetic field vector is defined on the reference frame of the
@@ -303,7 +303,12 @@ class Sequence:
             # Not all channels are empty
             raise ValueError("The magnetic field can only be set on an empty "
                              "sequence.")
-        self._mag_field = (bx, by, bz)
+
+        mag_vector = (bx, by, bz)
+        if np.linalg.norm(mag_vector) == 0.:
+            raise ValueError("The magnetic field must have a magnitude greater"
+                             " than 0.")
+        self._mag_field = mag_vector
 
     def declare_channel(self, name: str, channel_id: str,
                         initial_target: Optional[

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -87,25 +87,29 @@ def test_magnetic_field():
                                              "is in 'XY Mode'."):
         seq.magnetic_field
     seq.declare_channel('ch0', 'mw_global')    # seq in XY mode
-    assert seq.magnetic_field == (0., 0., 1.)    # mag field is the default
+    # mag field is the default
+    assert np.all(seq.magnetic_field == np.array((0., 0., 30.)))
     seq.set_magnetic_field(bx=1., by=-1., bz=0.5)
-    assert seq.magnetic_field == (1., -1., 0.5)
+    assert np.all(seq.magnetic_field == np.array((1., -1., 0.5)))
+    with pytest.raises(ValueError, match="magnitude greater than 0"):
+        seq.set_magnetic_field(bz=0.)
     assert seq._empty_sequence
     seq.add(Pulse.ConstantPulse(100, 1, 1, 0), 'ch0')
     assert not seq._empty_sequence
     with pytest.raises(ValueError, match="can only be set on an empty seq"):
-        seq.set_magnetic_field(0., 0., 0.)
+        seq.set_magnetic_field(1., 0., 0.)
 
     seq2 = Sequence(reg, MockDevice)
     seq2.declare_channel('ch0', 'rydberg_global')   # not in XY mode
     with pytest.raises(ValueError, match="can only be set in 'XY Mode'."):
-        seq2.set_magnetic_field(0., 0., 0.)
+        seq2.set_magnetic_field(1., 0., 0.)
 
     seq3 = Sequence(reg, MockDevice)
-    seq3.set_magnetic_field(0., 0., 0.)         # sets seq to XY mode
+    seq3.set_magnetic_field(1., 0., 0.)         # sets seq to XY mode
     assert set(seq3.available_channels) == {'mw_global'}
     seq3.declare_channel('ch0', 'mw_global')
-    assert seq3.magnetic_field == (0., 0., 0.)  # Does not change to default
+    # Does not change to default
+    assert np.all(seq3.magnetic_field == np.array((1., 0., 0.)))
     var = seq3.declare_variable('var')
     # Sequence is marked as non-empty when parametrized too
     seq3.add(Pulse.ConstantPulse(100, var, 1, 0), 'ch0')


### PR DESCRIPTION
- Magnetic field can be set on a Sequence if working on the XY mode
- On an empty sequence, setting the magnetic field puts it into the XY mode
- When not specified, assumes a default of (0, 0, 1) G when entering the XY mode