### PR TITLE
[HOTFIX] Include C6_coeffs.json file in dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
 include requirements.txt
 include LICENSE
+include pulser/devices/interaction_coefficients/C6_coeffs.json

--- a/pulser/_version.py
+++ b/pulser/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"


### PR DESCRIPTION
The C6_coeffs.json file was not being included in the `v0.4.0` distribution, this fixes that.