### PR TITLE
Custom labels

### DIFF
--- a/pulser/register.py
+++ b/pulser/register.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Iterable
+from collections.abc import Sequence as abcSequence
 import matplotlib.pyplot as plt
 from matplotlib import collections as mc
 import numpy as np
@@ -63,7 +64,7 @@ class BaseRegister(ABC):
         coords: np.ndarray,
         center: bool = True,
         prefix: Optional[str] = None,
-        labels: Optional[ArrayLike] = None,
+        labels: Optional[abcSequence[QubitId]] = None,
     ) -> T:
         """Creates the register from an array of coordinates.
 
@@ -95,6 +96,11 @@ class BaseRegister(ABC):
                 )
 
         elif labels is not None:
+            if len(coords) != len(labels):
+                raise ValueError(
+                    f"Label length ({len(labels)}) does not"
+                    f"match number of coordinates ({len(coords)})"
+                )
             qubits = dict(zip(cast(Iterable, labels), coords))
         else:
             qubits = dict(cast(Iterable, enumerate(coords)))
@@ -818,7 +824,6 @@ class Register3D(BaseRegister):
             If the atoms are not coplanar, raises an error.
         """
         coords = np.array(self._coords)
-        labels = self._ids
 
         barycenter = coords.sum(axis=0) / coords.shape[0]
         # run SVD
@@ -837,7 +842,7 @@ class Register3D(BaseRegister):
             coords_2D = np.array(
                 [np.array([e_x.dot(r), e_y.dot(r)]) for r in coords]
             )
-            return Register.from_coordinates(coords_2D, labels=labels)
+            return Register.from_coordinates(coords_2D, labels=self._ids)
 
     def draw(
         self,

--- a/pulser/tests/test_register.py
+++ b/pulser/tests/test_register.py
@@ -36,6 +36,11 @@ def test_creation():
     with pytest.raises(ValueError, match="vectors of size 2"):
         Register.from_coordinates([(0, 1, 0, 1)])
 
+    with pytest.raises(
+        NotImplementedError, match="a prefix and a set of labels"
+    ):
+        Register.from_coordinates(coords, prefix="a", labels=["a", "b"])
+
     with pytest.raises(ValueError, match="vectors of size 3"):
         Register3D.from_coordinates([((1, 0),), ((-1, 0),)])
 
@@ -43,6 +48,9 @@ def test_creation():
     reg2 = Register.from_coordinates(coords, center=False, prefix="q")
     assert np.all(np.array(reg1._coords) == np.array(reg2._coords))
     assert reg1._ids == reg2._ids
+
+    reg2b = Register.from_coordinates(coords, center=False, labels=["a", "b"])
+    assert reg2b._ids == ["a", "b"]
 
     reg3 = Register.from_coordinates(np.array(coords), prefix="foo")
     coords_ = np.array([(-0.5, 0), (0.5, 0)])

--- a/pulser/tests/test_register.py
+++ b/pulser/tests/test_register.py
@@ -52,6 +52,9 @@ def test_creation():
     reg2b = Register.from_coordinates(coords, center=False, labels=["a", "b"])
     assert reg2b._ids == ["a", "b"]
 
+    with pytest.raises(ValueError, match="Label length"):
+        Register.from_coordinates(coords, center=False, labels=["a", "b", "c"])
+
     reg3 = Register.from_coordinates(np.array(coords), prefix="foo")
     coords_ = np.array([(-0.5, 0), (0.5, 0)])
     assert reg3._ids == ["foo0", "foo1"]


### PR DESCRIPTION
Minor fix : `Register.from_coordinates()`now has an additional optional argument to specify custom labels on each qubit. This change is applied to the `to_2D()`method