### PR TITLE
Buffer times for retargeting and phase jumps

### DIFF
--- a/pulser/channels.py
+++ b/pulser/channels.py
@@ -39,8 +39,8 @@ class Channel:
         max_amp: Maximum pulse amplitude (in rad/µs).
         phase_jump_time: Time taken to change the phase between consecutive
             pulses (in ns).
-        min_retarget_interval: Minimum time required between two target
-            instructions (in ns).
+        min_retarget_interval: Minimum time required between the ends of two
+            target instructions (in ns).
         fixed_retarget_t: Time taken to change the target (in ns).
         max_targets: How many qubits can be addressed at once by the same beam.
         clock_period: The duration of a clock cycle (in ns). The duration of a

--- a/pulser/channels.py
+++ b/pulser/channels.py
@@ -39,8 +39,8 @@ class Channel:
         max_amp: Maximum pulse amplitude (in rad/µs).
         phase_jump_time: Time taken to change the phase between consecutive
             pulses (in ns).
-        retarget_time: Minimum time required between two target instructions
-            (in ns).
+        min_retarget_interval: Minimum time required between two target
+            instructions (in ns).
         fixed_retarget_t: Time taken to change the target (in ns).
         max_targets: How many qubits can be addressed at once by the same beam.
         clock_period: The duration of a clock cycle (in ns). The duration of a
@@ -60,7 +60,7 @@ class Channel:
     max_abs_detuning: float
     max_amp: float
     phase_jump_time: int = 0
-    retarget_time: Optional[int] = None
+    min_retarget_interval: Optional[int] = None
     fixed_retarget_t: Optional[int] = None
     max_targets: Optional[int] = None
     clock_period: int = 4  # ns
@@ -73,7 +73,7 @@ class Channel:
         max_abs_detuning: float,
         max_amp: float,
         phase_jump_time: int = 0,
-        retarget_time: int = 220,
+        min_retarget_interval: int = 220,
         fixed_retarget_t: int = 0,
         max_targets: int = 1,
         **kwargs: int,
@@ -86,8 +86,8 @@ class Channel:
             max_amp(float): Maximum pulse amplitude (in rad/µs).
             phase_jump_time (int): Time taken to change the phase between
                 consecutive pulses (in ns).
-            retarget_time (int): Minimum time required between two target
-                instructions (in ns).
+            min_retarget_interval (int): Minimum time required between two
+                target instructions (in ns).
             fixed_retarget_t (int): Time taken to change the target (in ns).
             max_targets (int): Maximum number of atoms the channel can target
                 simultaneously.
@@ -97,7 +97,7 @@ class Channel:
             max_abs_detuning,
             max_amp,
             phase_jump_time,
-            retarget_time,
+            min_retarget_interval,
             fixed_retarget_t,
             max_targets,
             **kwargs,
@@ -169,7 +169,7 @@ class Channel:
         )
         if self.addressing == "Local":
             config += (
-                f", Minimum retarget time: {self.retarget_time} ns, "
+                f", Minimum retarget time: {self.min_retarget_interval} ns, "
                 f"Fixed retarget time: {self.fixed_retarget_t} ns"
             )
             if cast(int, self.max_targets) > 1:

--- a/pulser/devices/_device_datacls.py
+++ b/pulser/devices/_device_datacls.py
@@ -231,10 +231,13 @@ class Device:
                         + r"- Maximum :math:`|\delta|`:"
                         + f" {ch.max_abs_detuning:.4g} rad/µs"
                     ),
+                    f"\t- Phase Jump Time: {ch.phase_jump_time} ns",
                 ]
                 if ch.addressing == "Local":
                     ch_lines += [
-                        f"\t- Maximum time to retarget: {ch.retarget_time} ns",
+                        "\t- Minimum time between retargets: "
+                        f"{ch.min_retarget_interval} ns",
+                        f"\t- Fixed retarget time: {ch.fixed_retarget_t} ns"
                         f"\t- Maximum simultaneous targets: {ch.max_targets}",
                     ]
                 ch_lines += [

--- a/pulser/devices/_device_datacls.py
+++ b/pulser/devices/_device_datacls.py
@@ -237,7 +237,7 @@ class Device:
                     ch_lines += [
                         "\t- Minimum time between retargets: "
                         f"{ch.min_retarget_interval} ns",
-                        f"\t- Fixed retarget time: {ch.fixed_retarget_t} ns"
+                        f"\t- Fixed retarget time: {ch.fixed_retarget_t} ns",
                         f"\t- Maximum simultaneous targets: {ch.max_targets}",
                     ]
                 ch_lines += [

--- a/pulser/devices/_mock_device.py
+++ b/pulser/devices/_mock_device.py
@@ -31,7 +31,12 @@ MockDevice = Device(
         (
             "rydberg_local",
             Rydberg.Local(
-                1000, 200, 0, max_targets=2000, clock_period=1, min_duration=1
+                1000,
+                200,
+                retarget_time=0,
+                max_targets=2000,
+                clock_period=1,
+                min_duration=1,
             ),
         ),
         (
@@ -41,7 +46,12 @@ MockDevice = Device(
         (
             "raman_local",
             Raman.Local(
-                1000, 200, 0, max_targets=2000, clock_period=1, min_duration=1
+                1000,
+                200,
+                retarget_time=0,
+                max_targets=2000,
+                clock_period=1,
+                min_duration=1,
             ),
         ),
         (

--- a/pulser/devices/_mock_device.py
+++ b/pulser/devices/_mock_device.py
@@ -33,7 +33,7 @@ MockDevice = Device(
             Rydberg.Local(
                 1000,
                 200,
-                retarget_time=0,
+                min_retarget_interval=0,
                 max_targets=2000,
                 clock_period=1,
                 min_duration=1,
@@ -48,7 +48,7 @@ MockDevice = Device(
             Raman.Local(
                 1000,
                 200,
-                retarget_time=0,
+                min_retarget_interval=0,
                 max_targets=2000,
                 clock_period=1,
                 min_duration=1,

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -664,7 +664,9 @@ class Sequence:
             if isinstance(op.type, Pulse):
                 if op.type.phase != pulse.phase:
                     delay_duration = max(
-                        delay_duration, self._channels[channel].phase_jump_time
+                        delay_duration,
+                        # Considers that the last pulse might not be at t0
+                        self._channels[channel].phase_jump_time - (t0 - op.tf),
                     )
                 break
 

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -623,17 +623,17 @@ class Sequence:
         t0 = last.tf  # Preliminary ti
         basis = channel_obj.basis
 
-        prs = {self._phase_ref[basis][q].last_phase for q in last.targets}
-        if len(prs) != 1:
+        ph_refs = {self._phase_ref[basis][q].last_phase for q in last.targets}
+        if len(ph_refs) != 1:
             raise ValueError(
                 "Cannot do a multiple-target pulse on qubits with different "
                 "phase references for the same basis."
             )
         else:
-            phase_ref = prs.pop()
+            phase_ref = ph_refs.pop()
 
         if phase_ref != 0:
-            # Has to recriate the original pulse with a new phase
+            # Has to recreate the original pulse with a new phase
             pulse = Pulse(
                 pulse.amplitude,
                 pulse.detuning,
@@ -666,16 +666,13 @@ class Sequence:
                     delay_duration = max(
                         delay_duration,
                         # Considers that the last pulse might not be at t0
-                        self._channels[channel].phase_jump_time - (t0 - op.tf),
+                        channel_obj.phase_jump_time - (t0 - op.tf),
                     )
                 break
 
         if delay_duration > 0:
             # Delay must not be shorter than the min duration for this channel
-            min_duration = self._channels[channel].min_duration
-            if delay_duration < min_duration:
-                delay_duration = min_duration
-
+            delay_duration = max(delay_duration, channel_obj.min_duration)
             self._delay(delay_duration, channel)
 
         ti = t0 + delay_duration

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -1061,7 +1061,9 @@ class Sequence:
                     delta = self._channels[channel].validate_duration(
                         16 if delta < 16 else delta
                     )
-            tf = ti + max(delta, self._channels[channel].fixed_retarget_t)
+            tf = ti + max(
+                delta, cast(int, self._channels[channel].fixed_retarget_t)
+            )
 
         except ValueError:
             ti = -1

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -1051,7 +1051,7 @@ class Sequence:
                     delta = self._channels[channel].validate_duration(
                         16 if delta < 16 else delta
                     )
-            tf = ti + delta
+            tf = ti + max(delta, self._channels[channel].fixed_retarget_t)
 
         except ValueError:
             ti = -1

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -1049,7 +1049,7 @@ class Sequence:
             if last.targets == qubits_set:
                 return
             ti = last.tf
-            retarget = cast(int, self._channels[channel].retarget_time)
+            retarget = cast(int, self._channels[channel].min_retarget_interval)
             elapsed = ti - self._last_target[channel]
             delta = cast(int, np.clip(retarget - elapsed, 0, retarget))
             if delta != 0:

--- a/pulser/tests/test_channels.py
+++ b/pulser/tests/test_channels.py
@@ -52,16 +52,20 @@ def test_validate_duration():
 
 
 def test_repr():
-    raman = Raman.Local(10, 2, retarget_time=1000, max_targets=4)
+    raman = Raman.Local(
+        10, 2, retarget_time=1000, fixed_retarget_t=200, max_targets=4
+    )
     r1 = (
         "Raman.Local(Max Absolute Detuning: 10 rad/µs, Max Amplitude: "
-        "2 rad/µs, Target time: 1000 ns, Max targets: 4, Basis: 'digital')"
+        "2 rad/µs, Phase Jump Time: 0 ns, Minimum retarget time: 1000 ns, "
+        "Fixed retarget time: 200 ns, Max targets: 4, Basis: 'digital')"
     )
     assert raman.__str__() == r1
 
-    ryd = Rydberg.Global(50, 2.5)
+    ryd = Rydberg.Global(50, 2.5, phase_jump_time=300)
     r2 = (
         "Rydberg.Global(Max Absolute Detuning: 50 rad/µs, "
-        "Max Amplitude: 2.5 rad/µs, Basis: 'ground-rydberg')"
+        "Max Amplitude: 2.5 rad/µs, Phase Jump Time: 300 ns, "
+        "Basis: 'ground-rydberg')"
     )
     assert ryd.__str__() == r2

--- a/pulser/tests/test_channels.py
+++ b/pulser/tests/test_channels.py
@@ -33,8 +33,10 @@ def test_device_channels():
             assert ch.clock_period >= 1
             assert ch.min_duration >= 1
             if ch.addressing == "Local":
-                assert ch.retarget_time >= 0
-                assert ch.retarget_time == int(ch.retarget_time)
+                assert ch.min_retarget_interval >= 0
+                assert ch.min_retarget_interval == int(
+                    ch.min_retarget_interval
+                )
                 assert ch.max_targets >= 1
                 assert ch.max_targets == int(ch.max_targets)
 
@@ -53,7 +55,7 @@ def test_validate_duration():
 
 def test_repr():
     raman = Raman.Local(
-        10, 2, retarget_time=1000, fixed_retarget_t=200, max_targets=4
+        10, 2, min_retarget_interval=1000, fixed_retarget_t=200, max_targets=4
     )
     r1 = (
         "Raman.Local(Max Absolute Detuning: 10 rad/µs, Max Amplitude: "

--- a/pulser/tests/test_devices.py
+++ b/pulser/tests/test_devices.py
@@ -61,7 +61,7 @@ def test_mock():
         assert ch.max_abs_detuning >= 1000
         assert ch.max_amp >= 200
         if ch.addressing == "Local":
-            assert ch.retarget_time == 0
+            assert ch.min_retarget_interval == 0
             assert ch.max_targets > 1
             assert ch.max_targets == int(ch.max_targets)
 

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -152,7 +152,7 @@ def test_target():
 
     assert seq._schedule["ch0"][-1] == _TimeSlot("target", -1, 0, {"q1"})
     seq.target("q4", "ch0")
-    retarget_t = seq.declared_channels["ch0"].retarget_time
+    retarget_t = seq.declared_channels["ch0"].min_retarget_interval
     assert seq._schedule["ch0"][-1] == _TimeSlot(
         "target", 0, retarget_t, {"q4"}
     )


### PR DESCRIPTION
Test coverage is at 100%, but more specific tests should be added once devices with channels using these quantities are defined (see #297).

Closes #296 .