### PR TITLE
`BlackmanWaveform.from_max_val()`: Move back to previous even duration when necessary (#218)

### DIFF
--- a/pulser/tests/test_waveforms.py
+++ b/pulser/tests/test_waveforms.py
@@ -183,6 +183,15 @@ def test_blackman():
     var._assign(-np.pi)
     assert wf_var.build() == wf
 
+    # Check moving back to previous even duration
+    area: float = np.pi / 6
+    max_val: float = 46
+    wf: BlackmanWaveform = BlackmanWaveform.from_max_val(max_val, area)
+    duration = wf.duration
+    assert(duration % 2 == 0)
+    wf2 = BlackmanWaveform(duration + 1, area)
+    assert(np.max(wf2.samples) < np.max(wf.samples) <= max_val)
+
 
 def test_interpolated():
     assert isinstance(interp.interp_function, PchipInterpolator)
@@ -303,17 +312,17 @@ def test_get_item():
 
         # Check with out of bounds slices
         assert (wf[: duration * 2] == samples).all()
-        assert (wf[-duration * 2 :] == samples).all()
-        assert (wf[-duration * 2 : duration * 2] == samples).all()
+        assert (wf[-duration * 2:] == samples).all()
+        assert (wf[-duration * 2: duration * 2] == samples).all()
         assert (
-            wf[duration // 2 : duration * 2]
-            == samples[duration // 2 : duration * 2]
+            wf[duration // 2: duration * 2]
+            == samples[duration // 2: duration * 2]
         ).all()
         assert (
-            wf[-duration * 2 : duration // 2]
-            == samples[-duration * 2 : duration // 2]
+            wf[-duration * 2: duration // 2]
+            == samples[-duration * 2: duration // 2]
         ).all()
         assert wf[2:1].size == 0
-        assert wf[duration * 2 :].size == 0
-        assert wf[duration * 2 : duration * 3].size == 0
-        assert wf[-duration * 3 : -duration * 2].size == 0
+        assert wf[duration * 2:].size == 0
+        assert wf[duration * 2: duration * 3].size == 0
+        assert wf[-duration * 3: -duration * 2].size == 0

--- a/pulser/tests/test_waveforms.py
+++ b/pulser/tests/test_waveforms.py
@@ -188,9 +188,9 @@ def test_blackman():
     max_val: float = 46
     wf: BlackmanWaveform = BlackmanWaveform.from_max_val(max_val, area)
     duration = wf.duration
-    assert(duration % 2 == 0)
+    assert duration % 2 == 0
     wf2 = BlackmanWaveform(duration + 1, area)
-    assert(np.max(wf2.samples) < np.max(wf.samples) <= max_val)
+    assert np.max(wf2.samples) < np.max(wf.samples) <= max_val
 
 
 def test_interpolated():
@@ -312,17 +312,17 @@ def test_get_item():
 
         # Check with out of bounds slices
         assert (wf[: duration * 2] == samples).all()
-        assert (wf[-duration * 2:] == samples).all()
-        assert (wf[-duration * 2: duration * 2] == samples).all()
+        assert (wf[-duration * 2 :] == samples).all()
+        assert (wf[-duration * 2 : duration * 2] == samples).all()
         assert (
-            wf[duration // 2: duration * 2]
-            == samples[duration // 2: duration * 2]
+            wf[duration // 2 : duration * 2]
+            == samples[duration // 2 : duration * 2]
         ).all()
         assert (
-            wf[-duration * 2: duration // 2]
-            == samples[-duration * 2: duration // 2]
+            wf[-duration * 2 : duration // 2]
+            == samples[-duration * 2 : duration // 2]
         ).all()
         assert wf[2:1].size == 0
-        assert wf[duration * 2:].size == 0
-        assert wf[duration * 2: duration * 3].size == 0
-        assert wf[-duration * 3: -duration * 2].size == 0
+        assert wf[duration * 2 :].size == 0
+        assert wf[duration * 2 : duration * 3].size == 0
+        assert wf[-duration * 3 : -duration * 2].size == 0

--- a/pulser/waveforms.py
+++ b/pulser/waveforms.py
@@ -542,6 +542,7 @@ class BlackmanWaveform(Waveform):
         # A normalized Blackman waveform has an area of 0.42 * duration
         duration = np.ceil(area / (0.42 * max_val) * 1e3)  # in ns
         wf = cls(duration, area)
+        previous_wf = None
 
         # Adjust for rounding errors to make sure max_val is not surpassed
         while np.abs(wf._scaling) > np.abs(max_val):

--- a/pulser/waveforms.py
+++ b/pulser/waveforms.py
@@ -552,8 +552,11 @@ class BlackmanWaveform(Waveform):
         # According to the documentation for numpy.blackman(), "the value one
         # appears only if the number of samples is odd". Hence, the previous
         # even duration can reach a maximal value closer to max_val.
-        if (previous_wf is not None and duration % 2 == 1 and
-                np.max(wf.samples) < np.max(previous_wf.samples) <= max_val):
+        if (
+            previous_wf is not None
+            and duration % 2 == 1
+            and np.max(wf.samples) < np.max(previous_wf.samples) <= max_val
+        ):
             wf = previous_wf
 
         return wf


### PR DESCRIPTION
Fixes #218.