### PR TITLE
Make SLM mask support device dependent

### DIFF
--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -45,6 +45,8 @@ class Device:
         interaction_coeff_xy: :math:`C_3/\hbar` (in :math:`\mu m^3 / \mu s`),
             which sets the van der Waals interaction strength between atoms in
             different Rydberg states.
+        supports_slm_mask: Whether the device supports the SLM mask feature.
+
     """
 
     name: str
@@ -56,6 +58,7 @@ class Device:
     _channels: tuple[tuple[str, Channel], ...]
     # Ising interaction coeff
     interaction_coeff_xy: float = 3700.0
+    supports_slm_mask: bool = False
     pre_calibrated_layouts: tuple[RegisterLayout, ...] = field(
         default_factory=tuple
     )

--- a/pulser-core/pulser/devices/_devices.py
+++ b/pulser-core/pulser/devices/_devices.py
@@ -24,6 +24,7 @@ Chadoq2 = Device(
     max_atom_num=100,
     max_radial_distance=50,
     min_atom_distance=4,
+    supports_slm_mask=True,
     _channels=(
         ("rydberg_global", Rydberg.Global(2 * np.pi * 20, 2 * np.pi * 2.5)),
         ("rydberg_local", Rydberg.Local(2 * np.pi * 20, 2 * np.pi * 10)),

--- a/pulser-core/pulser/devices/_mock_device.py
+++ b/pulser-core/pulser/devices/_mock_device.py
@@ -22,6 +22,7 @@ MockDevice = Device(
     max_atom_num=2000,
     max_radial_distance=1000,
     min_atom_distance=1,
+    supports_slm_mask=True,
     _channels=(
         (
             "rydberg_global",

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -353,6 +353,10 @@ class Sequence:
             qubits: Iterable of qubit ID's to mask during the first global
                 pulse of the sequence.
         """
+        if not self._device.supports_slm_mask:
+            raise ValueError(
+                f"The '{self._device}' device does not have an SLM mask."
+            )
         try:
             targets = set(qubits)
         except TypeError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ def mod_device() -> Device:
         max_atom_num=2000,
         max_radial_distance=1000,
         min_atom_distance=1,
+        supports_slm_mask=True,
         _channels=(
             (
                 "rydberg_global",

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -21,7 +21,7 @@ import pytest
 import pulser
 from pulser import Pulse, Register, Register3D, Sequence
 from pulser.channels import Raman, Rydberg
-from pulser.devices import Chadoq2, MockDevice
+from pulser.devices import Chadoq2, IroiseMVP, MockDevice
 from pulser.devices._device_datacls import Device
 from pulser.register.special_layouts import TriangularLatticeLayout
 from pulser.sequence.sequence import _TimeSlot
@@ -437,6 +437,10 @@ def test_sequence():
 def test_config_slm_mask():
     reg_s = Register({"q0": (0, 0), "q1": (10, 10), "q2": (-10, -10)})
     seq_s = Sequence(reg_s, device)
+
+    with pytest.raises(ValueError, match="does not have an SLM mask."):
+        seq_ = Sequence(reg_s, IroiseMVP)
+        seq_.config_slm_mask(["q0"])
 
     with pytest.raises(TypeError, match="must be castable to set"):
         seq_s.config_slm_mask(0)


### PR DESCRIPTION
I realized that currently we can program the SLM mask for every device, but not every device supports it. This makes the support  of the SLM mask (or lack thereof) explicit in the device configuration.