### PR TITLE
Measurement errors incoporated into `CoherentResults`

### DIFF
--- a/pulser/simulation/simresults.py
+++ b/pulser/simulation/simresults.py
@@ -309,13 +309,10 @@ class NoisyResults(SimulationResults):
         return super().expect(obs_list)
 
     def _calc_weights(self, t_index: int) -> np.ndarray:
-        n = self._size
-        return np.array(
-            [
-                self._results[t_index][np.binary_repr(k, n)]
-                for k in range(2 ** n)
-            ]
-        )
+        weights = np.zeros(2 ** self._size)
+        for bin_rep, prob in self._results[t_index].items():
+            weights[int(bin_rep, base=2)] = prob
+        return weights
 
     def plot(
         self,

--- a/pulser/simulation/simresults.py
+++ b/pulser/simulation/simresults.py
@@ -118,8 +118,8 @@ class SimulationResults(ABC):
                 if not isdiagonal(obs):
                     raise ValueError(f"Observable {obs!r} is non-diagonal.")
                 states = [
-                    self._calc_pseudo_density(self._get_index_from_time(t))
-                    for t in self._sim_times
+                    self._calc_pseudo_density(ind)
+                    for ind in range(len(self._results))
                 ]
             else:
                 states = self.states
@@ -202,7 +202,7 @@ class SimulationResults(ABC):
                 into the pseudo-density matrix.
 
         Returns:
-            Qobj: The pseudo-density matrix as a QObj.
+            qutip.Qobj: The pseudo-density matrix as a Qobj.
         """
 
         def _proj_from_bitstring(bitstring: str) -> qutip.Qobj:

--- a/pulser/simulation/simulation.py
+++ b/pulser/simulation/simulation.py
@@ -649,6 +649,13 @@ class Simulation:
             else self.config.solver_options
         )
 
+        meas_errors: Optional[Mapping[str, float]] = None
+        if "SPAM" in self.config.noise:
+            meas_errors = {
+                k: self.config.spam_dict[k]
+                for k in ("epsilon", "epsilon_prime")
+            }
+
         def _run_solver() -> CoherentResults:
             """Returns CoherentResults: Object containing evolution results."""
             if "dephasing" in self.config.noise:
@@ -677,50 +684,42 @@ class Simulation:
                 self.basis_name,
                 self._eval_times_array,
                 self._meas_basis,
+                meas_errors,
             )
 
         # Check if noises ask for averaging over multiple runs:
-        if set(self.config.noise).issubset({"dephasing"}):
-            return _run_solver()
-        else:
-            time_indices = range(len(self._eval_times_array))
-            total_count = np.array([Counter() for _ in time_indices])
-            # We run the system multiple times
-            for _ in range(self.config.runs):
-                # At each run, new random noise: new Hamiltonian
-                self._construct_hamiltonian()
-                # Get CoherentResults instance from sequence with added noise:
-                cleanres_noisyseq = _run_solver()
-                # Extract statistics at eval time:
-                if "SPAM" in self.config.noise:
-                    total_count += np.array(
-                        [
-                            cleanres_noisyseq._sampling_with_detection_errors(
-                                self.config.spam_dict,
-                                t,
-                                n_samples=self.config.samples_per_run,
-                            )
-                            for t in self._eval_times_array
-                        ]
+        if set(self.config.noise).issubset({"dephasing", "SPAM"}):
+            # If there is "SPAM", the preparation errors must be zero
+            if "SPAM" not in self.config.noise or self.config.eta == 0:
+                return _run_solver()
+
+        # Did not obey the conditions above, will return NoisyResults
+        time_indices = range(len(self._eval_times_array))
+        total_count = np.array([Counter() for _ in time_indices])
+        # We run the system multiple times
+        for _ in range(self.config.runs):
+            # At each run, new random noise: new Hamiltonian
+            self._construct_hamiltonian()
+            # Get CoherentResults instance from sequence with added noise:
+            cleanres_noisyseq = _run_solver()
+            # Extract statistics at eval time:
+            total_count += np.array(
+                [
+                    cleanres_noisyseq.sample_state(
+                        t, n_samples=self.config.samples_per_run
                     )
-                else:
-                    total_count += np.array(
-                        [
-                            cleanres_noisyseq.sample_state(
-                                t, n_samples=self.config.samples_per_run
-                            )
-                            for t in self._eval_times_array
-                        ]
-                    )
-            n_measures = self.config.runs * self.config.samples_per_run
-            total_run_prob = [
-                Counter({k: v / n_measures for k, v in total_count[t].items()})
-                for t in time_indices
-            ]
-            return NoisyResults(
-                total_run_prob,
-                self._size,
-                self.basis_name,
-                self._eval_times_array,
-                n_measures,
+                    for t in self._eval_times_array
+                ]
             )
+        n_measures = self.config.runs * self.config.samples_per_run
+        total_run_prob = [
+            Counter({k: v / n_measures for k, v in total_count[t].items()})
+            for t in time_indices
+        ]
+        return NoisyResults(
+            total_run_prob,
+            self._size,
+            self.basis_name,
+            self._eval_times_array,
+            n_measures,
+        )


### PR DESCRIPTION
These changes incorporate measurement errors into `CoherentResults`, such that:
- When calling `sample_state()`, the result automatically includes the measurement errors (i.e. `_sampling_with_detection_errors()` was incorporated in `sample_state()`)
- When calling `expect()`, it calculates the "pseudo-density matrices", corresponding to the state of the system post-measurement. When measurement errors are present, these are used instead of the state vectors

A few extra features were added in the process:
- The ability to calculate the pseudo-density matrix of the system at a given time is part of the parent class, as it is needed in both child classes now. The calculation might be expensive for large systems, so I'm caching them so that they're only computed once.
- The measurement errors are built into these density matrices by changing the projectors into the basis states when measurement errors are present
- `NoisyResults._calc_weights()` was refactored to avoid the exponential complexity with the system size.
- `expect()` is now defined solely in `SimulationResults`

Fixes #220 .