### PR TITLE
Enforce minimal duration for delay (#204)

### DIFF
--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -452,9 +452,19 @@ class Sequence:
                         current_max_t = op.tf
                         break
         ti = current_max_t
-        tf = ti + pulse.duration
         if ti > t0:
-            self._delay(ti-t0, channel)
+            # Insert a delay
+            delay_duration = ti - t0
+
+            # Delay must not be shorter than the min duration for this channel
+            min_duration = self._channels[channel].min_duration
+            if delay_duration < min_duration:
+                ti += (min_duration - delay_duration)
+                delay_duration = min_duration
+
+            self._delay(delay_duration, channel)
+
+        tf = ti + pulse.duration
 
         prs = {self._phase_ref[basis][q].last_phase for q in last.targets}
         if len(prs) != 1:
@@ -773,11 +783,6 @@ class Sequence:
         self._validate_channel(channel)
         if self.is_parametrized():
             return
-
-        # Delay must not be shorter than the minimal duration for this channel
-        min_duration = self._channels[channel].min_duration
-        if duration < min_duration:
-            duration = min_duration
 
         last = self._last(channel)
         ti = last.tf

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -774,6 +774,11 @@ class Sequence:
         if self.is_parametrized():
             return
 
+        # Delay must not be shorter than the minimal duration for this channel
+        min_duration = self._channels[channel].min_duration
+        if duration < min_duration:
+            duration = min_duration
+
         last = self._last(channel)
         ti = last.tf
         tf = ti + self._channels[channel].validate_duration(duration)

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -143,6 +143,17 @@ def test_delay():
     assert seq._last('ch0') == _TimeSlot('delay', 0, 388, {'q19'})
 
 
+def test_delay_min_duration():
+    # Check that a delay shorter than a channel's minimal duration
+    # is automatically extended to that minimal duration
+    seq = Sequence(reg, device)
+    seq.declare_channel('ch0', 'raman_local')
+    min_duration = seq._channels['ch0'].min_duration
+    seq.target('q0', 'ch0')
+    seq.delay(min_duration - 1, 'ch0')
+    assert seq._last('ch0') == _TimeSlot('delay', 0, min_duration, {'q0'})
+
+
 def test_phase():
     seq = Sequence(reg, device)
     seq.declare_channel('ch0', 'raman_local', initial_target='q0')

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -147,11 +147,18 @@ def test_delay_min_duration():
     # Check that a delay shorter than a channel's minimal duration
     # is automatically extended to that minimal duration
     seq = Sequence(reg, device)
-    seq.declare_channel('ch0', 'raman_local')
-    min_duration = seq._channels['ch0'].min_duration
-    seq.target('q0', 'ch0')
-    seq.delay(min_duration - 1, 'ch0')
-    assert seq._last('ch0') == _TimeSlot('delay', 0, min_duration, {'q0'})
+    seq.declare_channel('ch0', 'rydberg_global')
+    seq.declare_channel('ch1', 'rydberg_local')
+    seq.target('q0', 'ch1')
+    pulse0 = Pulse.ConstantPulse(52, 1, 1, 0)
+    pulse1 = Pulse.ConstantPulse(180, 1, 1, 0)
+    seq.add(pulse1, 'ch1')
+    seq.add(pulse0, 'ch0')
+    seq.target('q1', 'ch1')
+    seq.add(pulse1, 'ch1')
+    min_duration = seq._channels['ch1'].min_duration
+    assert seq._schedule['ch1'][3] == _TimeSlot(
+        'delay', 220, 220 + min_duration, {'q1'})
 
 
 def test_phase():


### PR DESCRIPTION
Enforces a minimal duration for delays, equal to the minimal duration allowed by the channel (see #204).

Adds a corresponding test for 100% coverage.