### PR TITLE
Added register drawing capabilities to Sequence.draw()

### DIFF
--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -25,7 +25,6 @@ from itertools import combinations
 import pulser
 from pulser.waveforms import ConstantWaveform, InterpolatedWaveform
 from pulser.pulse import Pulse
-from pulser.channels import Channel
 from pulser import Register, Register3D
 
 
@@ -154,9 +153,9 @@ def draw_sequence(
     area_ph_box = dict(boxstyle="round", facecolor="ghostwhite", alpha=0.7)
     slm_box = dict(boxstyle="round", alpha=0.4, facecolor="grey", hatch="//")
 
-    # Register related
     pos = np.array(seq._register._coords)
 
+    # Draw masked register
     if draw_register:
         if isinstance(seq._register, Register3D):
             labels = "xyz"
@@ -164,12 +163,14 @@ def draw_sequence(
                 pos,
             )
 
-            for ax_reg, (ix, iy) in zip(axes_reg, combinations(np.arange(3), 2)):
+            for ax_reg, (ix, iy) in zip(
+                axes_reg, combinations(np.arange(3), 2)
+            ):
                 seq._register._draw_2D(
                     ax=ax_reg,
                     pos=pos,
                     ids=seq._register._ids,
-                    plane=(ix,iy),
+                    plane=(ix, iy),
                     masked_qubits=seq._slm_mask_targets,
                 )
                 ax_reg.set_title(

--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -111,7 +111,7 @@ def draw_sequence(
     draw_interp_pts: bool = True,
     draw_phase_shifts: bool = False,
     draw_register: bool = False,
-) -> Figure:
+) -> tuple[Figure, Figure]:
     """Draws the entire sequence.
 
     Args:
@@ -503,3 +503,5 @@ def draw_sequence(
             if "detuning" in all_points:
                 pts = np.array(all_points["detuning"])
                 b.scatter(pts[:, 0], pts[:, 1], color="indigo")
+
+    return (fig_reg if draw_register else None, fig)

--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -125,7 +125,7 @@ def draw_sequence(
             top of the respective waveforms (defaults to True).
         draw_phase_shifts (bool): Whether phase shift and reference information
             should be added to the plot, defaults to False.
-        draw_register (bool): Whether to draw the register after the pulse
+        draw_register (bool): Whether to draw the register before the pulse
             sequence, with a visual indication (square halo) around the qubits
             masked by the SLM, defaults to False.
     """
@@ -161,7 +161,10 @@ def draw_sequence(
             labels = "xyz"
             fig_reg, axes_reg = seq._register._initialize_fig_axes_projection(
                 pos,
+                blockade_radius=35,
+                draw_half_radius=True,
             )
+            fig_reg.tight_layout(w_pad=6.5)
 
             for ax_reg, (ix, iy) in zip(
                 axes_reg, combinations(np.arange(3), 2)
@@ -181,7 +184,11 @@ def draw_sequence(
                 )
 
         elif isinstance(seq._register, Register):
-            fig_reg, ax_reg = seq._register._initialize_fig_axes(pos)
+            fig_reg, ax_reg = seq._register._initialize_fig_axes(
+                pos,
+                blockade_radius=35,
+                draw_half_radius=True,
+            )
             seq._register._draw_2D(
                 ax=ax_reg,
                 pos=pos,

--- a/pulser/register.py
+++ b/pulser/register.py
@@ -22,7 +22,7 @@ from matplotlib import collections as mc
 import numpy as np
 from numpy.typing import ArrayLike
 from scipy.spatial import KDTree
-from typing import Any, cast, Optional, Union, TypeVar, Type
+from typing import Any, cast, Optional, Union, TypeVar, Type, Tuple
 from itertools import combinations
 
 import pulser
@@ -634,8 +634,8 @@ class Register(BaseRegister):
         pos: np.ndarray,
         blockade_radius: Optional[float] = None,
         draw_half_radius: bool = False,
-    ) -> (matplotlib.figure.Figure, matplotlib.axes.Axes):
-        """Creates the Figure and Axes for drawing the register"""
+    ) -> Tuple[plt.figure.Figure, plt.axes.Axes]:
+        """Creates the Figure and Axes for drawing the register."""
         diffs = super()._register_dims(
             pos,
             blockade_radius=blockade_radius,
@@ -865,8 +865,8 @@ class Register3D(BaseRegister):
         pos: np.ndarray,
         blockade_radius: Optional[float] = None,
         draw_half_radius: bool = False,
-    ) -> (matplotlib.figure.Figure, matplotlib.axes.Axes):
-        """Creates the Figure and Axes for drawing the register projections"""
+    ) -> Tuple[plt.figure.Figure, plt.axes.Axes]:
+        """Creates the Figure and Axes for drawing the register projections."""
         diffs = super()._register_dims(
             pos,
             blockade_radius=blockade_radius,

--- a/pulser/register.py
+++ b/pulser/register.py
@@ -99,10 +99,27 @@ class BaseRegister(ABC):
         blockade_radius: Optional[float] = None,
         draw_graph: bool = True,
         draw_half_radius: bool = False,
+        masked_qubits: set[QubitId] = set(),
     ) -> None:
         ix, iy = plane
 
         ax.scatter(pos[:, ix], pos[:, iy], s=30, alpha=0.7, c="darkgreen")
+
+        # Draw square halo around masked qubits
+        if masked_qubits:
+            mask_pos = []
+            for i, c in zip(ids, pos):
+                if i in masked_qubits:
+                    mask_pos.append(c)
+            mask_arr = np.array(mask_pos)
+            ax.scatter(
+                mask_arr[:, ix],
+                mask_arr[:, iy],
+                marker="s",
+                s=1200,
+                alpha=0.2,
+                c="black",
+            )
 
         axes = "xyz"
 
@@ -115,7 +132,7 @@ class BaseRegister(ABC):
         if with_labels:
             # Determine which labels would overlap and merge those
             plot_pos = list(pos[:, (ix, iy)])
-            plot_ids = [f"{i}" for i in ids]
+            plot_ids = [f"{i}" + "(m)" * (i in masked_qubits) for i in ids]
             # Threshold distance between points
             epsilon = 1.0e-2 * np.diff(ax.get_xlim())[0]
 

--- a/pulser/register.py
+++ b/pulser/register.py
@@ -23,7 +23,7 @@ from matplotlib import collections as mc
 import numpy as np
 from numpy.typing import ArrayLike
 from scipy.spatial import KDTree
-from typing import Any, cast, Optional, Union, TypeVar, Type, Tuple
+from typing import Any, cast, Optional, Union, TypeVar, Type
 from itertools import combinations
 
 import pulser
@@ -651,7 +651,7 @@ class Register(BaseRegister):
         pos: np.ndarray,
         blockade_radius: Optional[float] = None,
         draw_half_radius: bool = False,
-    ) -> Tuple[plt.figure.Figure, plt.axes.Axes]:
+    ) -> tuple[plt.figure.Figure, plt.axes.Axes]:
         """Creates the Figure and Axes for drawing the register."""
         diffs = super()._register_dims(
             pos,
@@ -673,7 +673,6 @@ class Register(BaseRegister):
         blockade_radius: Optional[float] = None,
         draw_graph: bool = True,
         draw_half_radius: bool = False,
-        masked_qubits: set[QubitId] = set(),
     ) -> None:
         """Draws the entire register.
 
@@ -881,7 +880,7 @@ class Register3D(BaseRegister):
         pos: np.ndarray,
         blockade_radius: Optional[float] = None,
         draw_half_radius: bool = False,
-    ) -> Tuple[plt.figure.Figure, plt.axes.Axes]:
+    ) -> tuple[plt.figure.Figure, plt.axes.Axes]:
         """Creates the Figure and Axes for drawing the register projections."""
         diffs = super()._register_dims(
             pos,
@@ -968,6 +967,7 @@ class Register3D(BaseRegister):
                 blockade_radius=blockade_radius,
                 draw_half_radius=draw_half_radius,
             )
+            fig.tight_layout(w_pad=6.5)
 
             for ax, (ix, iy) in zip(axes, combinations(np.arange(3), 2)):
                 super()._draw_2D(

--- a/pulser/register.py
+++ b/pulser/register.py
@@ -150,7 +150,9 @@ class BaseRegister(ABC):
         if with_labels:
             # Determine which labels would overlap and merge those
             plot_pos = list(pos[:, (ix, iy)])
-            plot_ids = [f"{i}" + "(m)" * (i in masked_qubits) for i in ids]
+            plot_ids = [
+                f"[{i}]" if i in masked_qubits else f"{i}" for i in ids
+            ]
             # Threshold distance between points
             epsilon = 1.0e-2 * np.diff(ax.get_xlim())[0]
 
@@ -163,7 +165,13 @@ class BaseRegister(ABC):
                 while j < len(plot_ids):
                     r2 = plot_pos[j]
                     if np.max(np.abs(r - r2)) < epsilon:
-                        plot_ids[i] += ", " + plot_ids.pop(j)
+                        # Absorb square brackets for two adjacent masked qubits
+                        if plot_ids[i][-1] == "]" and plot_ids[j][0] == "[":
+                            plot_ids[i] = (
+                                plot_ids[i][:-1] + ", " + plot_ids.pop(j)[1:]
+                            )
+                        else:
+                            plot_ids[i] += ", " + plot_ids.pop(j)
                         plot_pos.pop(j)
                         overlap = True
                     else:

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -912,6 +912,7 @@ class Sequence:
         draw_phase_area: bool = False,
         draw_interp_pts: bool = True,
         draw_phase_shifts: bool = False,
+        draw_register: bool = False,
     ) -> None:
         """Draws the sequence in its current state.
 
@@ -923,6 +924,9 @@ class Sequence:
                 on top of the respective waveforms (defaults to True).
             draw_phase_shifts (bool): Whether phase shift and reference
                 information should be added to the plot, defaults to False.
+            draw_register (bool): Whether to draw the register after the pulse
+                sequence, with a visual indication (square halo) around the
+                qubits masked by the SLM, defaults to False.
 
         See Also:
             Simulation.draw(): Draws the provided sequence and the one used by
@@ -933,6 +937,7 @@ class Sequence:
             draw_phase_area=draw_phase_area,
             draw_interp_pts=draw_interp_pts,
             draw_phase_shifts=draw_phase_shifts,
+            draw_register=draw_register,
         )
 
     def _target(

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -36,7 +36,7 @@ from pulser.json.coders import PulserEncoder, PulserDecoder
 from pulser.json.utils import obj_to_dict
 from pulser.parametrized import Parametrized, Variable
 from pulser.pulse import Pulse
-from pulser.register import Register
+from pulser.register import BaseRegister, Register, Register3D
 from pulser._seq_drawer import draw_sequence
 
 if version_info[:2] >= (3, 8):  # pragma: no cover
@@ -147,7 +147,7 @@ class Sequence:
     generated from a single "parametrized" ``Sequence``.
 
     Args:
-        register(Register): The atom register on which to apply the pulses.
+        register(BaseRegister): The atom register on which to apply the pulses.
         device(Device): A valid device in which to execute the Sequence (import
             it from ``pulser.devices``).
 
@@ -156,7 +156,7 @@ class Sequence:
         they are the same for all Sequences built from a parametrized Sequence.
     """
 
-    def __init__(self, register: Register, device: Device):
+    def __init__(self, register: BaseRegister, device: Device):
         """Initializes a new pulse sequence."""
         if not isinstance(device, Device):
             raise TypeError(
@@ -179,7 +179,7 @@ class Sequence:
         # Checks if register is compatible with the device
         device.validate_register(register)
 
-        self._register: Register = register
+        self._register: BaseRegister = register
         self._device: Device = device
         self._in_xy: bool = False
         self._mag_field: Optional[tuple[float, float, float]] = None

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -914,9 +914,10 @@ class Sequence:
         draw_interp_pts: bool = True,
         draw_phase_shifts: bool = False,
         draw_register: bool = False,
-        fig_name: str = None,
-        kwargs_savefig: dict = {},
-        kwargs_savefig_register: dict = {},
+        fig_name_seq: str = None,
+        fig_name_reg: str = None,
+        kwargs_savefig_seq: dict = {},
+        kwargs_savefig_reg: dict = {},
     ) -> None:
         """Draws the sequence in its current state.
 
@@ -931,14 +932,18 @@ class Sequence:
             draw_register (bool): Whether to draw the register before the pulse
                 sequence, with a visual indication (square halo) around the
                 qubits masked by the SLM, defaults to False.
-            fig_name(str, default=None): The name on which to save the figure.
-                If None the figure will not be saved.
-            kwargs_savefig(dict, default={}): Keywords arguments for
-                `matplotlib.pyplot.savefig`, pulse drawing. Not applicable if
-                `fig_name`is `None`.
-            kwargs_savefig_register(dict, default={}): Keywords arguments for
-                `matplotlib.pyplot.savefig`, register drawing. Not applicable
-                if `fig_name`is `None` or `draw_register` is `False`.
+            fig_name_seq(str, default=None): The name on which to save the
+                figure of the sequence. If None the figure will not be saved.
+            fig_name_reg(str, default=None): The name on which to save the
+                figure of the register. If None or draw_register is `False`,
+                the figure will not be saved.
+            kwargs_savefig_seq(dict, default={}): Keywords arguments for
+                `matplotlib.figure.Figure.savefig`, sequence drawing.
+                Not applicable if `fig_name_seq`is `None`.
+            kwargs_savefig_reg(dict, default={}): Keywords arguments for
+                `matplotlib.figure.Figure.savefig`, register drawing.
+                Not applicable if `fig_name`is `None` or `draw_register` is
+                `False`.
 
         See Also:
             Simulation.draw(): Draws the provided sequence and the one used by
@@ -951,11 +956,10 @@ class Sequence:
             draw_phase_shifts=draw_phase_shifts,
             draw_register=draw_register,
         )
-        if fig_name is not None and fig_reg is not None:
-            fig_reg.savefig("register_" + fig_name, **kwargs_savefig_register)
-            fig.savefig("pulses_" + fig_name, **kwargs_savefig)
-        elif fig_name is not None:
-            fig.savefig(fig_name, **kwargs_savefig)
+        if fig_name_seq is not None:
+            fig.savefig(fig_name_seq, **kwargs_savefig_seq)
+        if fig_name_reg is not None and draw_register:
+            fig_reg.savefig(fig_name_reg, **kwargs_savefig_reg)
         plt.show()
 
     def _target(

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -916,6 +916,7 @@ class Sequence:
         draw_register: bool = False,
         fig_name: str = None,
         kwargs_savefig: dict = {},
+        kwargs_savefig_register: dict = {},
     ) -> None:
         """Draws the sequence in its current state.
 
@@ -933,22 +934,28 @@ class Sequence:
             fig_name(str, default=None): The name on which to save the figure.
                 If None the figure will not be saved.
             kwargs_savefig(dict, default={}): Keywords arguments for
-                `matplotlib.pyplot.savefig`. Not applicable if
+                `matplotlib.pyplot.savefig`, pulse drawing. Not applicable if
                 `fig_name`is `None`.
+            kwargs_savefig_register(dict, default={}): Keywords arguments for
+                `matplotlib.pyplot.savefig`, register drawing. Not applicable
+                if `fig_name`is `None` or `draw_register` is `False`.
 
         See Also:
             Simulation.draw(): Draws the provided sequence and the one used by
             the solver.
         """
-        draw_sequence(
+        fig_reg, fig = draw_sequence(
             self,
             draw_phase_area=draw_phase_area,
             draw_interp_pts=draw_interp_pts,
             draw_phase_shifts=draw_phase_shifts,
             draw_register=draw_register,
         )
-        if fig_name is not None:
-            plt.savefig(fig_name, **kwargs_savefig)
+        if fig_name is not None and fig_reg is not None:
+            fig_reg.savefig("register_" + fig_name, **kwargs_savefig_register)
+            fig.savefig("pulses_" + fig_name, **kwargs_savefig)
+        elif fig_name is not None:
+            fig.savefig(fig_name, **kwargs_savefig)
         plt.show()
 
     def _target(

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -24,6 +24,7 @@ import json
 from sys import version_info
 from typing import Any, cast, NamedTuple, Optional, Tuple, Union
 import warnings
+import os
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -914,10 +915,8 @@ class Sequence:
         draw_interp_pts: bool = True,
         draw_phase_shifts: bool = False,
         draw_register: bool = False,
-        fig_name_seq: str = None,
-        fig_name_reg: str = None,
-        kwargs_savefig_seq: dict = {},
-        kwargs_savefig_reg: dict = {},
+        fig_name: str = None,
+        kwargs_savefig: dict = {},
     ) -> None:
         """Draws the sequence in its current state.
 
@@ -932,18 +931,15 @@ class Sequence:
             draw_register (bool): Whether to draw the register before the pulse
                 sequence, with a visual indication (square halo) around the
                 qubits masked by the SLM, defaults to False.
-            fig_name_seq(str, default=None): The name on which to save the
-                figure of the sequence. If None the figure will not be saved.
-            fig_name_reg(str, default=None): The name on which to save the
-                figure of the register. If None or draw_register is `False`,
-                the figure will not be saved.
-            kwargs_savefig_seq(dict, default={}): Keywords arguments for
-                `matplotlib.figure.Figure.savefig`, sequence drawing.
-                Not applicable if `fig_name_seq`is `None`.
-            kwargs_savefig_reg(dict, default={}): Keywords arguments for
-                `matplotlib.figure.Figure.savefig`, register drawing.
-                Not applicable if `fig_name`is `None` or `draw_register` is
-                `False`.
+            fig_name(str, default=None): The name on which to save the
+                figure. If draw_register is True, both pulses and register
+                will be saved as figures, with a suffix "_pulses" and
+                "_register" in the file name. If draw_register is False, only
+                the pulses are saved, with no suffix. If fig_name is None,
+                no figure is saved.
+            kwargs_savefig(dict, default={}): Keywords arguments for
+                `matplotlib.figure.Figure.savefig`.
+                Not applicable if `fig_name`is `None`.
 
         See Also:
             Simulation.draw(): Draws the provided sequence and the one used by
@@ -956,10 +952,12 @@ class Sequence:
             draw_phase_shifts=draw_phase_shifts,
             draw_register=draw_register,
         )
-        if fig_name_seq is not None:
-            fig.savefig(fig_name_seq, **kwargs_savefig_seq)
-        if fig_name_reg is not None and draw_register:
-            fig_reg.savefig(fig_name_reg, **kwargs_savefig_reg)
+        if fig_name is not None and draw_register:
+            name, ext = os.path.splitext(fig_name)
+            fig.savefig(name + "_pulses" + ext, **kwargs_savefig)
+            fig_reg.savefig(name + "_register" + ext, **kwargs_savefig)
+        elif fig_name:
+            fig.savefig(fig_name, **kwargs_savefig)
         plt.show()
 
     def _target(

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -36,7 +36,7 @@ from pulser.json.coders import PulserEncoder, PulserDecoder
 from pulser.json.utils import obj_to_dict
 from pulser.parametrized import Parametrized, Variable
 from pulser.pulse import Pulse
-from pulser.register import BaseRegister, Register, Register3D
+from pulser.register import BaseRegister
 from pulser._seq_drawer import draw_sequence
 
 if version_info[:2] >= (3, 8):  # pragma: no cover

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -924,7 +924,7 @@ class Sequence:
                 on top of the respective waveforms (defaults to True).
             draw_phase_shifts (bool): Whether phase shift and reference
                 information should be added to the plot, defaults to False.
-            draw_register (bool): Whether to draw the register after the pulse
+            draw_register (bool): Whether to draw the register before the pulse
                 sequence, with a visual indication (square halo) around the
                 qubits masked by the SLM, defaults to False.
 

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -18,7 +18,7 @@ import numpy as np
 import pytest
 
 import pulser
-from pulser import Sequence, Pulse, Register
+from pulser import Sequence, Pulse, Register, Register3D
 from pulser.devices import Chadoq2, MockDevice
 from pulser.devices._device_datacls import Device
 from pulser.sequence import _TimeSlot
@@ -545,4 +545,26 @@ def test_slm_mask():
 
     # Check drawing method
     with patch("matplotlib.pyplot.show"):
-        seq_xy2.draw(draw_register=True)
+        seq_xy2.draw()
+
+
+def test_draw_register():
+    # Draw 2d register from sequence
+    reg = Register({"q0": (0, 0), "q1": (10, 10), "q2": (-10, -10)})
+    targets = ["q0", "q2"]
+    pulse = Pulse.ConstantPulse(100, 10, 0, 0)
+    seq = Sequence(reg, MockDevice)
+    seq.declare_channel("ch_xy", "mw_global")
+    seq.add(pulse, "ch_xy")
+    seq.config_slm_mask(targets)
+    with patch("matplotlib.pyplot.show"):
+        seq.draw(draw_register=True)
+
+    # Draw 3d register from sequence
+    reg3d = Register3D.cubic(3, 8)
+    seq3d = Sequence(reg3d, MockDevice)
+    seq3d.declare_channel("ch_xy", "mw_global")
+    seq3d.add(pulse, "ch_xy")
+    seq3d.config_slm_mask([0])
+    with patch("matplotlib.pyplot.show"):
+        seq3d.draw(draw_register=True)

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -545,4 +545,4 @@ def test_slm_mask():
 
     # Check drawing method
     with patch("matplotlib.pyplot.show"):
-        seq_xy2.draw()
+        seq_xy2.draw(draw_register=True)

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -328,8 +328,8 @@ def test_sequence():
 
     with patch("matplotlib.pyplot.show"):
         with patch("matplotlib.figure.Figure.savefig"):
-            seq.draw(fig_name_seq="my_sequence.pdf")
-            seq.draw(draw_register=True, fig_name_reg="my_register.pdf")
+            seq.draw(fig_name="my_sequence.pdf")
+            seq.draw(draw_register=True, fig_name="both.pdf")
 
     pulse1 = Pulse(
         InterpolatedWaveform(500, [0, 1, 0]),

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -328,8 +328,8 @@ def test_sequence():
 
     with patch("matplotlib.pyplot.show"):
         with patch("matplotlib.figure.Figure.savefig"):
-            seq.draw(fig_name="my_sequence.pdf")
-            seq.draw(draw_register=True, fig_name="my_sequence.pdf")
+            seq.draw(fig_name_seq="my_sequence.pdf")
+            seq.draw(draw_register=True, fig_name_reg="my_register.pdf")
 
     pulse1 = Pulse(
         InterpolatedWaveform(500, [0, 1, 0]),

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -567,6 +567,6 @@ def test_draw_register():
     seq3d = Sequence(reg3d, MockDevice)
     seq3d.declare_channel("ch_xy", "mw_global")
     seq3d.add(pulse, "ch_xy")
-    seq3d.config_slm_mask([0])
+    seq3d.config_slm_mask([6, 15])
     with patch("matplotlib.pyplot.show"):
         seq3d.draw(draw_register=True)

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -327,8 +327,9 @@ def test_sequence():
     seq.phase_shift(np.pi, "q0", basis="ground-rydberg")
 
     with patch("matplotlib.pyplot.show"):
-        with patch("matplotlib.pyplot.savefig"):
+        with patch("matplotlib.figure.Figure.savefig"):
             seq.draw(fig_name="my_sequence.pdf")
+            seq.draw(draw_register=True, fig_name="my_sequence.pdf")
 
     pulse1 = Pulse(
         InterpolatedWaveform(500, [0, 1, 0]),


### PR DESCRIPTION
`Sequence.draw()` now accepts a new boolean argument `draw_register` that defaults to `False`.
When `True`, the full register is shown after the pulse sequence. If an SLM mask is set, the masked qubits are shown as red crosses.

There are some points to discuss: 

1. The code is a bit redundant, as the register drawing part is copied from `Register.draw()`. One could think for example to split `Register.draw()` in two methods, the first returning an `ax` that could be used directly into `Sequence.draw()`. On the other hand, `Sequence` has the extra information on the SLM mask which is missing in `Register`, so I couldn't see a way to do that. 
2. Should the register drawing options (like blockade radius) be passed in `Sequence.draw()` as well? Or do we want to fall back on a set of default ones?
3. Should we introduce a flag to choose whether to highlight the masked qubits or not?
4. Related to the previous question: do we want to change the way masked qubits are shown? A sequence can be very long and complicated, with state preparation being just a small part of it. So perhaps showing a red cross is too strong as a visual cue?
5. When the register is drawn, an extra vertical padding between the different `axes` was added to avoid overlaps.

See attached image for the drawing result, where qubit `"q0"` and `"q10"` are masked.

![reg_draw](https://user-images.githubusercontent.com/32898410/136232171-5c44ee0f-dbf0-4877-8cc2-29c1bfba92e5.png)



