### PR TITLE
Updates to `pulser.sampler`

### DIFF
--- a/pulser/sampler/__init__.py
+++ b/pulser/sampler/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Pulser Development Team
+# Copyright 2022 Pulser Development Team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pulser/sampler/noise_model.py
+++ b/pulser/sampler/noise_model.py
@@ -1,0 +1,65 @@
+# Copyright 2022 Pulser Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Defines a NoiseModel and how to apply it to the samples."""
+from __future__ import annotations
+
+import functools
+from typing import Callable
+
+from pulser.sampler.samples import QubitSamples
+
+NoiseModel = Callable[[QubitSamples], QubitSamples]
+"""A function that apply some noise on a list of QubitSamples.
+
+A NoiseModel corresponds to a source of noises present in a device which is
+relevant when sampling the input pulses. Physical effects contributing to
+modifications of the shined amplitude, detuning and phase felt by qubits of the
+register are susceptible to be implemented by a NoiseModel.
+"""
+
+
+def compose_local_noises(*functions: NoiseModel) -> NoiseModel:
+    """Helper to compose multiple NoiseModel.
+
+    Args:
+        *functions: a list of functions
+
+    Returns:
+        The mathematical composition of *functions. The last element is applied
+        first. If *functions is [f, g, h], it returns f∘g∘h.
+    """
+    return functools.reduce(
+        lambda f, g: lambda x: f(g(x)), functions, lambda x: x
+    )
+
+
+def apply_noises(
+    samples: list[QubitSamples], noises: list[NoiseModel]
+) -> list[QubitSamples]:
+    """Apply a list of NoiseModel on a list of QubitSamples.
+
+    The noises are composed using the compose_local_noises function, such that
+    the last element is applied first.
+
+    Args:
+        samples (list[QubitSamples]): A list of QubitSamples.
+        noises (list[NoiseModel]): A list of NoiseModel.
+
+    Return:
+        A list of QubitSamples on which each element of noises has been
+        applied.
+    """
+    tot_noise = compose_local_noises(*noises)
+
+    return [tot_noise(s) for s in samples]

--- a/pulser/sampler/sampler.py
+++ b/pulser/sampler/sampler.py
@@ -10,9 +10,9 @@ from typing import Callable, List, Optional, cast
 
 import numpy as np
 
-import pulser.simulation.noises as noises
 from pulser.channels import Channel
 from pulser.pulse import Pulse
+from pulser.sampler.noise_model import NoiseModel, apply_noises
 from pulser.sampler.samples import QubitSamples
 from pulser.sequence import Sequence, _TimeSlot
 
@@ -20,8 +20,8 @@ from pulser.sequence import Sequence, _TimeSlot
 def sample(
     seq: Sequence,
     modulation: bool = False,
-    common_noises: Optional[list[noises.NoiseModel]] = None,
-    global_noises: Optional[list[noises.NoiseModel]] = None,
+    common_noises: Optional[list[NoiseModel]] = None,
+    global_noises: Optional[list[NoiseModel]] = None,
 ) -> dict:
     """Samples the given Sequence and returns a nested dictionary.
 
@@ -80,7 +80,7 @@ def sample(
         if modulation:
             s = _modulate(ch, s)
 
-        s = noises.apply(s, ch_noises)
+        s = apply_noises(s, ch_noises)
 
         if slm_on:  # Update the samples of masked qubits during SLM on times
             for i, _ in enumerate(s):

--- a/pulser/sampler/sampler.py
+++ b/pulser/sampler/sampler.py
@@ -1,3 +1,16 @@
+# Copyright 2022 Pulser Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Exposes the sample() functions.
 
 It contains many helpers.

--- a/pulser/sampler/samples.py
+++ b/pulser/sampler/samples.py
@@ -1,3 +1,16 @@
+# Copyright 2022 Pulser Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Defines samples dataclasses."""
 from __future__ import annotations
 

--- a/pulser/simulation/noises.py
+++ b/pulser/simulation/noises.py
@@ -1,3 +1,16 @@
+# Copyright 2022 Pulser Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Contains noise models.
 
 For now, only the amplitude and doppler noises are implemented in the form a

--- a/pulser/simulation/noises.py
+++ b/pulser/simulation/noises.py
@@ -6,7 +6,6 @@ sampling time.
 """
 from __future__ import annotations
 
-import functools
 from typing import Callable, Optional
 
 import numpy as np
@@ -104,39 +103,3 @@ def doppler(reg: Register, std_dev: float, seed: Optional[int]) -> NoiseModel:
         )
 
     return f
-
-
-def compose_local_noises(*functions: NoiseModel) -> NoiseModel:
-    """Helper to compose multiple NoiseModel.
-
-    Args:
-        *functions: a list of functions
-
-    Returns:
-        The mathematical composition of *functions. The last element is applied
-        first. If *functions is [f, g, h], it returns f∘g∘h.
-    """
-    return functools.reduce(
-        lambda f, g: lambda x: f(g(x)), functions, lambda x: x
-    )
-
-
-def apply(
-    samples: list[QubitSamples], noises: list[NoiseModel]
-) -> list[QubitSamples]:
-    """Apply a list of NoiseModel on a list of QubitSamples.
-
-    The noises are composed using the compose_local_noises function, such that
-    the last element is applied first.
-
-    Args:
-        samples (list[QubitSamples]): A list of QubitSamples.
-        noises (list[NoiseModel]): A list of NoiseModel.
-
-    Return:
-        A list of QubitSamples on which each element of noises has been
-        applied.
-    """
-    tot_noise = compose_local_noises(*noises)
-
-    return [tot_noise(s) for s in samples]

--- a/pulser/tests/test_sampling_noises.py
+++ b/pulser/tests/test_sampling_noises.py
@@ -1,3 +1,16 @@
+# Copyright 2022 Pulser Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from __future__ import annotations
 
 import numpy as np

--- a/pulser/tests/test_sequence_sampler.py
+++ b/pulser/tests/test_sequence_sampler.py
@@ -1,3 +1,16 @@
+# Copyright 2022 Pulser Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from __future__ import annotations
 
 import textwrap


### PR DESCRIPTION
- Separates the specific noise definitions from general noise objects to isolate `pulser.sampler` and `pulser.simulation`
- Adds missing license headers