### PR TITLE
Adds 'typing-extensions' to requirements for Python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ matplotlib
 numpy >= 1.20
 qutip
 scipy
+typing_extensions; python_version == '3.7' 
 
 # tests
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,9 @@ matplotlib
 numpy >= 1.20
 qutip
 scipy
-typing_extensions; python_version == '3.7' 
+
+# version specific
+typing_extensions; python_version == '3.7'
 
 # tests
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ qutip
 scipy
 
 # version specific
-typing_extensions; python_version == '3.7'
+typing-extensions; python_version == '3.7'
 
 # tests
 pytest

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,11 @@ setup(
         "scipy",
         "qutip",
     ],
+    extras_require={
+        ":python_version == '3.7'": [
+            "typing-extensions",
+        ]
+    },
     packages=find_packages(),
     include_package_data=True,
     description="A pulse-level composer for neutral-atom quantum devices.",


### PR DESCRIPTION
The `typing-extensions` package is necessary if using Python 3.7, so it's added to `requirements.txt` and `setup.py` as a version-dependent requirement.