### PR TITLE
`BlackmanWaveform.from_last_val()` fully compatible with negative inputs

### DIFF
--- a/pulser/tests/test_waveforms.py
+++ b/pulser/tests/test_waveforms.py
@@ -194,6 +194,13 @@ def test_blackman():
     wf2 = BlackmanWaveform(duration + 1, area)
     assert np.max(wf2.samples) < np.max(wf.samples) <= max_val
 
+    # Same but with a negativa max value
+    wf: BlackmanWaveform = BlackmanWaveform.from_max_val(-max_val, -area)
+    duration = wf.duration
+    assert duration % 2 == 0
+    wf2 = BlackmanWaveform(duration + 1, -area)
+    assert np.min(wf2.samples) > np.min(wf.samples) >= -max_val
+
 
 def test_interpolated():
     assert isinstance(interp.interp_function, PchipInterpolator)

--- a/pulser/tests/test_waveforms.py
+++ b/pulser/tests/test_waveforms.py
@@ -194,7 +194,7 @@ def test_blackman():
     wf2 = BlackmanWaveform(duration + 1, area)
     assert np.max(wf2.samples) < np.max(wf.samples) <= max_val
 
-    # Same but with a negativa max value
+    # Same but with a negative max value
     wf: BlackmanWaveform = BlackmanWaveform.from_max_val(-max_val, -area)
     duration = wf.duration
     assert duration % 2 == 0


### PR DESCRIPTION
Although the original implementation of `BlackmanWaveform.from_last_val()` had negative values in mind, the changes introduced in #222 were designed with only positive values in mind. These changes serve to make those changes work for negative waveforms as well.