### PR TITLE
[Hotfix] Restricting numpy version to fix qutip incompatibility 

### DIFF
--- a/pulser/devices/_device_datacls.py
+++ b/pulser/devices/_device_datacls.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 from scipy.spatial.distance import pdist, squareform
@@ -111,7 +111,9 @@ class Device:
         Returns:
             float: The rydberg blockade radius, in μm.
         """
-        return (self.interaction_coeff / rabi_frequency) ** (1 / 6)
+        return cast(
+            float, (self.interaction_coeff / rabi_frequency) ** (1 / 6)
+        )
 
     def rabi_from_blockade(self, blockade_radius: float) -> float:
         """The maximum Rabi frequency value to enforce a given blockade radius.

--- a/pulser/simulation/simulation.py
+++ b/pulser/simulation/simulation.py
@@ -881,7 +881,7 @@ class Simulation:
             if progress_bar is True:
                 p_bar = True
             elif (progress_bar is False) or (progress_bar is None):
-                p_bar = None  # type: ignore
+                p_bar = None
             else:
                 raise ValueError("`progress_bar` must be a bool.")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib
-numpy >= 1.20
+numpy >= 1.20, < 1.22
 qutip
 scipy
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     version=__version__,
     install_requires=[
         "matplotlib",
-        "numpy>=1.20",
+        "numpy>=1.20, <1.22",
         "scipy",
         "qutip",
     ],


### PR DESCRIPTION
As detailed in #303 , the latest version of `numpy` is not compatible with `qutip`, so I'm restricting the `numpy` version for now.

Additionally, the latest version of `mypy` also seems to have raised a couple `typing` errors, which i'm fixing here too.

Fixes #303.