### PR TITLE
Mappable Register

### DIFF
--- a/pulser/_seq_drawer.py
+++ b/pulser/_seq_drawer.py
@@ -161,10 +161,9 @@ def draw_sequence(
     area_ph_box = dict(boxstyle="round", facecolor="ghostwhite", alpha=0.7)
     slm_box = dict(boxstyle="round", alpha=0.4, facecolor="grey", hatch="//")
 
-    pos = np.array(seq.register._coords)
-
     # Draw masked register
     if draw_register:
+        pos = np.array(seq.register._coords)
         if isinstance(seq.register, Register3D):
             labels = "xyz"
             fig_reg, axes_reg = seq.register._initialize_fig_axes_projection(

--- a/pulser/register/_reg_drawer.py
+++ b/pulser/register/_reg_drawer.py
@@ -14,8 +14,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence as abcSequence
 from itertools import combinations
-from typing import Optional, Union
+from typing import Optional, Union, List, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -32,7 +33,7 @@ class RegDrawer:
     def _draw_2D(
         ax: plt.axes._subplots.AxesSubplot,
         pos: np.ndarray,
-        ids: list,
+        ids: abcSequence[QubitId],
         plane: tuple = (0, 1),
         with_labels: bool = True,
         blockade_radius: Optional[float] = None,
@@ -91,7 +92,9 @@ class RegDrawer:
                 while j < len(plot_ids):
                     r2 = plot_pos[j]
                     if np.max(np.abs(r - r2)) < epsilon:
-                        plot_ids[i] = plot_ids[i] + plot_ids.pop(j)
+                        plot_ids[i] = cast(List[str], plot_ids[i]) + cast(
+                            List[str], plot_ids.pop(j)
+                        )
                         plot_pos.pop(j)
                         overlap = True
                     else:
@@ -105,12 +108,16 @@ class RegDrawer:
                 has_masked = False
                 for j in range(len(plot_ids[i])):
                     if plot_ids[i][j] in [str(q) for q in masked_qubits]:
-                        plot_ids[i][j:] = [", ".join(plot_ids[i][j:])]
+                        cast(List[str], plot_ids[i])[j:] = [
+                            ", ".join(plot_ids[i][j:])
+                        ]
                         has_masked = True
                         break
                 # Add a square bracket that encloses all masked qubits
                 if has_masked:
-                    plot_ids[i][-1] = "[" + plot_ids[i][-1] + "]"
+                    cast(List[str], plot_ids[i])[-1] = (
+                        "[" + plot_ids[i][-1] + "]"
+                    )
                 # Merge what remains
                 plot_ids[i] = ", ".join(plot_ids[i])
                 bbs[plot_ids[i]] = overlap
@@ -165,7 +172,7 @@ class RegDrawer:
     @staticmethod
     def _draw_3D(
         pos: np.ndarray,
-        ids: list,
+        ids: abcSequence[QubitId],
         projection: bool = False,
         with_labels: bool = True,
         blockade_radius: Optional[float] = None,

--- a/pulser/register/_reg_drawer.py
+++ b/pulser/register/_reg_drawer.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence as abcSequence
 from itertools import combinations
-from typing import Optional, Union, List, cast
+from typing import List, Optional, Union, cast
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/pulser/register/base_register.py
+++ b/pulser/register/base_register.py
@@ -63,7 +63,7 @@ class BaseRegister(ABC):
             raise ValueError(
                 "Cannot create a Register with an empty qubit " "dictionary."
             )
-        self._ids = tuple(qubits.keys())
+        self._ids: tuple[QubitId, ...] = tuple(qubits.keys())
         self._coords = [np.array(v, dtype=float) for v in qubits.values()]
         self._dim = self._coords[0].size
         self._layout_info: Optional[_LayoutInfo] = None

--- a/pulser/register/base_register.py
+++ b/pulser/register/base_register.py
@@ -63,7 +63,7 @@ class BaseRegister(ABC):
             raise ValueError(
                 "Cannot create a Register with an empty qubit " "dictionary."
             )
-        self._ids = list(qubits.keys())
+        self._ids = tuple(qubits.keys())
         self._coords = [np.array(v, dtype=float) for v in qubits.values()]
         self._dim = self._coords[0].size
         self._layout_info: Optional[_LayoutInfo] = None
@@ -82,6 +82,11 @@ class BaseRegister(ABC):
     def qubits(self) -> dict[QubitId, np.ndarray]:
         """Dictionary of the qubit names and their position coordinates."""
         return dict(zip(self._ids, self._coords))
+
+    @property
+    def qubit_ids(self) -> tuple[QubitId, ...]:
+        """The qubit IDs of this register."""
+        return self._ids
 
     @classmethod
     def from_coordinates(

--- a/pulser/register/mappable_reg.py
+++ b/pulser/register/mappable_reg.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from pulser.register.register_layout import RegisterLayout
 
 
-class SuspendedRegister:
+class MappableRegister:
     """A register with the traps of each qubit still to be defined.
 
     Args:
@@ -35,7 +35,7 @@ class SuspendedRegister:
     """
 
     def __init__(self, register_layout: RegisterLayout, *qubit_ids: QubitId):
-        """Initializes the suspended register."""
+        """Initializes the mappable register."""
         self._layout = register_layout
         if len(qubit_ids) > self._layout.max_atom_num:
             raise ValueError(
@@ -47,7 +47,7 @@ class SuspendedRegister:
 
     @property
     def qubit_ids(self) -> tuple[QubitId, ...]:
-        """The qubit IDs of this suspended register."""
+        """The qubit IDs of this mappable register."""
         return self._qubit_ids
 
     def build_register(self, qubits: Mapping[QubitId, int]) -> BaseRegister:
@@ -56,7 +56,7 @@ class SuspendedRegister:
         Args:
             qubits (Mapping[QubitId, int]): A map between the qubit IDs to use
                 and the layout traps where the qubits will be placed. Qubit IDs
-                declared in the SuspendedRegister but not defined here will
+                declared in the MappableRegister but not defined here will
                 simply be left out of the final register.
 
         Returns:

--- a/pulser/register/register_layout.py
+++ b/pulser/register/register_layout.py
@@ -28,9 +28,9 @@ from numpy.typing import ArrayLike
 from pulser.json.utils import obj_to_dict
 from pulser.register._reg_drawer import RegDrawer
 from pulser.register.base_register import BaseRegister, QubitId
+from pulser.register.mappable_reg import MappableRegister
 from pulser.register.register import Register
 from pulser.register.register3d import Register3D
-from pulser.register.suspended_reg import SuspendedRegister
 
 if version_info[:2] >= (3, 8):  # pragma: no cover
     from functools import cached_property
@@ -249,28 +249,28 @@ class RegisterLayout(RegDrawer):
             )
         plt.show()
 
-    def make_suspended_register(
+    def make_mappable_register(
         self, n_qubits: int, prefix: str = "q"
-    ) -> SuspendedRegister:
-        """Creates a suspended register associated with this layout.
+    ) -> MappableRegister:
+        """Creates a mappable register associated with this layout.
 
-        A suspended register is a register whose atoms' positions have not yet
+        A mappable register is a register whose atoms' positions have not yet
         been defined. It can be used to create a sequence whose register is
         only defined when it is built. Note that not all the qubits 'reserved'
-        in a SuspendedRegister need to be in the final Register, as qubits not
+        in a MappableRegister need to be in the final Register, as qubits not
         associated with trap IDs won't be included. If you intend on defining
-        registers of different sizes from the same suspended register, reserve
+        registers of different sizes from the same mappable register, reserve
         as many qubits as you need for your largest register.
 
         Args:
-            n_qubits(int): The number of qubits to reserve in the suspended
+            n_qubits(int): The number of qubits to reserve in the mappable
                 register.
             prefix (str): The prefix for the qubit ids. Each qubit ID starts
                 with the prefix, followed by an int from 0 to N-1
                 (e.g. prefix='q' -> IDs: 'q0', 'q1', 'q2', ...).
         """
         qubit_ids = [f"{prefix}{i}" for i in range(n_qubits)]
-        return SuspendedRegister(self, *qubit_ids)
+        return MappableRegister(self, *qubit_ids)
 
     def _safe_hash(self) -> bytes:
         # Include dimensionality because the array is flattened with tobytes()

--- a/pulser/register/register_layout.py
+++ b/pulser/register/register_layout.py
@@ -30,6 +30,7 @@ from pulser.register._reg_drawer import RegDrawer
 from pulser.register.base_register import BaseRegister, QubitId
 from pulser.register.register import Register
 from pulser.register.register3d import Register3D
+from pulser.register.suspended_reg import SuspendedRegister
 
 if version_info[:2] >= (3, 8):  # pragma: no cover
     from functools import cached_property
@@ -247,6 +248,29 @@ class RegisterLayout(RegDrawer):
                 are_traps=True,
             )
         plt.show()
+
+    def make_suspended_register(
+        self, n_qubits: int, prefix: str = "q"
+    ) -> SuspendedRegister:
+        """Creates a suspended register associated with this layout.
+
+        A suspended register is a register whose atoms' positions have not yet
+        been defined. It can be used to create a sequence whose register is
+        only defined when it is built. Note that not all the qubits 'reserved'
+        in a SuspendedRegister need to be in the final Register, as qubits not
+        associated with trap IDs won't be included. If you intend on defining
+        registers of different sizes from the same suspended register, reserve
+        as many qubits as you need for your largest register.
+
+        Args:
+            n_qubits(int): The number of qubits to reserve in the suspended
+                register.
+            prefix (str): The prefix for the qubit ids. Each qubit ID starts
+                with the prefix, followed by an int from 0 to N-1
+                (e.g. prefix='q' -> IDs: 'q0', 'q1', 'q2', ...).
+        """
+        qubit_ids = [f"{prefix}{i}" for i in range(n_qubits)]
+        return SuspendedRegister(self, *qubit_ids)
 
     def _safe_hash(self) -> bytes:
         # Include dimensionality because the array is flattened with tobytes()

--- a/pulser/register/suspended_reg.py
+++ b/pulser/register/suspended_reg.py
@@ -15,15 +15,24 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-if TYPE_CHECKING:
+from pulser.json.utils import obj_to_dict
+
+if TYPE_CHECKING:  # pragma: no cover
     from pulser.register.base_register import QubitId, BaseRegister
     from pulser.register.register_layout import RegisterLayout
 
 
 class SuspendedRegister:
-    """A register with the traps of each qubit still to be defined."""
+    """A register with the traps of each qubit still to be defined.
+
+    Args:
+        register_layout (RegisterLayout): The register layout on which this
+            register will be defined.
+        qubit_ids (QubitId): The Ids for the qubits to pre-declare on this
+            register.
+    """
 
     def __init__(self, register_layout: RegisterLayout, *qubit_ids: QubitId):
         """Initializes the suspended register."""
@@ -61,3 +70,6 @@ class SuspendedRegister:
         return self._layout.define_register(
             *tuple(qubits.values()), qubit_ids=chosen_ids
         )
+
+    def _to_dict(self) -> dict[str, Any]:
+        return obj_to_dict(self, self._layout, *self._qubit_ids)

--- a/pulser/register/suspended_reg.py
+++ b/pulser/register/suspended_reg.py
@@ -1,0 +1,63 @@
+# Copyright 2022 Pulser Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Allows for a temporary register to exist, when associated with a layout."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pulser.register.base_register import QubitId, BaseRegister
+    from pulser.register.register_layout import RegisterLayout
+
+
+class SuspendedRegister:
+    """A register with the traps of each qubit still to be defined."""
+
+    def __init__(self, register_layout: RegisterLayout, *qubit_ids: QubitId):
+        """Initializes the suspended register."""
+        self._layout = register_layout
+        if len(qubit_ids) > self._layout.max_atom_num:
+            raise ValueError(
+                "The number of required traps is greater than the maximum "
+                "number of qubits allowed for this layout "
+                f"({self._layout.max_atom_num})."
+            )
+        self._qubit_ids = qubit_ids
+
+    @property
+    def qubit_ids(self) -> tuple[QubitId, ...]:
+        """The qubit IDs of this suspended register."""
+        return self._qubit_ids
+
+    def build_register(self, qubits: Mapping[QubitId, int]) -> BaseRegister:
+        """Builds an actual register.
+
+        Args:
+            qubits (Mapping[QubitId, int]): A map between the qubit IDs to use
+                and the layout traps where the qubits will be placed. Qubit IDs
+                declared in the SuspendedRegister but not defined here will
+                simply be left out of the final register.
+
+        Returns:
+            BaseRegister: The resulting register.
+        """
+        chosen_ids = tuple(qubits.keys())
+        if not set(chosen_ids) <= set(self._qubit_ids):
+            raise ValueError(
+                "All qubits must be labeled with pre-declared qubit IDs."
+            )
+        return self._layout.define_register(
+            *tuple(qubits.values()), qubit_ids=chosen_ids
+        )

--- a/pulser/register/suspended_reg.py
+++ b/pulser/register/suspended_reg.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any
 from pulser.json.utils import obj_to_dict
 
 if TYPE_CHECKING:  # pragma: no cover
-    from pulser.register.base_register import QubitId, BaseRegister
+    from pulser.register.base_register import BaseRegister, QubitId
     from pulser.register.register_layout import RegisterLayout
 
 

--- a/pulser/simulation/simulation.py
+++ b/pulser/simulation/simulation.py
@@ -82,7 +82,7 @@ class Simulation:
                 "The provided sequence has to be a valid "
                 "pulser.Sequence instance."
             )
-        if sequence.is_parametrized() or sequence._reg_suspended:
+        if sequence.is_parametrized() or sequence.is_register_mappable():
             raise ValueError(
                 "The provided sequence needs to be built to be simulated. Call"
                 " `Sequence.build()` with the necessary parameters."

--- a/pulser/simulation/simulation.py
+++ b/pulser/simulation/simulation.py
@@ -82,6 +82,11 @@ class Simulation:
                 "The provided sequence has to be a valid "
                 "pulser.Sequence instance."
             )
+        if sequence.is_parametrized() or sequence._reg_suspended:
+            raise ValueError(
+                "The provided sequence needs to be built to be simulated. Call"
+                " `Sequence.build()` with the necessary parameters."
+            )
         if not sequence._schedule:
             raise ValueError("The provided sequence has no declared channels.")
         if all(sequence._schedule[x][-1].tf == 0 for x in sequence._channels):

--- a/pulser/simulation/simulation.py
+++ b/pulser/simulation/simulation.py
@@ -98,6 +98,15 @@ class Simulation:
         self._qdict = self._seq.qubit_info
         self._size = len(self._qdict)
         self._tot_duration = self._seq.get_duration()
+
+        # Type hints for attributes defined outside of __init__
+        self.basis_name: str
+        self._config: SimConfig
+        self.op_matrix: dict[str, qutip.Qobj]
+        self.basis: dict[str, qutip.Qobj]
+        self.dim: int
+        self._eval_times_array: np.ndarray
+
         if not (0 < sampling_rate <= 1.0):
             raise ValueError(
                 "The sampling rate (`sampling_rate` = "

--- a/pulser/tests/test_json.py
+++ b/pulser/tests/test_json.py
@@ -67,6 +67,14 @@ def test_register_from_layout():
     assert new_reg._layout_info.trap_ids == (1, 0)
 
 
+def test_suspended_register():
+    layout = RegisterLayout([[0, 0], [1, 1], [1, 0], [0, 1]])
+    susp_reg = layout.make_suspended_register(2)
+    new_susp_reg = encode_decode(susp_reg)
+    assert new_susp_reg._layout == layout
+    assert new_susp_reg.qubit_ids == ("q0", "q1")
+
+
 def test_rare_cases():
     reg = Register.square(4)
     seq = Sequence(reg, Chadoq2)

--- a/pulser/tests/test_json.py
+++ b/pulser/tests/test_json.py
@@ -67,12 +67,12 @@ def test_register_from_layout():
     assert new_reg._layout_info.trap_ids == (1, 0)
 
 
-def test_suspended_register():
+def test_mappable_register():
     layout = RegisterLayout([[0, 0], [1, 1], [1, 0], [0, 1]])
-    susp_reg = layout.make_suspended_register(2)
-    new_susp_reg = encode_decode(susp_reg)
-    assert new_susp_reg._layout == layout
-    assert new_susp_reg.qubit_ids == ("q0", "q1")
+    mapp_reg = layout.make_mappable_register(2)
+    new_mapp_reg = encode_decode(mapp_reg)
+    assert new_mapp_reg._layout == layout
+    assert new_mapp_reg.qubit_ids == ("q0", "q1")
 
 
 def test_rare_cases():

--- a/pulser/tests/test_paramseq.py
+++ b/pulser/tests/test_paramseq.py
@@ -43,6 +43,8 @@ def test_var_declarations():
     var3 = sb.declare_variable("var3")
     assert sb.declared_variables["var3"] == var3.var
     assert isinstance(var3, VariableItem)
+    with pytest.raises(ValueError, match="'qubits' is a protected name"):
+        sb.declare_variable("qubits", size=10, dtype=str)
 
 
 def test_stored_calls():

--- a/pulser/tests/test_register.py
+++ b/pulser/tests/test_register.py
@@ -27,7 +27,7 @@ def test_creation():
         Register(empty_dict)
 
     coords = [(0, 0), (1, 0)]
-    ids = ["q0", "q1"]
+    ids = ("q0", "q1")
     qubits = dict(zip(ids, coords))
     with pytest.raises(TypeError):
         Register(coords)
@@ -50,14 +50,14 @@ def test_creation():
     assert reg1._ids == reg2._ids
 
     reg2b = Register.from_coordinates(coords, center=False, labels=["a", "b"])
-    assert reg2b._ids == ["a", "b"]
+    assert reg2b._ids == ("a", "b")
 
     with pytest.raises(ValueError, match="Label length"):
         Register.from_coordinates(coords, center=False, labels=["a", "b", "c"])
 
     reg3 = Register.from_coordinates(np.array(coords), prefix="foo")
     coords_ = np.array([(-0.5, 0), (0.5, 0)])
-    assert reg3._ids == ["foo0", "foo1"]
+    assert reg3._ids == ("foo0", "foo1")
     assert np.all(reg3._coords == coords_)
     assert not np.all(coords_ == coords)
 

--- a/pulser/tests/test_register_layout.py
+++ b/pulser/tests/test_register_layout.py
@@ -185,20 +185,20 @@ def test_triangular_lattice_layout():
     )
 
 
-def test_suspended_register_creation():
+def test_mappable_register_creation():
     tri = TriangularLatticeLayout(50, 5)
     with pytest.raises(ValueError, match="greater than the maximum"):
-        tri.make_suspended_register(26)
+        tri.make_mappable_register(26)
 
-    susp_reg = tri.make_suspended_register(5)
-    assert susp_reg.qubit_ids == ("q0", "q1", "q2", "q3", "q4")
+    mapp_reg = tri.make_mappable_register(5)
+    assert mapp_reg.qubit_ids == ("q0", "q1", "q2", "q3", "q4")
 
     with pytest.raises(
         ValueError, match="labeled with pre-declared qubit IDs"
     ):
-        susp_reg.build_register({"q0": 0, "q5": 2})
+        mapp_reg.build_register({"q0": 0, "q5": 2})
 
-    reg = susp_reg.build_register({"q0": 10, "q1": 49})
+    reg = mapp_reg.build_register({"q0": 10, "q1": 49})
     assert reg == Register(
         {"q0": tri.traps_dict[10], "q1": tri.traps_dict[49]}
     )

--- a/pulser/tests/test_register_layout.py
+++ b/pulser/tests/test_register_layout.py
@@ -183,3 +183,22 @@ def test_triangular_lattice_layout():
     tri.rectangular_register(5, 5) != Register.triangular_lattice(
         5, 5, spacing=5, prefix="q"
     )
+
+
+def test_suspended_register_creation():
+    tri = TriangularLatticeLayout(50, 5)
+    with pytest.raises(ValueError, match="greater than the maximum"):
+        tri.make_suspended_register(26)
+
+    susp_reg = tri.make_suspended_register(5)
+    assert susp_reg.qubit_ids == ("q0", "q1", "q2", "q3", "q4")
+
+    with pytest.raises(
+        ValueError, match="labeled with pre-declared qubit IDs"
+    ):
+        susp_reg.build_register({"q0": 0, "q5": 2})
+
+    reg = susp_reg.build_register({"q0": 10, "q1": 49})
+    assert reg == Register(
+        {"q0": tri.traps_dict[10], "q1": tri.traps_dict[49]}
+    )

--- a/pulser/tests/test_sequence.py
+++ b/pulser/tests/test_sequence.py
@@ -661,11 +661,11 @@ def test_hardware_constraints():
         seq.draw(mode="input+output")
 
 
-def test_suspended_register():
+def test_mappable_register():
     layout = TriangularLatticeLayout(100, 5)
-    susp_reg = layout.make_suspended_register(10)
-    seq = Sequence(susp_reg, Chadoq2)
-    assert seq._reg_suspended
+    mapp_reg = layout.make_mappable_register(10)
+    seq = Sequence(mapp_reg, Chadoq2)
+    assert seq.is_register_mappable()
     reserved_qids = tuple([f"q{i}" for i in range(10)])
     assert seq._qids == set(reserved_qids)
     with pytest.raises(RuntimeError, match="Can't access the qubit info"):
@@ -699,7 +699,7 @@ def test_suspended_register():
 
     seq_ = seq.build(qubits={"q2": 20, "q0": 10})
     seq_._last("ryd").targets == {"q2", "q0"}
-    assert not seq_._reg_suspended
+    assert not seq_.is_register_mappable()
     assert seq_.register == Register(
         {"q0": layout.traps_dict[10], "q2": layout.traps_dict[20]}
     )

--- a/pulser/tests/test_simulation.py
+++ b/pulser/tests/test_simulation.py
@@ -113,9 +113,9 @@ def test_initialization_and_construction_of_hamiltonian():
         Simulation(seq_copy)
 
     layout = RegisterLayout([[0, 0], [10, 10]])
-    susp_reg = layout.make_suspended_register(1)
-    seq_ = Sequence(susp_reg, Chadoq2)
-    assert seq_._reg_suspended and not seq_.is_parametrized()
+    mapp_reg = layout.make_mappable_register(1)
+    seq_ = Sequence(mapp_reg, Chadoq2)
+    assert seq_.is_register_mappable() and not seq_.is_parametrized()
     with pytest.raises(ValueError, match="needs to be built"):
         Simulation(seq_)
 

--- a/pulser/tests/test_simulation.py
+++ b/pulser/tests/test_simulation.py
@@ -21,6 +21,7 @@ import qutip
 
 from pulser import Pulse, Register, Sequence
 from pulser.devices import Chadoq2, MockDevice
+from pulser.register.register_layout import RegisterLayout
 from pulser.simulation import SimConfig, Simulation
 from pulser.waveforms import BlackmanWaveform, ConstantWaveform, RampWaveform
 
@@ -102,6 +103,21 @@ def test_initialization_and_construction_of_hamiltonian():
     for qobjevo in sim._hamiltonian.ops:
         for sh in qobjevo.qobj.shape:
             assert sh == sim.dim**sim._size
+
+    assert not seq.is_parametrized()
+    seq_copy = seq.build()  # Take a copy of the sequence
+    x = seq_copy.declare_variable("x")
+    seq_copy.add(Pulse.ConstantPulse(x, 1, 0, 0), "ryd")
+    assert seq_copy.is_parametrized()
+    with pytest.raises(ValueError, match="needs to be built"):
+        Simulation(seq_copy)
+
+    layout = RegisterLayout([[0, 0], [10, 10]])
+    susp_reg = layout.make_suspended_register(1)
+    seq_ = Sequence(susp_reg, Chadoq2)
+    assert seq_._reg_suspended and not seq_.is_parametrized()
+    with pytest.raises(ValueError, match="needs to be built"):
+        Simulation(seq_)
 
 
 def test_extraction_of_sequences():


### PR DESCRIPTION
Creates the `MappableRegister` class which enables the build of multiple sequences for the same `Sequence` instance, with the register being defined at build time.