### PR TITLE
Changing the line length for the `isort` config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,4 @@ line-length = 79
 
 [tool.isort]
 profile = "black"
+line_length = 79


### PR DESCRIPTION
Since we don't use the default `black` line length, only setting the `isort` profile to `black` will make `isort` go up to the 88 character limit, which causes an incompatibility with our custom 79 character limit. Adding an explicit `line_lenght=79` parameter to the `isort` config fixes this.