### PR TITLE
Bugfix in simulation with SLM mask

### DIFF
--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -513,6 +513,8 @@ class Simulation:
             if self._seq._slm_mask_targets and self._seq._slm_mask_time:
                 tf = self._seq._slm_mask_time[1]
                 for qubit in self._seq._slm_mask_targets:
+                    if qubit not in self.samples["Local"][basis]:
+                        continue
                     for x in ("amp", "det", "phase"):
                         self.samples["Local"][basis][qubit][x][0:tf] = 0
 


### PR DESCRIPTION
This fixes a bug that appeared when simulating a sequence where an SLM mask has a target that is never addressed by the local channel. The accompanying test is an example where a `KeyError` would be thrown without this change.