### PR TITLE
Uniform access to the layout in Register and MappableRegister

### DIFF
--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -154,9 +154,9 @@ class Device:
             )
         self._validate_coords(register.qubits, kind="atoms")
 
-        if register._layout_info is not None:
+        if register.layout is not None:
             try:
-                self.validate_layout(register._layout_info.layout)
+                self.validate_layout(register.layout)
             except (ValueError, TypeError):
                 raise ValueError(
                     "The 'register' is associated with an incompatible "

--- a/pulser-core/pulser/register/base_register.py
+++ b/pulser-core/pulser/register/base_register.py
@@ -88,6 +88,11 @@ class BaseRegister(ABC):
         """The qubit IDs of this register."""
         return self._ids
 
+    @property
+    def layout(self) -> Optional[RegisterLayout]:
+        """The layout used to define the register."""
+        return self._layout_info.layout if self._layout_info else None
+
     def find_indices(self, id_list: abcSequence[QubitId]) -> list[int]:
         """Computes indices of qubits.
 

--- a/pulser-core/pulser/register/mappable_reg.py
+++ b/pulser-core/pulser/register/mappable_reg.py
@@ -51,6 +51,11 @@ class MappableRegister:
         """The qubit IDs of this mappable register."""
         return self._qubit_ids
 
+    @property
+    def layout(self) -> RegisterLayout:
+        """The layout used to define the register."""
+        return self._layout
+
     def build_register(self, qubits: Mapping[QubitId, int]) -> BaseRegister:
         """Builds an actual register.
 

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -285,7 +285,7 @@ class Register(BaseRegister, RegDrawer):
         Args:
             degrees (float): The angle of rotation in degrees.
         """
-        if self._layout_info is not None:
+        if self.layout is not None:
             raise TypeError(
                 "A register defined from a RegisterLayout cannot be rotated."
             )

--- a/pulser-core/pulser/sequence.py
+++ b/pulser-core/pulser/sequence.py
@@ -212,7 +212,7 @@ class Sequence:
 
         # Checks if register is compatible with the device
         if isinstance(register, MappableRegister):
-            device.validate_layout(register._layout)
+            device.validate_layout(register.layout)
         else:
             device.validate_register(register)
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -85,7 +85,7 @@ def test_register_from_layout():
     seq = Sequence(reg, device=MockDevice)
     new_reg = encode_decode(seq).register
     assert reg == new_reg
-    assert new_reg._layout_info.layout == layout
+    assert new_reg.layout == layout
     assert new_reg._layout_info.trap_ids == (1, 0)
 
 
@@ -93,7 +93,7 @@ def test_mappable_register():
     layout = RegisterLayout([[0, 0], [1, 1], [1, 0], [0, 1]])
     mapp_reg = layout.make_mappable_register(2)
     new_mapp_reg = encode_decode(mapp_reg)
-    assert new_mapp_reg._layout == layout
+    assert new_mapp_reg.layout == layout
     assert new_mapp_reg.qubit_ids == ("q0", "q1")
 
     seq = Sequence(mapp_reg, MockDevice)


### PR DESCRIPTION
Adds a `layout` property to both `Register` and `MappableRegister` so that the underlying layout is accessible in the same way for both classes.