### PR TITLE
WIP: simulation with samples from pulser.sampler.sample()

### DIFF
--- a/pulser-core/pulser/sampler/sampler.py
+++ b/pulser-core/pulser/sampler/sampler.py
@@ -107,6 +107,16 @@ def sample(
     # format the samples in the simulation dict form
     d = _write_dict(seq, samples, addrs)
 
+    # Replace empty defaultdict with empty dicts.
+    # NOTE(lvignoli): this is the format required by the simulation module. We
+    # keep the above code for flexibility in the construction of QubitSamples
+    # and for other samples formats.
+    return _default_to_regular(d)
+
+
+def _default_to_regular(d: dict | defaultdict) -> dict:
+    if isinstance(d, defaultdict):
+        d = {k: _default_to_regular(v) for k, v in d.items()}
     return d
 
 

--- a/pulser-core/pulser/sampler/sampler.py
+++ b/pulser-core/pulser/sampler/sampler.py
@@ -33,6 +33,7 @@ from pulser.sequence import Sequence, _TimeSlot
 def sample(
     seq: Sequence,
     modulation: bool = False,
+    additional_final_sample: bool = False,
     common_noises: Optional[list[NoiseModel]] = None,
     global_noises: Optional[list[NoiseModel]] = None,
 ) -> dict:
@@ -101,6 +102,14 @@ def sample(
                     ti, tf = seq._slm_mask_time[0], seq._slm_mask_time[1]
                     s[i].amp[ti:tf] = 0.0
                     # apply only on amp since it's just a shutter
+
+        # Add final 0 samples to comply with the current format of the
+        # simulation module.
+        if additional_final_sample:
+            for sample in s:
+                sample.amp = np.append(sample.amp, 0.0)
+                sample.det = np.append(sample.det, 0.0)
+                sample.phase = np.append(sample.phase, 0.0)
 
         samples[ch_name] = s
 

--- a/pulser-simulation/pulser_simulation/simconfig.py
+++ b/pulser-simulation/pulser_simulation/simconfig.py
@@ -90,6 +90,8 @@ class SimConfig:
     doppler_sigma: float = field(
         init=False, default=KEFF * np.sqrt(KB * 50.0e-6 / MASS)
     )
+    use_sampler: bool = False
+    modulation: bool = False
 
     def __post_init__(self) -> None:
         self._process_temperature()

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -424,15 +424,11 @@ class Simulation:
         # Use the sampler if specified.
         # It _should_ do the same as the rest of the current function below.
         # Noises or slm are ignored for now.
-        # BUG: for the very first check, the final state state is not the same
-        # when simulating with the sampler: it outputs a 3-level state!
         if self.config.use_sampler:
-            print("Using the sampler")
-            self.sampled_samples = sampler.sample(self._seq)
-            self.samples = sampler.sample(self._seq)
+            self.samples = sampler.sample(
+                self._seq, additional_final_sample=True
+            )
             return
-
-        print("Using legacy sampling")
 
         def prepare_dict() -> dict[str, np.ndarray]:
             # Duration includes retargeting, delays, etc.

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -613,6 +613,23 @@ class Simulation:
 
     def _build_basis_and_op_matrices(self) -> None:
         """Determine dimension, basis and projector operators."""
+
+        def no_samples(d: dict) -> bool:
+            """Checks for "zero" samples dictionnaries.
+
+            Is true if the amplitude, detuning and phase samples are all zeros,
+            or if d is None or empty.
+            """
+            return (
+                d is None
+                or d == {}
+                or (
+                    all(d["amp"] == 0)
+                    and all(d["det"] == 0)
+                    and all(d["phase"] == 0)
+                )
+            )
+
         if self._interaction == "XY":
             self.basis_name = "XY"
             self.dim = 2
@@ -620,18 +637,16 @@ class Simulation:
             projectors = ["uu", "du", "ud", "dd"]
         else:
             # No samples => Empty dict entry => False
-            if (
-                not self.samples["Global"]["digital"]
-                and not self.samples["Local"]["digital"]
+            if no_samples(self.samples["Global"]["digital"]) and no_samples(
+                self.samples["Local"]["digital"]
             ):
                 self.basis_name = "ground-rydberg"
                 self.dim = 2
                 basis = ["r", "g"]
                 projectors = ["gr", "rr", "gg"]
-            elif (
-                not self.samples["Global"]["ground-rydberg"]
-                and not self.samples["Local"]["ground-rydberg"]
-            ):
+            elif no_samples(
+                self.samples["Global"]["ground-rydberg"]
+            ) and no_samples(self.samples["Local"]["ground-rydberg"]):
                 self.basis_name = "digital"
                 self.dim = 2
                 basis = ["g", "h"]

--- a/tutorials/simulation_with_sampler.ipynb
+++ b/tutorials/simulation_with_sampler.ipynb
@@ -21,7 +21,21 @@
     "import pulser_simulation\n",
     "from pulser import Pulse\n",
     "from pulser.devices import MockDevice\n",
-    "from pulser.waveforms import BlackmanWaveform"
+    "from pulser.waveforms import BlackmanWaveform, RampWaveform"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Simple sequence"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lets simulate a simple sequence, using either the `simulation.Simulation._extract_sample()` or the `sampler.sample()` functions for samples extraction."
    ]
   },
   {
@@ -47,7 +61,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Using legacy sampling\n",
       "501\n",
       "Quantum object: dims = [[2], [1]], shape = (2, 1), type = ket\n",
       "Qobj data =\n",
@@ -73,12 +86,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Using the sampler\n",
-      "500\n",
+      "501\n",
       "Quantum object: dims = [[2], [1]], shape = (2, 1), type = ket\n",
       "Qobj data =\n",
-      "[[0.17041078+0.22931142j]\n",
-      " [0.95831959+0.j        ]]\n"
+      "[[0.17230094+0.22978882j]\n",
+      " [0.95786715+0.j        ]]\n"
      ]
     }
    ],
@@ -95,7 +107,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "No more basis problem. The final state differ, most probably because of the additional zero sample in the legacy sampler."
+    "The final states are exactly the same."
    ]
   },
   {
@@ -115,30 +127,35 @@
     }
    ],
    "source": [
-    "all(\n",
-    "    sim.samples[\"Global\"][\"ground-rydberg\"][\"amp\"][:500]\n",
-    "    - sim2.samples[\"Global\"][\"ground-rydberg\"][\"amp\"]\n",
-    "    == 0\n",
-    ")"
+    "fs1 == fs2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is no surprise, since we can check that the samples are the same."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[10. 10. 10. 10. 10. 10. 10. 10. 10.  0.]\n",
-      "[10. 10. 10. 10. 10. 10. 10. 10. 10. 10.]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print(sim.samples[\"Global\"][\"ground-rydberg\"][\"amp\"][-10:])\n",
-    "print(sim2.samples[\"Global\"][\"ground-rydberg\"][\"amp\"][-10:])"
+    "def check(a, b):\n",
+    "    np.testing.assert_array_equal(a, b)\n",
+    "\n",
+    "check(sim.samples[\"Global\"][\"ground-rydberg\"][\"amp\"], sim2.samples[\"Global\"][\"ground-rydberg\"][\"amp\"])\n",
+    "check(sim.samples[\"Global\"][\"ground-rydberg\"][\"det\"], sim2.samples[\"Global\"][\"ground-rydberg\"][\"det\"])\n",
+    "check(sim.samples[\"Global\"][\"ground-rydberg\"][\"phase\"], sim2.samples[\"Global\"][\"ground-rydberg\"][\"phase\"])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We retain the additional 0 sample on all the parameters, thanks to the `additional_final_sample` flag when calling `sampler.sample`."
    ]
   },
   {
@@ -150,53 +167,48 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Quantum object: dims = [[2], [1]], shape = (2, 1), type = ket\n",
-      "Qobj data =\n",
-      "[[ 0.00189016+0.00047741j]\n",
-      " [-0.00045244+0.j        ]]\n"
+      "[10. 10. 10. 10. 10. 10. 10. 10. 10.  0.]\n",
+      "[10. 10. 10. 10. 10. 10. 10. 10. 10.  0.]\n"
      ]
     }
    ],
    "source": [
-    "print(fs1 - fs2)"
+    "print(sim.samples[\"Global\"][\"ground-rydberg\"][\"amp\"][-10:])\n",
+    "print(sim2.samples[\"Global\"][\"ground-rydberg\"][\"amp\"][-10:])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This should not be a problem for pulse waveforms that goes to zeros.\n",
-    "Let's check."
+    "### More intricate sequence"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using legacy sampling\n",
-      "Using the sampler\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "seq_blackman = pulser.Sequence(reg, MockDevice)\n",
-    "seq_blackman.declare_channel(\"main\", \"rydberg_global\")\n",
-    "seq_blackman.add(\n",
-    "    Pulse.ConstantDetuning(BlackmanWaveform(500, np.pi / 2), 0, 0), \"main\"\n",
-    ")\n",
+    "reg = pulser.Register.rectangle(1, 2, spacing=10.0, prefix=\"q\")\n",
+    "seq = pulser.Sequence(reg, MockDevice)\n",
+    "seq.declare_channel(\"main\", \"rydberg_global\")\n",
+    "seq.declare_channel(\"local\", \"rydberg_local\", initial_target=\"q0\")\n",
+    "seq.add(Pulse.ConstantDetuning(BlackmanWaveform(500, np.pi / 2), 0, 0), \"main\")\n",
+    "seq.add(Pulse.ConstantPulse(100, 2, -3, 0), \"local\")\n",
+    "seq.target(\"q1\", \"local\")\n",
+    "seq.add(Pulse.ConstantAmplitude(4, RampWaveform(123, -20, 31), 0), \"local\")\n",
     "\n",
-    "sim3 = pulser_simulation.Simulation(seq_blackman)\n",
+    "seq.add(Pulse.ConstantAmplitude(3, BlackmanWaveform(500, np.pi), 0), \"main\")\n",
+    "\n",
+    "\n",
+    "sim3 = pulser_simulation.Simulation(seq)\n",
     "res3 = sim3.run()\n",
     "\n",
     "sim4 = pulser_simulation.Simulation(\n",
-    "    seq_blackman, config=pulser_simulation.SimConfig(use_sampler=True)\n",
+    "    seq, config=pulser_simulation.SimConfig(use_sampler=True)\n",
     ")\n",
-    "res4 = sim4.run()"
+    "res4 = sim4.run()\n"
    ]
   },
   {
@@ -205,140 +217,18 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Quantum object: dims = [[2], [1]], shape = (2, 1), type = ket\n",
-      "Qobj data =\n",
-      "[[0.      -0.70708856j]\n",
-      " [0.707125+0.j        ]]\n",
-      "Quantum object: dims = [[2], [1]], shape = (2, 1), type = ket\n",
-      "Qobj data =\n",
-      "[[0.        -0.70708855j]\n",
-      " [0.70712502+0.j        ]]\n"
-     ]
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "print(res3.get_final_state())\n",
-    "print(res4.get_final_state())\n",
-    "\n",
-    "np.testing.assert_allclose(\n",
-    "    res3.get_final_state(), res4.get_final_state(), rtol=0, atol=1e-7\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The `digital` key still exist in the sample dictionary with the new sampler, it is just zero."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "dict_keys(['ground-rydberg', 'digital'])\n",
-      "{'amp': array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0.]), 'det': array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0.]), 'phase': array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
-      "       0., 0., 0., 0., 0., 0., 0.])}\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(sim2.samples[\"Global\"].keys())\n",
-    "print(sim2.samples[\"Global\"][\"digital\"])"
+    "res3.get_final_state() == res4.get_final_state()"
    ]
   }
  ],

--- a/tutorials/simulation_with_sampler.ipynb
+++ b/tutorials/simulation_with_sampler.ipynb
@@ -19,9 +19,9 @@
     "\n",
     "import pulser\n",
     "import pulser_simulation\n",
-    "from pulser.channels import Rydberg\n",
+    "from pulser import Pulse\n",
     "from pulser.devices import MockDevice\n",
-    "from pulser import Pulse\n"
+    "from pulser.waveforms import BlackmanWaveform"
    ]
   },
   {
@@ -35,7 +35,7 @@
     "\n",
     "seq.declare_channel(\"main\", \"rydberg_global\")\n",
     "\n",
-    "seq.add(Pulse.ConstantPulse(500, 10, 20, 0), \"main\")\n"
+    "seq.add(Pulse.ConstantPulse(500, 10, 20, 0), \"main\")"
    ]
   },
   {
@@ -74,12 +74,11 @@
      "output_type": "stream",
      "text": [
       "Using the sampler\n",
-      "501\n",
-      "Quantum object: dims = [[3], [1]], shape = (3, 1), type = ket\n",
+      "500\n",
+      "Quantum object: dims = [[2], [1]], shape = (2, 1), type = ket\n",
       "Qobj data =\n",
-      "[[0.17041513+0.2293127j]\n",
-      " [0.95831851+0.j       ]\n",
-      " [0.        +0.j       ]]\n"
+      "[[0.17041078+0.22931142j]\n",
+      " [0.95831959+0.j        ]]\n"
      ]
     }
    ],
@@ -87,7 +86,7 @@
     "config2 = pulser_simulation.SimConfig(use_sampler=True)\n",
     "sim2 = pulser_simulation.Simulation(seq, config=config2)\n",
     "res2 = sim2.run()\n",
-    "print(len(sim.samples[\"Global\"][\"ground-rydberg\"][\"amp\"]))\n",
+    "print(len(sim2.samples[\"Global\"][\"ground-rydberg\"][\"amp\"]))\n",
     "fs2 = res2.get_final_state()\n",
     "print(fs2)"
    ]
@@ -96,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The two final state differ: using the sampler, we have a 3-level state."
+    "No more basis problem. The final state differ, most probably because of the additional zero sample in the legacy sampler."
    ]
   },
   {
@@ -105,29 +104,242 @@
    "metadata": {},
    "outputs": [
     {
-     "ename": "TypeError",
-     "evalue": "Incompatible quantum object dimensions",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[1;32m/Users/manta/Desktop/Pulser/simulation_with_sampler.ipynb Cell 6'\u001b[0m in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> <a href='vscode-notebook-cell:/Users/manta/Desktop/Pulser/simulation_with_sampler.ipynb#ch0000006?line=0'>1</a>\u001b[0m \u001b[39mprint\u001b[39m(fs1 \u001b[39m-\u001b[39m fs2)\n",
-      "File \u001b[0;32m~/.pyenv/versions/3.10.1/envs/pulser_dev/lib/python3.10/site-packages/qutip/qobj.py:476\u001b[0m, in \u001b[0;36mQobj.__sub__\u001b[0;34m(self, other)\u001b[0m\n\u001b[1;32m    472\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m__sub__\u001b[39m(\u001b[39mself\u001b[39m, other):\n\u001b[1;32m    473\u001b[0m     \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    474\u001b[0m \u001b[39m    SUBTRACTION with Qobj on LEFT [ ex. Qobj-4 ]\u001b[39;00m\n\u001b[1;32m    475\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 476\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m \u001b[39m+\u001b[39;49m (\u001b[39m-\u001b[39;49mother)\n",
-      "File \u001b[0;32m~/.pyenv/versions/3.10.1/envs/pulser_dev/lib/python3.10/site-packages/qutip/qobj.py:435\u001b[0m, in \u001b[0;36mQobj.__add__\u001b[0;34m(self, other)\u001b[0m\n\u001b[1;32m    432\u001b[0m     \u001b[39mreturn\u001b[39;00m out\n\u001b[1;32m    434\u001b[0m \u001b[39melif\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mdims \u001b[39m!=\u001b[39m other\u001b[39m.\u001b[39mdims:\n\u001b[0;32m--> 435\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mTypeError\u001b[39;00m(\u001b[39m'\u001b[39m\u001b[39mIncompatible quantum object dimensions\u001b[39m\u001b[39m'\u001b[39m)\n\u001b[1;32m    437\u001b[0m \u001b[39melif\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mshape \u001b[39m!=\u001b[39m other\u001b[39m.\u001b[39mshape:\n\u001b[1;32m    438\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mTypeError\u001b[39;00m(\u001b[39m'\u001b[39m\u001b[39mMatrix shapes do not match\u001b[39m\u001b[39m'\u001b[39m)\n",
-      "\u001b[0;31mTypeError\u001b[0m: Incompatible quantum object dimensions"
-     ]
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "print(fs1 - fs2)\n"
+    "all(\n",
+    "    sim.samples[\"Global\"][\"ground-rydberg\"][\"amp\"][:500]\n",
+    "    - sim2.samples[\"Global\"][\"ground-rydberg\"][\"amp\"]\n",
+    "    == 0\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[10. 10. 10. 10. 10. 10. 10. 10. 10.  0.]\n",
+      "[10. 10. 10. 10. 10. 10. 10. 10. 10. 10.]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(sim.samples[\"Global\"][\"ground-rydberg\"][\"amp\"][-10:])\n",
+    "print(sim2.samples[\"Global\"][\"ground-rydberg\"][\"amp\"][-10:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Quantum object: dims = [[2], [1]], shape = (2, 1), type = ket\n",
+      "Qobj data =\n",
+      "[[ 0.00189016+0.00047741j]\n",
+      " [-0.00045244+0.j        ]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(fs1 - fs2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This should not be a problem for pulse waveforms that goes to zeros.\n",
+    "Let's check."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using legacy sampling\n",
+      "Using the sampler\n"
+     ]
+    }
+   ],
+   "source": [
+    "seq_blackman = pulser.Sequence(reg, MockDevice)\n",
+    "seq_blackman.declare_channel(\"main\", \"rydberg_global\")\n",
+    "seq_blackman.add(\n",
+    "    Pulse.ConstantDetuning(BlackmanWaveform(500, np.pi / 2), 0, 0), \"main\"\n",
+    ")\n",
+    "\n",
+    "sim3 = pulser_simulation.Simulation(seq_blackman)\n",
+    "res3 = sim3.run()\n",
+    "\n",
+    "sim4 = pulser_simulation.Simulation(\n",
+    "    seq_blackman, config=pulser_simulation.SimConfig(use_sampler=True)\n",
+    ")\n",
+    "res4 = sim4.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Quantum object: dims = [[2], [1]], shape = (2, 1), type = ket\n",
+      "Qobj data =\n",
+      "[[0.      -0.70708856j]\n",
+      " [0.707125+0.j        ]]\n",
+      "Quantum object: dims = [[2], [1]], shape = (2, 1), type = ket\n",
+      "Qobj data =\n",
+      "[[0.        -0.70708855j]\n",
+      " [0.70712502+0.j        ]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(res3.get_final_state())\n",
+    "print(res4.get_final_state())\n",
+    "\n",
+    "np.testing.assert_allclose(\n",
+    "    res3.get_final_state(), res4.get_final_state(), rtol=0, atol=1e-7\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `digital` key still exist in the sample dictionary with the new sampler, it is just zero."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dict_keys(['ground-rydberg', 'digital'])\n",
+      "{'amp': array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0.]), 'det': array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0.]), 'phase': array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+      "       0., 0., 0., 0., 0., 0., 0.])}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(sim2.samples[\"Global\"].keys())\n",
+    "print(sim2.samples[\"Global\"][\"digital\"])"
+   ]
   }
  ],
  "metadata": {

--- a/tutorials/simulation_with_sampler.ipynb
+++ b/tutorials/simulation_with_sampler.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Simulation using the `pulser.sampler` module\n",
+    "\n",
+    "This notebook is a work document to investigate how to use the sampler correctly in the simulation module."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "import pulser\n",
+    "import pulser_simulation\n",
+    "from pulser.channels import Rydberg\n",
+    "from pulser.devices import MockDevice\n",
+    "from pulser import Pulse\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reg = pulser.Register.square(1)\n",
+    "seq = pulser.Sequence(reg, MockDevice)\n",
+    "\n",
+    "seq.declare_channel(\"main\", \"rydberg_global\")\n",
+    "\n",
+    "seq.add(Pulse.ConstantPulse(500, 10, 20, 0), \"main\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using legacy sampling\n",
+      "501\n",
+      "Quantum object: dims = [[2], [1]], shape = (2, 1), type = ket\n",
+      "Qobj data =\n",
+      "[[0.17230094+0.22978882j]\n",
+      " [0.95786715+0.j        ]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "sim = pulser_simulation.Simulation(seq)\n",
+    "res = sim.run()\n",
+    "print(len(sim.samples[\"Global\"][\"ground-rydberg\"][\"amp\"]))\n",
+    "fs1 = res.get_final_state()\n",
+    "print(fs1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using the sampler\n",
+      "501\n",
+      "Quantum object: dims = [[3], [1]], shape = (3, 1), type = ket\n",
+      "Qobj data =\n",
+      "[[0.17041513+0.2293127j]\n",
+      " [0.95831851+0.j       ]\n",
+      " [0.        +0.j       ]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "config2 = pulser_simulation.SimConfig(use_sampler=True)\n",
+    "sim2 = pulser_simulation.Simulation(seq, config=config2)\n",
+    "res2 = sim2.run()\n",
+    "print(len(sim.samples[\"Global\"][\"ground-rydberg\"][\"amp\"]))\n",
+    "fs2 = res2.get_final_state()\n",
+    "print(fs2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The two final state differ: using the sampler, we have a 3-level state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "Incompatible quantum object dimensions",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m/Users/manta/Desktop/Pulser/simulation_with_sampler.ipynb Cell 6'\u001b[0m in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> <a href='vscode-notebook-cell:/Users/manta/Desktop/Pulser/simulation_with_sampler.ipynb#ch0000006?line=0'>1</a>\u001b[0m \u001b[39mprint\u001b[39m(fs1 \u001b[39m-\u001b[39m fs2)\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.10.1/envs/pulser_dev/lib/python3.10/site-packages/qutip/qobj.py:476\u001b[0m, in \u001b[0;36mQobj.__sub__\u001b[0;34m(self, other)\u001b[0m\n\u001b[1;32m    472\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m__sub__\u001b[39m(\u001b[39mself\u001b[39m, other):\n\u001b[1;32m    473\u001b[0m     \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    474\u001b[0m \u001b[39m    SUBTRACTION with Qobj on LEFT [ ex. Qobj-4 ]\u001b[39;00m\n\u001b[1;32m    475\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 476\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m \u001b[39m+\u001b[39;49m (\u001b[39m-\u001b[39;49mother)\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.10.1/envs/pulser_dev/lib/python3.10/site-packages/qutip/qobj.py:435\u001b[0m, in \u001b[0;36mQobj.__add__\u001b[0;34m(self, other)\u001b[0m\n\u001b[1;32m    432\u001b[0m     \u001b[39mreturn\u001b[39;00m out\n\u001b[1;32m    434\u001b[0m \u001b[39melif\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mdims \u001b[39m!=\u001b[39m other\u001b[39m.\u001b[39mdims:\n\u001b[0;32m--> 435\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mTypeError\u001b[39;00m(\u001b[39m'\u001b[39m\u001b[39mIncompatible quantum object dimensions\u001b[39m\u001b[39m'\u001b[39m)\n\u001b[1;32m    437\u001b[0m \u001b[39melif\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mshape \u001b[39m!=\u001b[39m other\u001b[39m.\u001b[39mshape:\n\u001b[1;32m    438\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mTypeError\u001b[39;00m(\u001b[39m'\u001b[39m\u001b[39mMatrix shapes do not match\u001b[39m\u001b[39m'\u001b[39m)\n",
+      "\u001b[0;31mTypeError\u001b[0m: Incompatible quantum object dimensions"
+     ]
+    }
+   ],
+   "source": [
+    "print(fs1 - fs2)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.1 64-bit ('pulser_dev')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.1"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "09d8bcf34db098a0f7dfd01b586d0dc1b8210cc666e3c39f20e5f794936347e7"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Draft PR for substituting the legacy sampling in the `Simulation` class with the dedicated `pulser.sampler` module.

It is in particular a prerequisite to simulation of modulated sequence (see #315).

Blindly substituting the core of `Simulation._extract_samples()` with `pulser.sampler.sample()` does not work: weirdly the final state of the two simulations differ by the number of levels considered, the new one outputting a 3-level state.
Also, restricted to the first 2 components, they are numerically not the same at 1e-3 accuracy.

I have been unable to pinpoint where the divergence occurs.

Run the notebook `tutorials/simulation_with_sampler.ipynb` to see the issue in action.