### PR TITLE
Remove restriction that only Chadoq2 was supported for abstract sequence

### DIFF
--- a/pulser-core/pulser/json/abstract_repr/schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schema.json
@@ -150,6 +150,14 @@
       ],
       "type": "object"
     },
+    "Device": {
+      "enum": [
+        "Chadoq2",
+        "IroiseMVP",
+        "MockDevice"
+      ],
+      "type": "string"
+    },
     "ExprArgument": {
       "anyOf": [
         {
@@ -559,7 +567,11 @@
           "type": "object"
         },
         "device": {
-          "const": "Chadoq2",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Device"
+            }
+          ],
           "description": "A valid device in which to execute the Sequence",
           "type": "string"
         },
@@ -658,7 +670,7 @@
           "type": "string"
         },
         "value": {
-          "description": "Default variable value. The default array length determins the variable array size.",
+          "description": "Default variable value. The default array length determines the variable array size.",
           "items": {
             "type": "number"
           },

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import jsonschema
 import numpy as np
@@ -52,8 +52,6 @@ SPECIAL_WFS: dict[str, tuple[Callable, tuple[str, ...]]] = {
 
 
 class TestSerialization:
-
-    # @pytest.mark.parametrize("device", [Chadoq2, MockDevice])
     @pytest.fixture(params=[Chadoq2, MockDevice])
     def sequence(self, request):
         qubits = {"control": (-2, 0), "target": (2, 0)}

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -51,15 +51,14 @@ SPECIAL_WFS: dict[str, tuple[Callable, tuple[str, ...]]] = {
 }
 
 
-
 class TestSerialization:
 
-    #@pytest.mark.parametrize("device", [Chadoq2, MockDevice])
+    # @pytest.mark.parametrize("device", [Chadoq2, MockDevice])
     @pytest.fixture(params=[Chadoq2, MockDevice])
     def sequence(self, request):
         qubits = {"control": (-2, 0), "target": (2, 0)}
         reg = Register(qubits)
-        device=request.param
+        device = request.param
         seq = Sequence(reg, device)
         seq.declare_channel("digital", "raman_local", initial_target="control")
         seq.declare_channel(
@@ -127,7 +126,9 @@ class TestSerialization:
                 "measurement",
             ]
         )
-        assert abstract["device"] in [d.name for d in [*devices._valid_devices, *devices._mock_devices]]
+        assert abstract["device"] in [
+            d.name for d in [*devices._valid_devices, *devices._mock_devices]
+        ]
         assert abstract["register"] == [
             {"name": "control", "x": -2.0, "y": 0.0},
             {"name": "target", "x": 2.0, "y": 0.0},


### PR DESCRIPTION
Remove restriction that only Chadoq2 was supported for abstract sequence. 

It would be useful if this could also be released as 0.7.1 since we're using it for validating sequences in the cloud service.