### PR TITLE
Hotfix: Register from mappable register going back to mappable in Sequence

### DIFF
--- a/pulser/tests/test_json.py
+++ b/pulser/tests/test_json.py
@@ -96,6 +96,13 @@ def test_mappable_register():
     assert new_mapp_reg._layout == layout
     assert new_mapp_reg.qubit_ids == ("q0", "q1")
 
+    seq = Sequence(mapp_reg, MockDevice)
+    assert seq.is_register_mappable()
+    mapped_seq = seq.build(qubits={"q0": 2, "q1": 1})
+    assert not mapped_seq.is_register_mappable()
+    new_mapped_seq = Sequence.deserialize(mapped_seq.serialize())
+    assert not new_mapped_seq.is_register_mappable()
+
 
 def test_rare_cases():
     reg = Register.square(4)


### PR DESCRIPTION
A sequence that was built from a sequence with a mappable register was going back to having a mappable register after serialization and deserialization. This was because the first call that is used to initialise the sequence was not being updated when the register is defined.

This PR adds the fix and a test for this scenario.