### PR TITLE
Decorator type hints

### DIFF
--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -40,7 +40,7 @@ def gather_data(seq: pulser.sequence.Sequence) -> dict:
     """
     # The minimum time axis length is 100 ns
     total_duration = max(seq.get_duration(), 100)
-    data = {}
+    data: dict[str, Any] = {}
     for ch, sch in seq._schedule.items():
         time = [-1]  # To not break the "time[-1]" later on
         amp = []

--- a/pulser/parametrized/decorators.py
+++ b/pulser/parametrized/decorators.py
@@ -18,12 +18,15 @@ from __future__ import annotations
 from collections.abc import Callable
 from functools import wraps
 from itertools import chain
-from typing import Any
+from typing import Any, TypeVar, cast
 
 from pulser.parametrized import Parametrized, ParamObj
 
 
-def parametrize(func: Callable) -> Callable:
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def parametrize(func: F) -> F:
     """Makes a function support parametrized arguments.
 
     Note:
@@ -38,4 +41,4 @@ def parametrize(func: Callable) -> Callable:
                 return ParamObj(func, *args, **kwargs)
         return func(*args, **kwargs)
 
-    return wrapper
+    return cast(F, wrapper)

--- a/pulser/parametrized/decorators.py
+++ b/pulser/parametrized/decorators.py
@@ -23,7 +23,7 @@ from typing import Any, TypeVar, cast
 from pulser.parametrized import Parametrized, ParamObj
 
 
-F = TypeVar("F", bound=Callable[..., Any])
+F = TypeVar("F", bound=Callable)
 
 
 def parametrize(func: F) -> F:

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -22,7 +22,7 @@ from functools import wraps
 from itertools import chain
 import json
 from sys import version_info
-from typing import Any, cast, NamedTuple, Optional, Tuple, Union
+from typing import Any, cast, NamedTuple, Optional, Tuple, TypeVar, Union
 import warnings
 import os
 
@@ -56,6 +56,7 @@ else:  # pragma: no cover
 
 QubitId = Union[int, str]
 PROTOCOLS = Literal["min-delay", "no-delay", "wait-for-all"]
+F = TypeVar("F", bound=Callable)
 
 
 class _TimeSlot(NamedTuple):
@@ -71,7 +72,7 @@ class _TimeSlot(NamedTuple):
 _Call = namedtuple("_Call", ["name", "args", "kwargs"])
 
 
-def _screen(func: Callable) -> Callable:
+def _screen(func: F) -> F:
     """Blocks the call to a function if the Sequence is parametrized."""
 
     @wraps(func)
@@ -83,14 +84,14 @@ def _screen(func: Callable) -> Callable:
             )
         return func(self, *args, **kwargs)
 
-    return wrapper
+    return cast(F, wrapper)
 
 
-def _store(func):  # type: ignore
+def _store(func: F) -> F:
     """Stores any Sequence building call for deferred execution."""
 
     @wraps(func)
-    def wrapper(self: Sequence, *args, **kwargs):  # type: ignore
+    def wrapper(self: Sequence, *args: Any, **kwargs: Any) -> Any:
         def verify_variable(x: Any) -> None:
             if isinstance(x, Parametrized):
                 # If not already, the sequence becomes parametrized
@@ -122,7 +123,7 @@ def _store(func):  # type: ignore
         func(self, *args, **kwargs)
         storage.append(_Call(func.__name__, args, kwargs))
 
-    return wrapper
+    return cast(F, wrapper)
 
 
 class Sequence:
@@ -419,10 +420,7 @@ class Sequence:
         name: str,
         channel_id: str,
         initial_target: Optional[
-            Union[
-                Iterable[Union[QubitId, Parametrized]],
-                Union[QubitId, Parametrized],
-            ]
+            Union[QubitId, Iterable[QubitId], Parametrized]
         ] = None,
     ) -> None:
         """Declares a new channel to the Sequence.

--- a/pulser/sequence.py
+++ b/pulser/sequence.py
@@ -86,11 +86,11 @@ def _screen(func: Callable) -> Callable:
     return wrapper
 
 
-def _store(func: Callable) -> Callable:
+def _store(func):  # type: ignore
     """Stores any Sequence building call for deferred execution."""
 
     @wraps(func)
-    def wrapper(self: Sequence, *args: Any, **kwargs: Any) -> Any:
+    def wrapper(self: Sequence, *args, **kwargs):  # type: ignore
         def verify_variable(x: Any) -> None:
             if isinstance(x, Parametrized):
                 # If not already, the sequence becomes parametrized


### PR DESCRIPTION
Fix for #310 , which improves the type hints of decorators and fixes the `mypy` errors arising from it. As a result, the full type hints for `Pulse` have been brought back, after they were changed on #242.