### PR TITLE
Forbid combination of custom initial_state with state preparation errors

### DIFF
--- a/pulser/simulation/simulation.py
+++ b/pulser/simulation/simulation.py
@@ -238,7 +238,7 @@ class Simulation:
     def initial_state(self, state: Union[str, np.ndarray, qutip.Qobj]) -> None:
         """Sets the initial state of the simulation."""
         self._initial_state: qutip.Qobj
-        if state == "all-ground":
+        if isinstance(state, str) and state == "all-ground":
             self._initial_state = qutip.tensor(
                 [self.basis["g"] for _ in range(self._size)]
             )
@@ -678,6 +678,13 @@ class Simulation:
                 k: self.config.spam_dict[k]
                 for k in ("epsilon", "epsilon_prime")
             }
+            if self.config.eta > 0 and self.initial_state != qutip.tensor(
+                [self.basis["g"] for _ in range(self._size)]
+            ):
+                raise NotImplementedError(
+                    "Can't combine state preparation errors with an initial "
+                    "state different from the ground."
+                )
 
         def _run_solver() -> CoherentResults:
             """Returns CoherentResults: Object containing evolution results."""

--- a/pulser/tests/test_simulation.py
+++ b/pulser/tests/test_simulation.py
@@ -328,6 +328,7 @@ def test_add_max_step_and_delays():
 
 def test_run():
     sim = Simulation(seq, sampling_rate=0.01)
+    sim.set_config(SimConfig("SPAM", eta=0.0))
     with patch("matplotlib.pyplot.show"):
         sim.draw(draw_phase_area=True)
     bad_initial = np.array([1.0])
@@ -356,6 +357,14 @@ def test_run():
     seq.measure("ground-rydberg")
     sim.run()
     assert sim._seq._measurement == "ground-rydberg"
+
+    sim.set_config(SimConfig("SPAM", eta=0.1))
+    with pytest.raises(
+        NotImplementedError,
+        match="Can't combine state preparation errors with an initial state "
+        "different from the ground.",
+    ):
+        sim.run()
 
 
 def test_eval_times():


### PR DESCRIPTION
This PR prevents the existing conflict between the setting of a custom initial state and the way we simulate state preparation errors, as described in #244.

Closes #244 .