### PR TITLE
fixed global-local overwriting bug and added test

### DIFF
--- a/pulser/simulation/simulation.py
+++ b/pulser/simulation/simulation.py
@@ -401,13 +401,13 @@ class Simulation:
                 noise_amp = np.random.normal(1.0, 1.0e-3) * np.exp(
                     -((r / w0) ** 2)
                 )
-            samples_dict["amp"][slot.ti : slot.tf] = (
+            samples_dict["amp"][slot.ti : slot.tf] += (
                 _pulse.amplitude.samples * noise_amp
             )
-            samples_dict["det"][slot.ti : slot.tf] = (
+            samples_dict["det"][slot.ti : slot.tf] += (
                 _pulse.detuning.samples + noise_det
             )
-            samples_dict["phase"][slot.ti : slot.tf] = _pulse.phase
+            samples_dict["phase"][slot.ti : slot.tf] += _pulse.phase
 
         for channel in self._seq.declared_channels:
             addr = self._seq.declared_channels[channel].addressing

--- a/pulser/tests/test_simulation.py
+++ b/pulser/tests/test_simulation.py
@@ -527,3 +527,29 @@ def test_add_config():
     sim.add_config(SimConfig(noise=("SPAM", "amplitude"), laser_waist=172.0))
     assert "amplitude" in sim.config.noise and "SPAM" in sim.config.noise
     assert sim.config.laser_waist == 172.0
+
+
+def test_cuncurrent_pulses():
+    reg = Register({"q0": (0, 0)})
+    seq = Sequence(reg, Chadoq2)
+
+    seq.declare_channel('ch_local', 'rydberg_local', initial_target='q0')
+    seq.declare_channel('ch_global', 'rydberg_global')
+
+    pulse = Pulse.ConstantPulse(20, 10, 0, 0)
+
+    seq.add(pulse, 'ch_local')
+    seq.add(pulse, 'ch_global', protocol='no-delay')
+
+    # Clean simulation
+    sim_no_noise = Simulation(seq)
+
+    # Noisy simulation
+    sim_with_noise = Simulation(seq)
+    config_doppler = SimConfig(noise=('doppler'))
+    sim_with_noise.set_config(config_doppler)
+
+    for t in sim_no_noise._times:
+        ham_no_noise = sim_no_noise.get_hamiltonian(t)
+        ham_with_noise = sim_with_noise.get_hamiltonian(t)
+        assert ham_no_noise[0, 1] == ham_with_noise[0, 1]

--- a/pulser/tests/test_simulation.py
+++ b/pulser/tests/test_simulation.py
@@ -533,20 +533,20 @@ def test_cuncurrent_pulses():
     reg = Register({"q0": (0, 0)})
     seq = Sequence(reg, Chadoq2)
 
-    seq.declare_channel('ch_local', 'rydberg_local', initial_target='q0')
-    seq.declare_channel('ch_global', 'rydberg_global')
+    seq.declare_channel("ch_local", "rydberg_local", initial_target="q0")
+    seq.declare_channel("ch_global", "rydberg_global")
 
     pulse = Pulse.ConstantPulse(20, 10, 0, 0)
 
-    seq.add(pulse, 'ch_local')
-    seq.add(pulse, 'ch_global', protocol='no-delay')
+    seq.add(pulse, "ch_local")
+    seq.add(pulse, "ch_global", protocol="no-delay")
 
     # Clean simulation
     sim_no_noise = Simulation(seq)
 
     # Noisy simulation
     sim_with_noise = Simulation(seq)
-    config_doppler = SimConfig(noise=('doppler'))
+    config_doppler = SimConfig(noise=("doppler"))
     sim_with_noise.set_config(config_doppler)
 
     for t in sim_no_noise._times:


### PR DESCRIPTION
The error was caused by amp, det and phase samples replacing the old values instead of adding. That would be fine it two pulses with different addressing and basis could never write on the same samples, but with the introduction of noise sometimes a global pulse becomes local and a conflict might happen.

Since the amp, det and phase samples are always initialized to 0, it's fine to add instead of replacing. 

I also added a unit test in `test_simulation.py` that the old code does not pass regarding this issue.
 