### PR TITLE
Make drawing of phase shift information optional

### DIFF
--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -83,8 +83,9 @@ def gather_data(seq: pulser.sequence.Sequence) -> dict:
 
 def draw_sequence(seq: pulser.sequence.Sequence,
                   sampling_rate: Optional[float] = None,
-                  draw_phase_area: bool = False) -> None:
-    """Draw the entire sequence.
+                  draw_phase_area: bool = False,
+                  draw_phase_shifts: bool = False) -> None:
+    """Draws the entire sequence.
 
     Args:
         seq (pulser.Sequence): The input sequence of operations on a device.
@@ -93,6 +94,8 @@ def draw_sequence(seq: pulser.sequence.Sequence,
             input pulse.
         draw_phase_area (bool): Whether phase and area values need to be shown
             as text on the plot, defaults to False.
+        draw_phase_shifts (bool): Whether phase shift and reference information
+            should be added to the plot, defaults to False.
     """
 
     def phase_str(phi: float) -> str:
@@ -264,7 +267,7 @@ def draw_sequence(seq: pulser.sequence.Sequence,
                     a.text(x, tgt_txt_y, tgt_str, fontsize=12, ha='left',
                            bbox=q_box)
                     phase = seq._phase_ref[basis][targets[0]][0]
-                    if phase:
+                    if phase and draw_phase_shifts:
                         msg = r"$\phi=$" + phase_str(phase)
                         a.text(0, max_amp*1.1, msg, ha='left', fontsize=12,
                                bbox=ph_box)
@@ -277,7 +280,7 @@ def draw_sequence(seq: pulser.sequence.Sequence,
                 b.axvspan(ti, tf, alpha=0.4, color='grey', hatch='//')
                 a.text(tf + t[-1]*5e-3, tgt_txt_y, tgt_str, ha='left',
                        fontsize=12, bbox=q_box)
-                if phase:
+                if phase and draw_phase_shifts:
                     msg = r"$\phi=$" + phase_str(phase)
                     wrd_len = len(max(tgt_strs, key=len))
                     x = tf + t[-1]*0.01*(wrd_len+1)
@@ -286,7 +289,8 @@ def draw_sequence(seq: pulser.sequence.Sequence,
         # Terminate the last open regions
         if target_regions:
             target_regions[-1].append(t[-1])
-        for start, targets_, end in target_regions:
+        for start, targets_, end in (
+                target_regions if draw_phase_shifts else []):
             start = cast(float, start)
             targets_ = cast(list, targets_)
             end = cast(float, end)

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -711,14 +711,18 @@ class Sequence:
         return cast(Sequence, json.loads(obj, cls=PulserDecoder, **kwargs))
 
     @_screen
-    def draw(self, draw_phase_area: bool = False) -> None:
+    def draw(self, draw_phase_area: bool = False,
+             draw_phase_shifts: bool = False) -> None:
         """Draws the sequence in its current state.
 
         Keyword Args:
             draw_phase_area (bool): Whether phase and area values need
                 to be shown as text on the plot, defaults to False.
+            draw_phase_shifts (bool): Whether phase shift and reference
+                information should be added to the plot, defaults to False.
         """
-        draw_sequence(self, draw_phase_area=draw_phase_area)
+        draw_sequence(self, draw_phase_area=draw_phase_area,
+                      draw_phase_shifts=draw_phase_shifts)
 
     def _target(self, qubits: Union[Iterable[QubitId],
                                     QubitId], channel: str) -> None:

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -724,6 +724,10 @@ class Sequence:
                 on top of the respective waveforms (defaults to True).
             draw_phase_shifts (bool): Whether phase shift and reference
                 information should be added to the plot, defaults to False.
+
+        See Also:
+            Simulation.draw(): Draws the provided sequence and the one used by
+                the solver.
         """
         draw_sequence(self, draw_phase_area=draw_phase_area,
                       draw_interp_pts=draw_interp_pts,

--- a/pulser/simulation/simulation.py
+++ b/pulser/simulation/simulation.py
@@ -275,15 +275,28 @@ class Simulation:
                              "float between 0 and 1.")
         self._evaluation_times: Union[str, ArrayLike, float] = value
 
-    def draw(self, draw_phase_area: bool = False) -> None:
-        """Draws the input sequence and the one used in QuTip.
+    def draw(self, draw_phase_area: bool = False,
+             draw_interp_pts: bool = False,
+             draw_phase_shifts: bool = False) -> None:
+        """Draws the input sequence and the one used by the solver.
 
         Keyword Args:
             draw_phase_area (bool): Whether phase and area values need
                 to be shown as text on the plot, defaults to False.
+            draw_interp_pts (bool): When the sequence has pulses with waveforms
+                of type InterpolatedWaveform, draws the points of interpolation
+                on top of the respective waveforms (defaults to False).
+            draw_phase_shifts (bool): Whether phase shift and reference
+                information should be added to the plot, defaults to False.
+
+        See Also:
+            Sequence.draw(): Draws the sequence in its current state.
         """
         draw_sequence(
-            self._seq, self._sampling_rate, draw_phase_area=draw_phase_area
+            self._seq, self._sampling_rate,
+            draw_phase_area=draw_phase_area,
+            draw_interp_pts=draw_interp_pts,
+            draw_phase_shifts=draw_phase_shifts,
         )
 
     def _extract_samples(self) -> None:

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -304,7 +304,7 @@ def test_sequence():
     assert seq._last('ch2').tf == seq._last('ch0').tf
 
     with patch('matplotlib.pyplot.show'):
-        seq.draw()
+        seq.draw(draw_phase_shifts=True)
 
     assert seq._total_duration == 4000
 

--- a/tutorials/composition/Phase Shifts and Virtual Z gates.ipynb
+++ b/tutorials/composition/Phase Shifts and Virtual Z gates.ipynb
@@ -129,7 +129,8 @@
        "{'rydberg_global': Rydberg.Global(Max Absolute Detuning: 1000 rad/µs, Max Amplitude: 200 rad/µs, Basis: 'ground-rydberg'),\n",
        " 'rydberg_local': Rydberg.Local(Max Absolute Detuning: 1000 rad/µs, Max Amplitude: 200 rad/µs, Target time: 0 ns, Max targets: 2000, Basis: 'ground-rydberg'),\n",
        " 'raman_global': Raman.Global(Max Absolute Detuning: 1000 rad/µs, Max Amplitude: 200 rad/µs, Basis: 'digital'),\n",
-       " 'raman_local': Raman.Local(Max Absolute Detuning: 1000 rad/µs, Max Amplitude: 200 rad/µs, Target time: 0 ns, Max targets: 2000, Basis: 'digital')}"
+       " 'raman_local': Raman.Local(Max Absolute Detuning: 1000 rad/µs, Max Amplitude: 200 rad/µs, Target time: 0 ns, Max targets: 2000, Basis: 'digital'),\n",
+       " 'mw_global': Microwave.Global(Max Absolute Detuning: 1000 rad/µs, Max Amplitude: 200 rad/µs, Basis: 'XY')}"
       ]
      },
      "execution_count": 2,
@@ -229,7 +230,7 @@
     "# Now the phase shift of pi on 'q0', for the 'digital' basis, which is usually where phase shifts are useful\n",
     "seq.phase_shift(np.pi, 'q0', basis='digital') \n",
     "\n",
-    "seq.draw()"
+    "seq.draw(draw_phase_shifts=True)"
    ]
   },
   {
@@ -263,7 +264,7 @@
     "h = Pulse.ConstantDetuning(pi2_wf, detuning=0, phase=np.pi/2, post_phase_shift=np.pi)\n",
     "\n",
     "seq.add(h, 'ch0')\n",
-    "seq.draw()"
+    "seq.draw(draw_phase_shifts=True)"
    ]
   },
   {
@@ -401,7 +402,7 @@
    "source": [
     "seq.add(h, 'raman')\n",
     "seq.add(h, 'ryd1')\n",
-    "seq.draw()"
+    "seq.draw(draw_phase_shifts=True)"
    ]
   },
   {
@@ -535,7 +536,7 @@
     "seq.target('q1', 'ryd1')\n",
     "seq.add(h, 'ryd1')\n",
     "print(seq)\n",
-    "seq.draw()"
+    "seq.draw(draw_phase_shifts=True)"
    ]
   },
   {
@@ -565,7 +566,7 @@
    ],
    "source": [
     "seq.target('q1', 'ryd2')\n",
-    "seq.draw()"
+    "seq.draw(draw_phase_shifts=True)"
    ]
   },
   {


### PR DESCRIPTION
The display of the phase shift information on the drawing of a sequence is a niche usecase, so it is turned into an optional on `Sequence.draw()` that defaults to `False`.