### PR TITLE
Removing restriction on numpy version following qutip's update

### DIFF
--- a/pulser/register/register.py
+++ b/pulser/register/register.py
@@ -265,7 +265,7 @@ class Register(BaseRegister):
             coords = np.concatenate((coords, coords2))
 
         coords *= spacing
-        coords = np.concatenate(([(0.0, 0.0)], coords))
+        coords = np.concatenate((np.zeros((1, 2)), coords))
 
         return cls.from_coordinates(coords, center=False, prefix=prefix)
 

--- a/pulser/waveforms.py
+++ b/pulser/waveforms.py
@@ -174,7 +174,7 @@ class Waveform(ABC):
         mod_samples = self._modulated_samples(channel)
         tr = channel.rise_time
         trim = slice(tr - start, len(mod_samples) - tr + end)
-        return cast(np.ndarray, mod_samples[trim])
+        return mod_samples[trim]
 
     @functools.lru_cache()
     def modulation_buffers(self, channel: Channel) -> tuple[int, int]:
@@ -226,7 +226,7 @@ class Waveform(ABC):
     ) -> Union[float, np.ndarray]:
         if isinstance(index_or_slice, slice):
             s: slice = self._check_slice(index_or_slice)
-            return cast(np.ndarray, self._samples[s])
+            return self._samples[s]
         else:
             index: int = self._check_index(index_or_slice)
             return cast(float, self._samples[index])
@@ -726,6 +726,7 @@ class InterpolatedWaveform(Waveform):
         super().__init__(duration)
         self._values = np.array(values, dtype=float)
         if times is not None:
+            times = cast(ArrayLike, times)
             times_ = np.array(times, dtype=float)
             if len(times_) != len(self._values):
                 raise ValueError(
@@ -932,6 +933,7 @@ class KaiserWaveform(Waveform):
         """
         max_val = cast(float, max_val)
         area = cast(float, area)
+        beta = cast(float, beta)
 
         if np.sign(max_val) != np.sign(area):
             raise ValueError(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib
-numpy >= 1.20, < 1.22
-qutip
+numpy >= 1.20
+qutip >= 4.6.3
 scipy
 
 # version specific

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ setup(
     version=__version__,
     install_requires=[
         "matplotlib",
-        "numpy>=1.20, <1.22",
+        "numpy>=1.20",
         "scipy",
-        "qutip",
+        "qutip>=4.6.3",
     ],
     extras_require={
         ":python_version == '3.7'": [


### PR DESCRIPTION
`qutip` 4.6.3 now supports the latest version of `numpy`, so I'm removing the restriction that `numpy < 1.22` and rather place it on qutip to be `>=4.6.3`(ie it's latest version).

This effectively reverses the hotfix introduced in #304 , which was needed due to an update of `numpy` that `qutip` did not support.