### PR TITLE
New `InterpolatedWaveform` class

### DIFF
--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import Any, cast, Optional, Union
 
 import matplotlib.pyplot as plt
@@ -21,7 +22,7 @@ import numpy as np
 from scipy.interpolate import CubicSpline
 
 import pulser
-from pulser.waveforms import ConstantWaveform
+from pulser.waveforms import ConstantWaveform, InterpolatedWaveform
 from pulser.pulse import Pulse
 
 
@@ -42,6 +43,7 @@ def gather_data(seq: pulser.sequence.Sequence) -> dict:
         time = [-1]     # To not break the "time[-1]" later on
         amp = []
         detuning = []
+        interp_pts = defaultdict(list)  # List of interpolation points
         target: dict[Union[str, tuple[int, int]], Any] = {}
         # phase_shift = {}
         for slot in sch:
@@ -68,6 +70,14 @@ def gather_data(seq: pulser.sequence.Sequence) -> dict:
                 time += list(range(slot.ti, slot.tf))
                 amp += pulse.amplitude.samples.tolist()
                 detuning += pulse.detuning.samples.tolist()
+                for wf_type in ["amplitude", "detuning"]:
+                    wf = getattr(pulse, wf_type)
+                    if isinstance(wf, InterpolatedWaveform):
+                        interp_pts[wf_type] += [
+                            (round(t + slot.ti), v) for t, v in
+                            zip(wf._times * (wf._duration - 1), wf._values)
+                        ]
+
         if time[-1] < seq._total_duration - 1:
             time += [time[-1]+1, seq._total_duration-1]
             amp += [0, 0]
@@ -78,12 +88,15 @@ def gather_data(seq: pulser.sequence.Sequence) -> dict:
                     'target': target}
         if hasattr(seq, "_measurement"):
             data[ch]['measurement'] = seq._measurement
+        if interp_pts:
+            data[ch]['interp_pts'] = interp_pts
     return data
 
 
 def draw_sequence(seq: pulser.sequence.Sequence,
                   sampling_rate: Optional[float] = None,
-                  draw_phase_area: bool = False) -> None:
+                  draw_phase_area: bool = False,
+                  draw_interp_pts: bool = True) -> None:
     """Draw the entire sequence.
 
     Args:
@@ -93,6 +106,9 @@ def draw_sequence(seq: pulser.sequence.Sequence,
             input pulse.
         draw_phase_area (bool): Whether phase and area values need to be shown
             as text on the plot, defaults to False.
+        draw_interp_pts (bool): When the sequence has pulses with waveforms of
+            type InterpolatedWaveform, draws the points of interpolation on
+            top of the respective waveforms.
     """
 
     def phase_str(phi: float) -> str:
@@ -318,5 +334,14 @@ def draw_sequence(seq: pulser.sequence.Sequence,
         else:
             a.axhline(0, linestyle='-', linewidth=0.5, color='grey')
             b.axhline(0, linestyle=':', linewidth=0.5, color='grey')
+
+        if 'interp_pts' in data[ch] and draw_interp_pts:
+            all_points = data[ch]['interp_pts']
+            if 'amplitude' in all_points:
+                pts = np.array(all_points['amplitude'])
+                a.scatter(pts[:, 0], pts[:, 1], color="darkgreen")
+            if 'detuning' in all_points:
+                pts = np.array(all_points['detuning'])
+                b.scatter(pts[:, 0], pts[:, 1], color="indigo")
 
     plt.show()

--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -43,7 +43,8 @@ def gather_data(seq: pulser.sequence.Sequence) -> dict:
         time = [-1]     # To not break the "time[-1]" later on
         amp = []
         detuning = []
-        interp_pts = defaultdict(list)  # List of interpolation points
+        # List of interpolation points
+        interp_pts: defaultdict[str, list[list[float]]] = defaultdict(list)
         target: dict[Union[str, tuple[int, int]], Any] = {}
         # phase_shift = {}
         for slot in sch:
@@ -73,10 +74,9 @@ def gather_data(seq: pulser.sequence.Sequence) -> dict:
                 for wf_type in ["amplitude", "detuning"]:
                     wf = getattr(pulse, wf_type)
                     if isinstance(wf, InterpolatedWaveform):
-                        interp_pts[wf_type] += [
-                            (round(t + slot.ti), v) for t, v in
-                            zip(wf._times * (wf._duration - 1), wf._values)
-                        ]
+                        pts = wf.data_points
+                        pts[:, 0] += slot.ti
+                        interp_pts[wf_type] += pts.tolist()
 
         if time[-1] < seq._total_duration - 1:
             time += [time[-1]+1, seq._total_duration-1]

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -701,14 +701,19 @@ class Sequence:
         return cast(Sequence, json.loads(obj, cls=PulserDecoder, **kwargs))
 
     @_screen
-    def draw(self, draw_phase_area: bool = False) -> None:
+    def draw(self, draw_phase_area: bool = False,
+             draw_interp_pts: bool = True) -> None:
         """Draws the sequence in its current state.
 
         Keyword Args:
             draw_phase_area (bool): Whether phase and area values need
                 to be shown as text on the plot, defaults to False.
+            draw_interp_pts (bool): When the sequence has pulses with waveforms
+                of type InterpolatedWaveform, draws the points of interpolation
+                on top of the respective waveforms.
         """
-        draw_sequence(self, draw_phase_area=draw_phase_area)
+        draw_sequence(self, draw_phase_area=draw_phase_area,
+                      draw_interp_pts=draw_interp_pts)
 
     def _target(self, qubits: Union[Iterable[QubitId],
                                     QubitId], channel: str) -> None:

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -22,7 +22,8 @@ from pulser import Sequence, Pulse, Register
 from pulser.devices import Chadoq2, MockDevice
 from pulser.devices._device_datacls import Device
 from pulser.sequence import _TimeSlot
-from pulser.waveforms import BlackmanWaveform, CompositeWaveform, RampWaveform
+from pulser.waveforms import (BlackmanWaveform, CompositeWaveform,
+                              RampWaveform, InterpolatedWaveform)
 
 reg = Register.triangular_lattice(4, 7, spacing=5, prefix='q')
 device = Chadoq2
@@ -231,7 +232,10 @@ def test_sequence():
     with patch('matplotlib.pyplot.show'):
         seq.draw()
 
-    pulse1 = Pulse.ConstantPulse(500, 2, -10, 0, post_phase_shift=np.pi)
+    # pulse1 = Pulse.ConstantPulse(500, 2, -10, 0, post_phase_shift=np.pi)
+    pulse1 = Pulse(InterpolatedWaveform(500, [0, 1, 0]),
+                   InterpolatedWaveform(500, [-1, 1, 0]), phase=0,
+                   post_phase_shift=np.pi)
     pulse2 = Pulse.ConstantDetuning(BlackmanWaveform(1e3, np.pi/4), 25, np.pi,
                                     post_phase_shift=1)
     with pytest.raises(TypeError):

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -250,7 +250,6 @@ def test_sequence():
     with patch('matplotlib.pyplot.show'):
         seq.draw()
 
-    # pulse1 = Pulse.ConstantPulse(500, 2, -10, 0, post_phase_shift=np.pi)
     pulse1 = Pulse(InterpolatedWaveform(500, [0, 1, 0]),
                    InterpolatedWaveform(500, [-1, 1, 0]), phase=0,
                    post_phase_shift=np.pi)

--- a/pulser/tests/test_waveforms.py
+++ b/pulser/tests/test_waveforms.py
@@ -17,11 +17,13 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
+from scipy.interpolate import interp1d, PchipInterpolator
 
 from pulser.json.coders import PulserEncoder, PulserDecoder
 from pulser.parametrized import Variable, ParamObj
 from pulser.waveforms import (ConstantWaveform, RampWaveform, BlackmanWaveform,
-                              CustomWaveform, CompositeWaveform)
+                              CustomWaveform, CompositeWaveform,
+                              InterpolatedWaveform)
 
 np.random.seed(20201105)
 
@@ -31,6 +33,8 @@ arb_samples = np.random.random(52)
 custom = CustomWaveform(arb_samples)
 blackman = BlackmanWaveform(40, np.pi)
 composite = CompositeWaveform(blackman, constant, custom)
+interp_values = [0, 1, 4.4, 2, 3, 1, 0]
+interp = InterpolatedWaveform(1000, interp_values)
 
 
 def test_duration():
@@ -66,6 +70,10 @@ def test_change_duration():
     assert new_ramp.duration == 100
     assert new_ramp != ramp
 
+    assert interp.duration == 1000
+    new_interp = interp.change_duration(100)
+    assert new_interp.duration == 100
+
 
 def test_samples():
     assert np.all(constant.samples == -3)
@@ -85,6 +93,7 @@ def test_draw():
     with patch('matplotlib.pyplot.show'):
         composite.draw()
         blackman.draw()
+        interp.draw()
 
 
 def test_eq():
@@ -102,6 +111,8 @@ def test_first_last():
     assert composite.first_value == 0
     assert composite.last_value == arb_samples[-1]
     assert custom.first_value == arb_samples[0]
+    assert np.isclose(interp.first_value, interp_values[0])
+    assert np.isclose(interp.last_value, interp_values[-1])
 
 
 def test_hash():
@@ -165,6 +176,44 @@ def test_blackman():
     assert wf_var.build() == wf
 
 
+def test_interpolated():
+    assert isinstance(interp.interp_function, PchipInterpolator)
+
+    times = np.linspace(0.2, 0.8, num=len(interp_values))
+    with pytest.raises(ValueError, match="must match the number of `values`"):
+        InterpolatedWaveform(1000, interp_values, times=times[:-1])
+    with pytest.raises(ValueError, match="must be greater than or equal to 0"):
+        InterpolatedWaveform(1000, interp_values, times=times - 0.21)
+    with pytest.raises(ValueError, match="must be less than or equal to 1"):
+        InterpolatedWaveform(1000, interp_values, times=times + 0.21)
+    with pytest.raises(ValueError, match="array of non-repeating values"):
+        InterpolatedWaveform(1000, interp_values,
+                             times=[0.2] + times[:-1].tolist())
+
+    with pytest.raises(ValueError, match="Invalid interpolator 'fake'"):
+        InterpolatedWaveform(1000, interp_values, times=times,
+                             interpolator="fake")
+
+    dt = 1000
+    interp_wf = InterpolatedWaveform(dt, [0, 1], interpolator="interp1d",
+                                     kind="linear")
+    assert isinstance(interp_wf.interp_function, interp1d)
+    np.testing.assert_allclose(interp_wf.samples, np.linspace(0, 1., num=dt))
+
+    interp_wf *= 2
+    np.testing.assert_allclose(interp_wf.samples, np.linspace(0, 2., num=dt))
+
+    wf_str = "InterpolatedWaveform(Points: (0, 0), (999, 2)"
+    assert str(interp_wf) == wf_str + ")"
+    assert repr(interp_wf) == wf_str + ", Interpolator=interp1d)"
+
+    vals = np.linspace(0, 1, num=5) ** 2
+    interp_wf2 = InterpolatedWaveform(dt, vals, interpolator="interp1d",
+                                      kind="quadratic")
+    np.testing.assert_allclose(interp_wf2.samples,
+                               np.linspace(0, 1, num=dt)**2, atol=1e-3)
+
+
 def test_ops():
     assert -constant == ConstantWaveform(100, 3)
     assert ramp * 2 == RampWaveform(2e3, 10, 38)
@@ -176,6 +225,6 @@ def test_ops():
 
 
 def test_serialization():
-    for wf in [constant, ramp, custom, blackman, composite]:
+    for wf in [constant, ramp, custom, blackman, composite, interp]:
         s = json.dumps(wf, cls=PulserEncoder)
         assert wf == json.loads(s, cls=PulserDecoder)

--- a/pulser/tests/test_waveforms.py
+++ b/pulser/tests/test_waveforms.py
@@ -255,7 +255,7 @@ def test_get_item():
 
     # Check nominal operations
 
-    for wf in [blackman, composite, constant, custom, ramp]:
+    for wf in [blackman, composite, constant, custom, ramp, interp]:
         duration = wf.duration
         duration14 = duration // 4
         duration34 = duration * 3 // 4

--- a/pulser/waveforms.py
+++ b/pulser/waveforms.py
@@ -523,12 +523,26 @@ class BlackmanWaveform(Waveform):
 
 
 class InterpolatedWaveform(Waveform):
-    """Creates a waveform from interpolation of a set of data points."""
+    """Creates a waveform from interpolation of a set of data points.
+
+    Args:
+        duration (int): The waveform duration (in ns).
+        values (ArrayLike): Values of the interpolation points (in rad/µs).
+        times (Optional[ArrayLike]): Fractions of the total duration (between 0
+            and 1), indicating where to place each value on the time axis. If
+            not given, the values are spread evenly throughout the full
+            duration of the waveform.
+        interpolator (str = "PchipInterpolator"): The SciPy interpolation class
+            to use. Supports "PchipInterpolator" and "interp1d".
+        **interpolator_kwargs: Extra parameters to give to the chosen
+            interpolator class.
+    """
     def __init__(self, duration: Union[int, Parametrized],
                  values: Union[ArrayLike, Parametrized],
                  times: Optional[Union[ArrayLike, Parametrized]] = None,
                  interpolator: str = "PchipInterpolator",
                  **interpolator_kwargs: Any):
+        """Initializes a new InterpolatedWaveform."""
         super().__init__(duration)
         self._values = np.array(values, dtype=float)
         if times is not None:

--- a/pulser/waveforms.py
+++ b/pulser/waveforms.py
@@ -613,8 +613,8 @@ class InterpolatedWaveform(Waveform):
         """The duration of the pulse (in ns)."""
         return self._duration
 
-    @property
-    def samples(self) -> np.ndarray:
+    @cached_property
+    def _samples(self) -> np.ndarray:
         """The value at each time step that describes the waveform."""
         return cast(np.ndarray,
                     np.round(self._interp_func(np.arange(self._duration)),

--- a/pulser/waveforms.py
+++ b/pulser/waveforms.py
@@ -632,16 +632,6 @@ class InterpolatedWaveform(Waveform):
         """Points (t[ns], value[rad/µs]) that define the interpolation."""
         return self._data_pts.copy()
 
-    @property
-    def first_value(self) -> float:
-        """The first value in the waveform."""
-        return float(self.interp_function(0))
-
-    @property
-    def last_value(self) -> float:
-        """The last value in the waveform."""
-        return float(self.interp_function(self.duration - 1))
-
     def change_duration(self, new_duration: int) -> InterpolatedWaveform:
         """Returns a new waveform with modified duration.
 

--- a/pulser/waveforms.py
+++ b/pulser/waveforms.py
@@ -27,6 +27,7 @@ from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 import numpy as np
 from numpy.typing import ArrayLike
+import scipy.interpolate as interpolate
 
 from pulser.parametrized import Parametrized, ParamObj
 from pulser.parametrized.decorators import parametrize
@@ -518,6 +519,115 @@ class BlackmanWaveform(Waveform):
 
     def __mul__(self, other: float) -> BlackmanWaveform:
         return BlackmanWaveform(self._duration, self._area * float(other))
+
+
+class InterpolatedWaveform(Waveform):
+    """Creates a waveform from interpolation of a set of data points."""
+    def __init__(self, duration: Union[int, Parametrized],
+                 values: Union[ArrayLike, Parametrized],
+                 times: Optional[Union[ArrayLike, Parametrized]] = None,
+                 interpolator: str = "PchipInterpolator",
+                 **interpolator_kwargs: Any):
+        super().__init__(duration)
+        self._values = np.array(values, dtype=float)
+        if times is not None:
+            times_ = np.array(times, dtype=float)
+            if len(times_) != len(self._values):
+                raise ValueError(
+                    "When specified, the number of time coordinates in `times`"
+                    f" ({len(times_)}) must match the number of `values` "
+                    f"({len(self._values)}).")
+            if np.any(times_ < 0):
+                raise ValueError(
+                    "All values in `times` must be greater than or equal to 0."
+                )
+            if np.any(times_ > 1):
+                raise ValueError(
+                    "All values in `times` must be less than or equal to 1."
+                )
+            unique_times = np.unique(times)     # Sorted array of unique values
+            if len(times_) != len(unique_times):
+                raise ValueError(
+                    "`times` must be an array of non-repeating values."
+                )
+            # if np.any(times_ != unique_times):
+            #     raise ValueError("`times` must be an array of monotonically "
+            #                      "increasing values.")
+            self._times = times_
+        else:
+            self._times = np.linspace(0, 1, num=len(self._values))
+
+        valid_interpolators = ("PchipInterpolator", "interp1d")
+        if interpolator not in valid_interpolators:
+            raise ValueError(f"Invalid interpolator '{interpolator}', only "
+                             "accepts: " + ", ".join(valid_interpolators))
+        interp_cls = getattr(interpolate, interpolator)
+        self._interp_func = interp_cls(self._times * self._duration,
+                                       self._values, **interpolator_kwargs)
+        self._kwargs: dict[str, Any] = {
+                        "times": times,
+                        "interpolator": interpolator,
+                        **interpolator_kwargs
+                        }
+
+    @property
+    def duration(self) -> int:
+        """The duration of the pulse (in ns)."""
+        return self._duration
+
+    @property
+    def samples(self) -> np.ndarray:
+        """The value at each time step that describes the waveform."""
+        return cast(np.ndarray, self._interp_func(np.arange(self._duration)))
+
+    @property
+    def interp_function(self) -> Union[interpolate.PchipInterpolator,
+                                       interpolate.interp1d]:
+        """The interpolating function."""
+        return self._interp_func
+
+    @property
+    def first_value(self) -> float:
+        """The first value in the waveform."""
+        return float(self.interp_function(0))
+
+    @property
+    def last_value(self) -> float:
+        """The last value in the waveform."""
+        return float(self.interp_function(self.duration - 1))
+
+    def change_duration(self, new_duration: int) -> InterpolatedWaveform:
+        """Returns a new waveform with modified duration.
+
+        Args:
+            new_duration(int): The duration of the new waveform.
+
+        Returns:
+            InterpolatedWaveform: The new waveform with the same coordinates
+                for interpolation but a new duration.
+        """
+        return InterpolatedWaveform(new_duration, self._values, **self._kwargs)
+
+    def _plot(self, ax: Axes, ylabel: str,
+              color: Optional[str] = None) -> None:
+        super()._plot(ax, ylabel, color=color)
+        ax.scatter(self._times * self._duration, self._values, c=color)
+
+    def _to_dict(self) -> dict[str, Any]:
+        return obj_to_dict(self, self._duration, self._values, **self._kwargs)
+
+    def __str__(self) -> str:
+        coords = [f"({x*self._duration:.3g}, {y:.3g})"
+                  for x, y in zip(self._times, self._values)]
+        return f"InterpolatedWaveform(Points: {', '.join(coords)})"
+
+    def __repr__(self) -> str:
+        interp_str = f", Interpolator={self._kwargs['interpolator']})"
+        return self.__str__()[:-1] + interp_str
+
+    def __mul__(self, other: float) -> InterpolatedWaveform:
+        return InterpolatedWaveform(self._duration, self._values * other,
+                                    **self._kwargs)
 
 
 # To replicate __init__'s signature in __new__ for every Waveform subclass


### PR DESCRIPTION
- Adds a new waveform type, `InterpolatedWaveform`, which lets the user create a waveform by defining a set of interpolation points and an interpolator.
- Currently supports `interp1d` and `PchipInterpolator` from `scipy.interpolate`, with access to these interpolators optional arguments
- Adds support for drawing the interpolation points on top of the waveform in `Waveform.draw()`, `Pulse.draw()` and `Sequence.draw()`
