### PR TITLE
Introducing the `Device` vs `VirtualDevice` distinction

### DIFF
--- a/docs/source/apidoc/core.rst
+++ b/docs/source/apidoc/core.rst
@@ -71,28 +71,31 @@ Devices
 
 Structure of a Device
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The :class:`Device` class sets the structure of every device instance.
+The :class:`Device` class sets the structure of a physical device, 
+while :class:`VirtualDevice` is a more permissive device type which can
+only be used in emulators, as it does not necessarily represent the
+constraints of a physical device. 
 
-.. automodule:: pulser.devices._device_datacls
-   :members:
+Illustrative instances of :class:`Device` (see `Physical Devices`_) and :class:`VirtualDevice` 
+(the `MockDevice`) come included in the `pulser.devices` module.
+
+.. autoclass:: pulser.devices._device_datacls.Device
+  :members:
+
+.. autoclass:: pulser.devices._device_datacls.VirtualDevice
+  :members:
+
+.. _Physical Devices:
 
 Physical Devices
 ^^^^^^^^^^^^^^^^^^^
-Each device instance holds the characteristics of a physical device,
+Each `Device`` instance holds the characteristics of a physical device,
 which when associated with a :class:`pulser.Sequence` condition its development.
 
 .. autodata:: pulser.devices.Chadoq2
 
 .. autodata:: pulser.devices.IroiseMVP
 
-The MockDevice
-^^^^^^^^^^^^^^^^
-A very permissive device that supports sequences which are currently unfeasible
-on physical devices. Unlike with physical devices, its channels remain available
-after declaration and can be declared again so as to have multiple channels
-with the same characteristics.
-
-.. autodata:: pulser.devices.MockDevice
 
 Channels
 ^^^^^^^^^^^

--- a/pulser-core/pulser/channels.py
+++ b/pulser-core/pulser/channels.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import warnings
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from sys import version_info
 from typing import Any, Optional, cast
 
@@ -25,6 +25,7 @@ import numpy as np
 from numpy.typing import ArrayLike
 from scipy.fft import fft, fftfreq, ifft
 
+from pulser.json.utils import obj_to_dict
 from pulser.pulse import Pulse
 
 if version_info[:2] >= (3, 8):  # pragma: no cover
@@ -472,6 +473,9 @@ class Channel(ABC):
             config += f", Modulation Bandwidth: {self.mod_bandwidth} MHz"
         config += f", Basis: '{self.basis}')"
         return self.name + config
+
+    def _to_dict(self) -> dict[str, Any]:
+        return obj_to_dict(self, **asdict(self))
 
 
 @dataclass(init=True, repr=False, frozen=True)

--- a/pulser-core/pulser/devices/__init__.py
+++ b/pulser-core/pulser/devices/__init__.py
@@ -17,10 +17,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pulser.devices._device_datacls import Device
+from pulser.devices._device_datacls import Device, VirtualDevice
 from pulser.devices._devices import Chadoq2, IroiseMVP
 from pulser.devices._mock_device import MockDevice
 
 # Registers which devices can be used to avoid definition of custom devices
-_mock_devices: tuple[Device, ...] = (MockDevice,)
+_mock_devices: tuple[VirtualDevice, ...] = (MockDevice,)
 _valid_devices: tuple[Device, ...] = (Chadoq2, IroiseMVP)

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -86,7 +86,7 @@ class BaseDevice(ABC):
             if not isinstance(value, type_):
                 raise TypeError(
                     f"{param} must be of type '{type_.__name__}', "
-                    f"not '{type(value)}'."
+                    f"not '{type(value).__name__}'."
                 )
 
         type_check("name", str)
@@ -112,7 +112,7 @@ class BaseDevice(ABC):
             elif value is None:
                 raise TypeError(
                     f"'{param}' can't be None in a '{type(self).__name__}' "
-                    "device."
+                    "instance."
                 )
             else:
                 prelude = ""
@@ -295,7 +295,7 @@ class BaseDevice(ABC):
         # This is used instead of dataclasses.asdict() because asdict()
         # is recursive and we have Channel dataclasses in the args that
         # we don't want to convert to dict
-        return dict((f.name, getattr(self, f.name)) for f in fields(self))
+        return {f.name: getattr(self, f.name) for f in fields(self)}
 
     def _validate_coords(
         self, coords_dict: dict[QubitId, np.ndarray], kind: str = "atoms"

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -475,7 +475,7 @@ class VirtualDevice(BaseDevice):
     A VirtualDevice can only be used for emulation and allows some parameters
     to be left undefined. Furthermore, it optionally allows the same channel
     to be declared multiple times in the same Sequence (when
-    'reusable_channels=True') and allows the Rydberg level to be changed.
+    `reusable_channels=True`) and allows the Rydberg level to be changed.
 
     Attributes:
         name: The name of the device.

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -14,8 +14,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field, fields
+from sys import version_info
+from typing import Any, Optional, cast
+from warnings import warn
 
 import numpy as np
 from scipy.spatial.distance import pdist, squareform
@@ -26,10 +29,24 @@ from pulser.json.utils import obj_to_dict
 from pulser.register.base_register import BaseRegister, QubitId
 from pulser.register.register_layout import COORD_PRECISION, RegisterLayout
 
+if version_info[:2] >= (3, 8):  # pragma: no cover
+    from typing import Literal, get_args
+else:  # pragma: no cover
+    try:
+        from typing_extensions import Literal, get_args  # type: ignore
+    except ImportError:
+        raise ImportError(
+            "Using pulser with Python version 3.7 requires the"
+            " `typing_extensions` module. Install it by running"
+            " `pip install typing-extensions`."
+        )
 
-@dataclass(frozen=True, repr=False)
-class Device:
-    r"""Definition of a neutral-atom device.
+DIMENSIONS = Literal[2, 3]
+
+
+@dataclass(frozen=True, repr=False)  # type: ignore[misc]
+class BaseDevice(ABC):
+    r"""Base class of a neutral-atom device.
 
     Attributes:
         name: The name of the device.
@@ -45,36 +62,92 @@ class Device:
             which sets the van der Waals interaction strength between atoms in
             different Rydberg states.
         supports_slm_mask: Whether the device supports the SLM mask feature.
-
     """
-
     name: str
-    dimensions: int
+    dimensions: DIMENSIONS
     rydberg_level: int
-    max_atom_num: int
-    max_radial_distance: int
-    min_atom_distance: int
     _channels: tuple[tuple[str, Channel], ...]
-    # Ising interaction coeff
+    min_atom_distance: float
+    max_atom_num: Optional[int]
+    max_radial_distance: Optional[int]
     interaction_coeff_xy: float = 3700.0
     supports_slm_mask: bool = False
-    pre_calibrated_layouts: tuple[RegisterLayout, ...] = field(
-        default_factory=tuple
-    )
+    reusable_channels: bool = field(default=False, init=False)
 
     def __post_init__(self) -> None:
-        # Hack to override the docstring of an instance
-        for ch_id, ch_obj in self._channels:
-            if ch_obj.is_virtual():
-                _sep = "', '"
-                raise ValueError(
-                    "A 'Device' instance cannot contain virtual channels."
-                    f" For channel '{ch_id}', please define: "
-                    f"'{_sep.join(ch_obj._undefined_fields())}'"
+        def type_check(
+            param: str, type_: type, value_override: Any = None
+        ) -> None:
+            value = (
+                getattr(self, param)
+                if value_override is None
+                else value_override
+            )
+            if not isinstance(value, type_):
+                raise TypeError(
+                    f"{param} must be of type '{type_.__name__}', "
+                    f"not '{type(value)}'."
                 )
+
+        type_check("name", str)
+        if self.dimensions not in get_args(DIMENSIONS):
+            raise ValueError(
+                f"'dimensions' must be one of {get_args(DIMENSIONS)}, "
+                f"not {self.dimensions}."
+            )
+        self._validate_rydberg_level(self.rydberg_level)
+        for ch_id, ch_obj in self._channels:
+            type_check("All channel IDs", str, value_override=ch_id)
+            type_check("All channels", Channel, value_override=ch_obj)
+
+        for param in (
+            "min_atom_distance",
+            "max_atom_num",
+            "max_radial_distance",
+        ):
+            value = getattr(self, param)
+            if param in self._optional_parameters:
+                prelude = "When defined, "
+                is_none = value is None
+            elif value is None:
+                raise TypeError(
+                    f"'{param}' can't be None in a '{type(self).__name__}' "
+                    "device."
+                )
+            else:
+                prelude = ""
+                is_none = False
+
+            if param == "min_atom_distance":
+                comp = "greater than or equal to zero"
+                valid = is_none or value >= 0
+            else:
+                if not is_none:
+                    type_check(param, int)
+                comp = "greater than zero"
+                valid = is_none or value > 0
+            msg = prelude + f"'{param}' must be {comp}, not {value}."
+            if not valid:
+                raise ValueError(msg)
+
+        type_check("interaction_coeff_xy", float)
+        type_check("supports_slm_mask", bool)
+        type_check("reusable_channels", bool)
+
+        def to_tuple(obj: tuple | list) -> tuple:
+            if isinstance(obj, (tuple, list)):
+                obj = tuple(to_tuple(el) for el in obj)
+            return obj
+
+        # Turns mutable lists into immutable tuples
+        object.__setattr__(self, "_channels", to_tuple(self._channels))
+        # Hack to override the docstring of an instance
         object.__setattr__(self, "__doc__", self._specs(for_docs=True))
-        for layout in self.pre_calibrated_layouts:
-            self.validate_layout(layout)
+
+    @property
+    @abstractmethod
+    def _optional_parameters(self) -> tuple[str, ...]:
+        pass
 
     @property
     def channels(self) -> dict[str, Channel]:
@@ -91,11 +164,6 @@ class Device:
         r""":math:`C_6/\hbar` coefficient of chosen Rydberg level."""
         return float(c6_dict[self.rydberg_level])
 
-    @property
-    def calibrated_register_layouts(self) -> dict[str, RegisterLayout]:
-        """Register layouts already calibrated on this device."""
-        return {str(layout): layout for layout in self.pre_calibrated_layouts}
-
     def print_specs(self) -> None:
         """Prints the device specifications."""
         title = f"{self.name} Specifications"
@@ -105,23 +173,6 @@ class Device:
 
     def __repr__(self) -> str:
         return self.name
-
-    def change_rydberg_level(self, ryd_lvl: int) -> None:
-        """Changes the Rydberg level used in the Device.
-
-        Args:
-            ryd_lvl: the Rydberg level to use (between 50 and 100).
-
-        Note:
-            Modifications to the `rydberg_level` attribute only affect the
-            outcomes of local emulations.
-        """
-        if not isinstance(ryd_lvl, int):
-            raise TypeError("Rydberg level has to be an int.")
-        if not ((49 < ryd_lvl) & (101 > ryd_lvl)):
-            raise ValueError("Rydberg level should be between 50 and 100.")
-
-        object.__setattr__(self, "rydberg_level", ryd_lvl)
 
     def rydberg_blockade_radius(self, rabi_frequency: float) -> float:
         """Calculates the Rydberg blockade radius for a given Rabi frequency.
@@ -239,12 +290,12 @@ class Device:
 
         return "\n".join(lines + ch_lines)
 
-    def _validate_coords(
-        self, coords_dict: dict[QubitId, np.ndarray], kind: str = "atoms"
+    def _validate_atom_number(
+        self, coords: list[np.ndarray], kind: str
     ) -> None:
-        ids = list(coords_dict.keys())
-        coords = list(coords_dict.values())
-        max_number = self.max_atom_num * (2 if kind == "traps" else 1)
+        max_number = cast(int, self.max_atom_num) * (
+            2 if kind == "traps" else 1
+        )
         if len(coords) > max_number:
             raise ValueError(
                 f"The number of {kind} ({len(coords)})"
@@ -253,24 +304,37 @@ class Device:
                 f" ({max_number})."
             )
 
+    def _validate_atom_distance(
+        self, ids: list[QubitId], coords: list[np.ndarray], kind: str
+    ) -> None:
+        def invalid_dists(dists: np.ndarray) -> np.ndarray:
+            cond1 = dists - self.min_atom_distance < -(
+                10 ** (-COORD_PRECISION)
+            )
+            # Ensures there are no identical traps when
+            # min_atom_distance = 0
+            cond2 = dists < 10 ** (-COORD_PRECISION)
+            return cast(np.ndarray, np.logical_or(cond1, cond2))
+
         if len(coords) > 1:
             distances = pdist(coords)  # Pairwise distance between atoms
-            if np.any(
-                distances - self.min_atom_distance
-                < -(10 ** (-COORD_PRECISION))
-            ):
+            if np.any(invalid_dists(distances)):
                 sq_dists = squareform(distances)
                 mask = np.triu(np.ones(len(coords), dtype=bool), k=1)
                 bad_pairs = np.argwhere(
-                    np.logical_and(sq_dists < self.min_atom_distance, mask)
+                    np.logical_and(invalid_dists(sq_dists), mask)
                 )
                 bad_qbt_pairs = [(ids[i], ids[j]) for i, j in bad_pairs]
                 raise ValueError(
                     f"The minimal distance between {kind} in this device "
-                    f"({self.min_atom_distance} µm) is not respected for the "
-                    f"pairs: {bad_qbt_pairs}"
+                    f"({self.min_atom_distance} µm) is not respected "
+                    f"(up to a precision of 1e{-COORD_PRECISION} µm) "
+                    f"for the pairs: {bad_qbt_pairs}"
                 )
 
+    def _validate_radial_distance(
+        self, ids: list[QubitId], coords: list[np.ndarray], kind: str
+    ) -> None:
         too_far = np.linalg.norm(coords, axis=1) > self.max_radial_distance
         if np.any(too_far):
             raise ValueError(
@@ -279,7 +343,172 @@ class Device:
                 f"for: {[ids[int(i)] for i in np.where(too_far)[0]]}"
             )
 
+    def _validate_rydberg_level(self, ryd_lvl: int) -> None:
+        if not isinstance(ryd_lvl, int):
+            raise TypeError("Rydberg level has to be an int.")
+        if not ((49 < ryd_lvl) & (101 > ryd_lvl)):
+            raise ValueError("Rydberg level should be between 50 and 100.")
+
+    def _params(self) -> dict[str, Any]:
+        return dict((f.name, getattr(self, f.name)) for f in fields(self))
+
+    def _validate_coords(
+        self, coords_dict: dict[QubitId, np.ndarray], kind: str = "atoms"
+    ) -> None:
+        ids = list(coords_dict.keys())
+        coords = list(coords_dict.values())
+        if not (
+            "max_atom_num" in self._optional_parameters
+            and self.max_atom_num is None
+        ):
+            self._validate_atom_number(coords, kind)
+        self._validate_atom_distance(ids, coords, kind)
+        if not (
+            "max_radial_distance" in self._optional_parameters
+            and self.max_radial_distance is None
+        ):
+            self._validate_radial_distance(ids, coords, kind)
+
+    @abstractmethod
+    def _to_dict(self) -> dict[str, Any]:
+        pass
+
+
+@dataclass(frozen=True, repr=False)
+class Device(BaseDevice):
+    r"""Specifications of a neutral-atom device.
+
+    A Device instance is immutable and must have all of its parameters defined.
+    For usage in emulations, it can be converted to a VirtualDevice through the
+    `Device.to_virtual()` method.
+
+    Attributes:
+        name: The name of the device.
+        dimensions: Whether it supports 2D or 3D arrays.
+        rybderg_level : The value of the principal quantum number :math:`n`
+            when the Rydberg level used is of the form
+            :math:`|nS_{1/2}, m_j = +1/2\rangle`.
+        max_atom_num: Maximum number of atoms supported in an array.
+        max_radial_distance: The furthest away an atom can be from the center
+            of the array (in μm).
+        min_atom_distance: The closest together two atoms can be (in μm).
+        interaction_coeff_xy: :math:`C_3/\hbar` (in :math:`\mu m^3 / \mu s`),
+            which sets the van der Waals interaction strength between atoms in
+            different Rydberg states.
+        supports_slm_mask: Whether the device supports the SLM mask feature.
+        pre_calibrated_layouts: RegisterLayout instances that are already
+            available on the Device.
+    """
+    max_atom_num: int
+    max_radial_distance: int
+    pre_calibrated_layouts: tuple[RegisterLayout, ...] = field(
+        default_factory=tuple
+    )
+
+    def __post_init__(self) -> None:
+        for ch_id, ch_obj in self._channels:
+            if ch_obj.is_virtual():
+                _sep = "', '"
+                raise ValueError(
+                    "A 'Device' instance cannot contain virtual channels."
+                    f" For channel '{ch_id}', please define: "
+                    f"'{_sep.join(ch_obj._undefined_fields())}'"
+                )
+        for layout in self.pre_calibrated_layouts:
+            self.validate_layout(layout)
+        super().__post_init__()
+
+    @property
+    def _optional_parameters(self) -> tuple[str, ...]:
+        return ()
+
+    @property
+    def calibrated_register_layouts(self) -> dict[str, RegisterLayout]:
+        """Register layouts already calibrated on this device."""
+        return {str(layout): layout for layout in self.pre_calibrated_layouts}
+
+    def change_rydberg_level(self, ryd_lvl: int) -> None:
+        """Changes the Rydberg level used in the Device.
+
+        Args:
+            ryd_lvl: the Rydberg level to use (between 50 and 100).
+
+        Note:
+            Deprecated in version 0.8.0. Convert the device to a VirtualDevice
+            with 'Device.to_virtual()' and use
+            'VirtualDevice.change_rydberg_level()' instead.
+        """
+        warn(
+            "'Device.change_rydberg_level()' is deprecated and will be removed"
+            " in version 0.9.0.\nConvert the device to a VirtualDevice with "
+            "'Device.to_virtual()' and use "
+            "'VirtualDevice.change_rydberg_level()' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        # Ignoring type because it expects a VirtualDevice
+        # Won't fix because this line will be removed
+        VirtualDevice.change_rydberg_level(self, ryd_lvl)  # type: ignore
+
+    def to_virtual(self) -> VirtualDevice:
+        """Converts the Device into a VirtualDevice."""
+        params = self._params()
+        all_params_names = set(params)
+        target_params_names = {f.name for f in fields(VirtualDevice)}
+        for param in all_params_names - target_params_names:
+            del params[param]
+        return VirtualDevice(**params)
+
     def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(
             self, _build=False, _module="pulser.devices", _name=self.name
         )
+
+
+@dataclass(frozen=True)
+class VirtualDevice(BaseDevice):
+    r"""Specifications of a virtual neutral-atom device.
+
+    A VirtualDevice can only be used for emulation and allows some parameters
+    to be left undefined. Furthermore, it optionally allows the same channel
+    to be declared multiple times in the same Sequence (when
+    'reusable_channels=True') and allows the Rydberg level to be changed.
+
+    Attributes:
+        name: The name of the device.
+        dimensions: Whether it supports 2D or 3D arrays.
+        rybderg_level : The value of the principal quantum number :math:`n`
+            when the Rydberg level used is of the form
+            :math:`|nS_{1/2}, m_j = +1/2\rangle`.
+        max_atom_num: Maximum number of atoms supported in an array.
+        max_radial_distance: The furthest away an atom can be from the center
+            of the array (in μm).
+        min_atom_distance: The closest together two atoms can be (in μm).
+        interaction_coeff_xy: :math:`C_3/\hbar` (in :math:`\mu m^3 / \mu s`),
+            which sets the van der Waals interaction strength between atoms in
+            different Rydberg states.
+        supports_slm_mask: Whether the device supports the SLM mask feature.
+        reusable_channels: Whether each channel can be declared multiple times
+            on the same pulse sequence.
+    """
+    min_atom_distance: float = 0
+    max_atom_num: Optional[int] = None
+    max_radial_distance: Optional[int] = None
+    supports_slm_mask: bool = True
+    reusable_channels: bool = True
+
+    @property
+    def _optional_parameters(self) -> tuple[str, ...]:
+        return ("max_atom_num", "max_radial_distance")
+
+    def change_rydberg_level(self, ryd_lvl: int) -> None:
+        """Changes the Rydberg level used in the Device.
+
+        Args:
+            ryd_lvl: the Rydberg level to use (between 50 and 100).
+        """
+        self._validate_rydberg_level(ryd_lvl)
+        object.__setattr__(self, "rydberg_level", ryd_lvl)
+
+    def _to_dict(self) -> dict[str, Any]:
+        return obj_to_dict(self, _module="pulser.devices", **self._params())

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -292,6 +292,9 @@ class BaseDevice(ABC):
             raise ValueError("Rydberg level should be between 50 and 100.")
 
     def _params(self) -> dict[str, Any]:
+        # This is used instead of dataclasses.asdict() because asdict()
+        # is recursive and we have Channel dataclasses in the args that
+        # we don't want to convert to dict
         return dict((f.name, getattr(self, f.name)) for f in fields(self))
 
     def _validate_coords(

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -288,7 +288,7 @@ class BaseDevice(ABC):
     def _validate_rydberg_level(self, ryd_lvl: int) -> None:
         if not isinstance(ryd_lvl, int):
             raise TypeError("Rydberg level has to be an int.")
-        if not ((49 < ryd_lvl) & (101 > ryd_lvl)):
+        if not 49 < ryd_lvl < 101:
             raise ValueError("Rydberg level should be between 50 and 100.")
 
     def _params(self) -> dict[str, Any]:

--- a/pulser-core/pulser/devices/_mock_device.py
+++ b/pulser-core/pulser/devices/_mock_device.py
@@ -13,50 +13,21 @@
 # limitations under the License.
 
 from pulser.channels import Microwave, Raman, Rydberg
-from pulser.devices._device_datacls import Device
+from pulser.devices._device_datacls import VirtualDevice
 
-MockDevice = Device(
+MockDevice = VirtualDevice(
     name="MockDevice",
     dimensions=3,
     rydberg_level=70,
-    max_atom_num=2000,
-    max_radial_distance=1000,
-    min_atom_distance=1,
+    max_atom_num=None,
+    max_radial_distance=None,
+    min_atom_distance=0.0,
     supports_slm_mask=True,
     _channels=(
-        (
-            "rydberg_global",
-            Rydberg.Global(1000, 200, clock_period=1, min_duration=1),
-        ),
-        (
-            "rydberg_local",
-            Rydberg.Local(
-                1000,
-                200,
-                min_retarget_interval=0,
-                max_targets=2000,
-                clock_period=1,
-                min_duration=1,
-            ),
-        ),
-        (
-            "raman_global",
-            Raman.Global(1000, 200, clock_period=1, min_duration=1),
-        ),
-        (
-            "raman_local",
-            Raman.Local(
-                1000,
-                200,
-                min_retarget_interval=0,
-                max_targets=2000,
-                clock_period=1,
-                min_duration=1,
-            ),
-        ),
-        (
-            "mw_global",
-            Microwave.Global(1000, 200, clock_period=1, min_duration=1),
-        ),
+        ("rydberg_global", Rydberg.Global(None, None, max_duration=None)),
+        ("rydberg_local", Rydberg.Local(None, None, max_duration=None)),
+        ("raman_global", Raman.Global(None, None, max_duration=None)),
+        ("raman_local", Raman.Local(None, None, max_duration=None)),
+        ("mw_global", Microwave.Global(None, None, max_duration=None)),
     ),
 )

--- a/pulser-core/pulser/json/supported.py
+++ b/pulser-core/pulser/json/supported.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 import pulser.devices as devices
+from pulser.channels import CH_TYPE, get_args
 from pulser.json.exceptions import SerializationError
 
 SUPPORTED_BUILTINS = ("float", "int", "str", "set")
@@ -72,6 +73,7 @@ SUPPORTED_MODULES = {
     "pulser.devices": tuple(
         [dev.name for dev in devices._valid_devices] + ["MockDevice"]
     ),
+    "pulser.channels": tuple(get_args(CH_TYPE)),
     "pulser.pulse": ("Pulse",),
     "pulser.waveforms": (
         "CompositeWaveform",

--- a/pulser-core/pulser/json/supported.py
+++ b/pulser-core/pulser/json/supported.py
@@ -71,7 +71,7 @@ SUPPORTED_MODULES = {
     ),
     "pulser.register.mappable_reg": ("MappableRegister",),
     "pulser.devices": tuple(
-        [dev.name for dev in devices._valid_devices] + ["MockDevice"]
+        [dev.name for dev in devices._valid_devices] + ["VirtualDevice"]
     ),
     "pulser.channels": tuple(get_args(CH_TYPE)),
     "pulser.pulse": ("Pulse",),

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -210,7 +210,7 @@ class Register(BaseRegister, RegDrawer):
     def max_connectivity(
         cls,
         n_qubits: int,
-        device: pulser.devices._device_datacls.Device,
+        device: pulser.devices._device_datacls.BaseDevice,
         spacing: float = None,
         prefix: str = None,
     ) -> Register:
@@ -234,11 +234,8 @@ class Register(BaseRegister, RegDrawer):
             A register with qubits placed for maximum connectivity.
         """
         # Check device
-        if not isinstance(device, pulser.devices._device_datacls.Device):
-            raise TypeError(
-                "'device' must be of type 'Device'. Import a valid"
-                " device from 'pulser.devices'."
-            )
+        if not isinstance(device, pulser.devices._device_datacls.BaseDevice):
+            raise TypeError("'device' must be of type 'BaseDevice'.")
 
         # Check number of qubits (1 or above)
         if n_qubits < 1:
@@ -248,7 +245,7 @@ class Register(BaseRegister, RegDrawer):
             )
 
         # Check number of qubits (less than the max number of atoms)
-        if n_qubits > device.max_atom_num:
+        if device.max_atom_num is not None and n_qubits > device.max_atom_num:
             raise ValueError(
                 f"The number of qubits (`n_qubits` = {n_qubits})"
                 " must be less than or equal to the maximum"
@@ -256,6 +253,11 @@ class Register(BaseRegister, RegDrawer):
                 f" ({device.max_atom_num})."
             )
 
+        if not device.min_atom_distance > 0.0:
+            raise NotImplementedError(
+                "Maximum connectivity layouts are not well defined for a "
+                f"device with 'min_atom_distance={device.min_atom_distance}'."
+            )
         # Default spacing or check minimal distance
         if spacing is None:
             spacing = device.min_atom_distance

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -30,8 +30,7 @@ from numpy.typing import ArrayLike
 import pulser
 import pulser.sequence._decorators as seq_decorators
 from pulser.channels import Channel
-from pulser.devices import MockDevice
-from pulser.devices._device_datacls import Device
+from pulser.devices._device_datacls import BaseDevice
 from pulser.json.abstract_repr.deserializer import (
     deserialize_abstract_sequence,
 )
@@ -101,26 +100,15 @@ class Sequence:
     """
 
     def __init__(
-        self, register: Union[BaseRegister, MappableRegister], device: Device
+        self,
+        register: Union[BaseRegister, MappableRegister],
+        device: BaseDevice,
     ):
         """Initializes a new pulse sequence."""
-        if not isinstance(device, Device):
+        if not isinstance(device, BaseDevice):
             raise TypeError(
-                "'device' must be of type 'Device'. Import a valid"
-                " device from 'pulser.devices'."
+                f"'device' must be of type 'BaseDevice', not {type(device)}."
             )
-        cond1 = device not in pulser.devices._valid_devices
-        cond2 = device not in pulser.devices._mock_devices
-        if cond1 and cond2:
-            names = [d.name for d in pulser.devices._valid_devices]
-            warns_msg = (
-                "The Sequence's device should be imported from "
-                + "'pulser.devices'. Correct operation is not ensured"
-                + " for custom devices. Choose 'MockDevice'"
-                + " or one of the following real devices:\n"
-                + "\n".join(names)
-            )
-            warnings.warn(warns_msg, stacklevel=2)
 
         # Checks if register is compatible with the device
         if isinstance(register, MappableRegister):
@@ -129,7 +117,7 @@ class Sequence:
             device.validate_register(register)
 
         self._register: Union[BaseRegister, MappableRegister] = register
-        self._device: Device = device
+        self._device: BaseDevice = device
         self._in_xy: bool = False
         self._mag_field: Optional[tuple[float, float, float]] = None
         self._calls: list[_Call] = [_Call("__init__", (register, device), {})]
@@ -202,7 +190,9 @@ class Sequence:
             return {
                 id: ch
                 for id, ch in self._device.channels.items()
-                if (id not in occupied_ch_ids or self._device == MockDevice)
+                if (
+                    id not in occupied_ch_ids or self._device.reusable_channels
+                )
                 and (ch.basis == "XY" if self._in_xy else ch.basis != "XY")
             }
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -46,29 +46,6 @@ def test_init():
     assert Chadoq2.__repr__() == "Chadoq2"
 
 
-def test_mock():
-    dev = pulser.devices.MockDevice
-    assert dev.dimensions == 3
-    assert dev.rydberg_level > 49
-    assert dev.rydberg_level < 101
-    assert dev.max_atom_num > 1000
-    assert dev.min_atom_distance <= 1
-    assert dev.interaction_coeff > 0
-    assert dev.interaction_coeff_xy == 3700
-    names = ["Rydberg", "Raman", "Microwave"]
-    basis = ["ground-rydberg", "digital", "XY"]
-    for ch in dev.channels.values():
-        assert ch.name in names
-        assert ch.basis == basis[names.index(ch.name)]
-        assert ch.addressing in ["Local", "Global"]
-        assert ch.max_abs_detuning >= 1000
-        assert ch.max_amp >= 200
-        if ch.addressing == "Local":
-            assert ch.min_retarget_interval == 0
-            assert ch.max_targets > 1
-            assert ch.max_targets == int(ch.max_targets)
-
-
 def test_change_rydberg_level():
     dev = pulser.devices.MockDevice
     dev.change_rydberg_level(60)

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from dataclasses import FrozenInstanceError
 from unittest.mock import patch
 
@@ -26,7 +27,98 @@ from pulser.register.register_layout import RegisterLayout
 from pulser.register.special_layouts import TriangularLatticeLayout
 
 
-def test_init():
+@pytest.fixture
+def test_params():
+    return dict(
+        name="Test",
+        dimensions=2,
+        rydberg_level=70,
+        _channels=(),
+        min_atom_distance=1,
+        max_atom_num=None,
+        max_radial_distance=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "param, value, msg",
+    [
+        ("name", 1, None),
+        ("interaction_coeff_xy", 1000, None),
+        ("supports_slm_mask", 0, None),
+        ("reusable_channels", "true", None),
+        ("max_atom_num", 1e9, None),
+        ("max_radial_distance", 100.4, None),
+        ("rydberg_level", 70.0, "Rydberg level has to be an int."),
+        (
+            "_channels",
+            ((1, Rydberg.Global(None, None)),),
+            "All channel IDs must be of type 'str', not 'int'",
+        ),
+        (
+            "_channels",
+            (("ch1", "Rydberg.Global(None, None)"),),
+            "All channels must be of type 'Channel', not 'str'",
+        ),
+    ],
+)
+def test_post_init_type_checks(test_params, param, value, msg):
+    test_params[param] = value
+    error_msg = msg or f"{param} must be of type"
+    with pytest.raises(TypeError, match=error_msg):
+        VirtualDevice(**test_params)
+
+
+@pytest.mark.parametrize(
+    "param, value, msg",
+    [
+        (
+            "dimensions",
+            1,
+            re.escape("'dimensions' must be one of (2, 3), not 1."),
+        ),
+        ("rydberg_level", 49, "Rydberg level should be between 50 and 100."),
+        ("rydberg_level", 101, "Rydberg level should be between 50 and 100."),
+        (
+            "min_atom_distance",
+            -0.001,
+            "'min_atom_distance' must be greater than or equal to zero",
+        ),
+        ("max_atom_num", 0, None),
+        ("max_radial_distance", 0, None),
+    ],
+)
+def test_post_init_value_errors(test_params, param, value, msg):
+    test_params[param] = value
+    error_msg = msg or f"When defined, '{param}' must be greater than zero"
+    with pytest.raises(ValueError, match=error_msg):
+        VirtualDevice(**test_params)
+
+
+potential_params = ("max_atom_num", "max_radial_distance")
+
+
+@pytest.mark.parametrize("none_param", potential_params)
+def test_optional_parameters(test_params, none_param):
+    test_params.update({p: 10 for p in potential_params})
+    test_params[none_param] = None
+    with pytest.raises(
+        TypeError,
+        match=f"'{none_param}' can't be None in a 'Device' instance.",
+    ):
+        Device(**test_params)
+    VirtualDevice(**test_params)  # Valid as None on a VirtualDevice
+
+
+def test_tuple_conversion(test_params):
+    test_params["_channels"] = (
+        ["rydberg_global", Rydberg.Global(None, None)],
+    )
+    dev = VirtualDevice(**test_params)
+    assert dev._channels == (("rydberg_global", Rydberg.Global(None, None)),)
+
+
+def test_valid_devices():
     for dev in pulser.devices._valid_devices:
         assert dev.dimensions in (2, 3)
         assert dev.rydberg_level > 49
@@ -60,6 +152,7 @@ def test_change_rydberg_level():
     dev.change_rydberg_level(70)
 
     with pytest.warns(DeprecationWarning):
+        assert pulser.__version__ < "0.9"
         og_ryd_level = Chadoq2.rydberg_level
         Chadoq2.change_rydberg_level(60)
         assert Chadoq2.rydberg_level == 60

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -286,6 +286,8 @@ def test_convert_to_virtual():
         max_radial_distance=40,
         _channels=(("rydberg_global", Rydberg.Global(0, 10)),),
     )
-    assert Device(**params).to_virtual() == VirtualDevice(
+    assert Device(
+        pre_calibrated_layouts=(TriangularLatticeLayout(40, 2),), **params
+    ).to_virtual() == VirtualDevice(
         supports_slm_mask=False, reusable_channels=False, **params
     )

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -50,6 +50,18 @@ def test_encoder():
         encode(1j)
 
 
+def test_device(mod_device):
+    assert encode_decode(Chadoq2) == Chadoq2
+    with pytest.raises(SerializationError):
+        encode_decode(mod_device)
+
+
+def test_virtual_device(mod_device):
+    assert encode_decode(MockDevice) == MockDevice
+    virtual_mod = mod_device.to_virtual()
+    assert encode_decode(virtual_mod) == virtual_mod
+
+
 def test_register_2d():
     reg = Register({"c": (1, 2), "d": (8, 4)})
     seq = Sequence(reg, device=Chadoq2)

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -18,7 +18,7 @@ import numpy as np
 import pytest
 
 from pulser import Register, Register3D
-from pulser.devices import Chadoq2
+from pulser.devices import Chadoq2, MockDevice
 
 
 def test_creation():
@@ -184,6 +184,13 @@ def test_max_connectivity():
         reg = Register.max_connectivity(
             max_atom_num, device, spacing=spacing - 1.0
         )
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Maximum connectivity layouts are not well defined for a "
+        "device with 'min_atom_distance=0.0'.",
+    ):
+        Register.max_connectivity(1e9, MockDevice)
 
     # Check 1 atom
     reg = Register.max_connectivity(1, device)

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -37,12 +37,8 @@ device = Chadoq2
 
 
 def test_init():
-    with pytest.raises(TypeError, match="must be of type 'Device'"):
+    with pytest.raises(TypeError, match="must be of type 'BaseDevice'"):
         Sequence(reg, Device)
-
-    fake_device = Device("fake", 2, 70, 100, 100, 1, Chadoq2._channels)
-    with pytest.warns(UserWarning, match="imported from 'pulser.devices'"):
-        Sequence(reg, fake_device)
 
     seq = Sequence(reg, device)
     assert seq.qubit_info == reg.qubits
@@ -615,10 +611,8 @@ def test_hardware_constraints():
             ("raman_local", raman_local),
         ),
     )
-    with pytest.warns(
-        UserWarning, match="should be imported from 'pulser.devices'"
-    ):
-        seq = Sequence(reg, ConstrainedChadoq2)
+
+    seq = Sequence(reg, ConstrainedChadoq2)
     seq.declare_channel("ch0", "rydberg_global")
     seq.declare_channel("ch1", "raman_local", initial_target="q1")
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -183,6 +183,11 @@ def test_target():
 
     seq2 = Sequence(reg, MockDevice)
     seq2.declare_channel("ch0", "raman_local", initial_target={"q1", "q10"})
+
+    # Test unlimited targets with Local channel when 'max_targets=None'
+    assert seq2.declared_channels["ch0"].max_targets is None
+    seq2.target(set(reg.qubit_ids) - {"q2"}, "ch0")
+
     seq2.phase_shift(1, "q2")
     with pytest.raises(ValueError, match="qubits with different phase"):
         seq2.target({"q3", "q1", "q2"}, "ch0")


### PR DESCRIPTION
Prior to this PR, a `Device` instance was the only way to encode the device specs. Furthermore, these specs were not meant to be user defined but rather import from the `pulser.devices` module.
This PR makes the declaration of custom devices properly validated and introduces the concept of `VirtualDevice` - a device that is not realistic and thus is meant to be used only in emulators.

- Creates the `BaseDevice` ABC and its subclasses, `Device` and `VirtualDevice`
- Turns `MockDevice` into a `VirtualDevice` instance
- Adds checks to the initialisation parameters so that user-definition is properly validated
- Introduces full serialization for `VirtualDevice`