### PR TITLE
Fixes bug with SimResults.expect()

### DIFF
--- a/pulser/simulation/simresults.py
+++ b/pulser/simulation/simresults.py
@@ -98,7 +98,9 @@ class SimulationResults(ABC):
             raise TypeError("`obs_list` must be a list of operators.")
 
         qobj_list = []
-        legal_shape = (2 ** self._size, 2 ** self._size)
+        dim = self._dim if not self._use_pseudo_dens else 2
+        legal_dims = [[dim] * self._size] * 2
+        legal_shape = (dim ** self._size, dim ** self._size)
         for obs in obs_list:
             if not (
                 isinstance(obs, np.ndarray) or isinstance(obs, qutip.Qobj)
@@ -113,7 +115,7 @@ class SimulationResults(ABC):
                     "Incompatible shape of observable."
                     + f"Expected {legal_shape}, got {obs.shape}."
                 )
-            qobj_list.append(qutip.Qobj(obs))
+            qobj_list.append(qutip.Qobj(obs, dims=legal_dims))
             if self._use_pseudo_dens:
                 if not isdiagonal(obs):
                     raise ValueError(f"Observable {obs!r} is non-diagonal.")

--- a/pulser/tests/test_simresults.py
+++ b/pulser/tests/test_simresults.py
@@ -227,7 +227,6 @@ def test_expect():
     exp3dim = sim3dim.run().expect(
         [qutip.tensor(qutip.basis(3, 0).proj(), qutip.qeye(3))]
     )
-    print(exp3dim)
     assert np.isclose(exp3dim[0][-1], 1.89690200e-14)
 
 

--- a/pulser/tests/test_simresults.py
+++ b/pulser/tests/test_simresults.py
@@ -218,6 +218,17 @@ def test_expect():
         results_single._calc_pseudo_density(-1).full(),
         np.array([[1 - config.epsilon_prime, 0], [0, config.epsilon_prime]]),
     )
+    seq3dim = Sequence(reg, Chadoq2)
+    seq3dim.declare_channel("ryd", "rydberg_global")
+    seq3dim.declare_channel("ram", "raman_local", initial_target="A")
+    seq3dim.add(pi, "ram")
+    seq3dim.add(pi, "ryd")
+    sim3dim = Simulation(seq3dim)
+    exp3dim = sim3dim.run().expect(
+        [qutip.tensor(qutip.basis(3, 0).proj(), qutip.qeye(3))]
+    )
+    print(exp3dim)
+    assert np.isclose(exp3dim[0][-1], 1.89690200e-14)
 
 
 def test_expect_noisy():


### PR DESCRIPTION
Fixes a bug regarding the computation of expectation values in the all basis via SimResults.expect().