### PR TITLE
Include magnetic field in serialization

### DIFF
--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -168,6 +168,7 @@ class Sequence:
         self._register: Register = register
         self._device: Device = device
         self._in_xy: bool = False
+        self._mag_field: Optional[tuple[float, float, float]] = None
         self._calls: list[_Call] = [_Call("__init__", (register, device), {})]
         self._channels: dict[str, Channel] = {}
         self._schedule: dict[str, list[_TimeSlot]] = {}

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -309,6 +309,9 @@ class Sequence:
                              " than 0.")
         self._mag_field = mag_vector
 
+        # No parametrization -> Always stored as a regular call
+        self._calls.append(_Call("set_magnetic_field", mag_vector, {}))
+
     def declare_channel(self, name: str, channel_id: str,
                         initial_target: Optional[
                             Union[Iterable[Union[QubitId, Parametrized]],

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -115,7 +115,13 @@ def test_magnetic_field():
     seq3.add(Pulse.ConstantPulse(100, var, 1, 0), 'ch0')
     assert seq3.is_parametrized()
     with pytest.raises(ValueError, match="can only be set on an empty seq"):
-        seq.set_magnetic_field()
+        seq3.set_magnetic_field()
+
+    seq3_str = seq3.serialize()
+    seq3_ = Sequence.deserialize(seq3_str)
+    assert seq3_._in_xy
+    assert str(seq3) == str(seq3_)
+    assert np.all(seq3_.magnetic_field == np.array((1., 0., 0.)))
 
 
 def test_target():


### PR DESCRIPTION
The changes in #200 forgot to add serialization support. These changes store the call(s) in which the magnetic field is set, so that when a sequence is serialized and deserialized, it keeps the magnetic field information.