### PR TITLE
Adding optional slug to RegisterLayout

### DIFF
--- a/pulser-core/pulser/register/register_layout.py
+++ b/pulser-core/pulser/register/register_layout.py
@@ -57,9 +57,11 @@ class RegisterLayout(RegDrawer):
 
     Args:
         trap_coordinates: The trap coordinates defining the layout.
+        slug: An optional identifier for the layout.
     """
 
     trap_coordinates: ArrayLike
+    slug: Optional[str] = None
 
     def __post_init__(self) -> None:
         shape = np.array(self.trap_coordinates).shape
@@ -292,6 +294,9 @@ class RegisterLayout(RegDrawer):
 
     def __repr__(self) -> str:
         return f"RegisterLayout_{self._safe_hash().hex()}"
+
+    def __str__(self) -> str:
+        return self.slug or self.__repr__()
 
     def _to_dict(self) -> dict[str, Any]:
         # Allows for serialization of subclasses without a special _to_dict()

--- a/pulser-core/pulser/register/special_layouts.py
+++ b/pulser-core/pulser/register/special_layouts.py
@@ -37,8 +37,13 @@ class SquareLatticeLayout(RegisterLayout):
         self._rows = int(rows)
         self._columns = int(columns)
         self._spacing = int(spacing)
+        slug = (
+            f"SquareLatticeLayout({self._rows}x{self._columns}, "
+            f"{self._spacing}µm)"
+        )
         super().__init__(
-            patterns.square_rect(self._rows, self._columns) * self._spacing
+            patterns.square_rect(self._rows, self._columns) * self._spacing,
+            slug=slug,
         )
 
     def square_register(self, side: int, prefix: str = "q") -> Register:
@@ -90,12 +95,6 @@ class SquareLatticeLayout(RegisterLayout):
             Register, self.define_register(*trap_ids, qubit_ids=qubit_ids)
         )
 
-    def __str__(self) -> str:
-        return (
-            f"SquareLatticeLayout({self._rows}x{self._columns}, "
-            f"{self._spacing}µm)"
-        )
-
     def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(self, self._rows, self._columns, self._spacing)
 
@@ -111,7 +110,10 @@ class TriangularLatticeLayout(RegisterLayout):
     def __init__(self, n_traps: int, spacing: int):
         """Initializes a TriangularLatticeLayout."""
         self._spacing = int(spacing)
-        super().__init__(patterns.triangular_hex(int(n_traps)) * self._spacing)
+        slug = f"TriangularLatticeLayout({int(n_traps)}, {self._spacing}µm)"
+        super().__init__(
+            patterns.triangular_hex(int(n_traps)) * self._spacing, slug=slug
+        )
 
     def hexagonal_register(self, n_atoms: int, prefix: str = "q") -> Register:
         """Defines a register with an hexagonal shape.
@@ -163,12 +165,6 @@ class TriangularLatticeLayout(RegisterLayout):
         qubit_ids = [f"{prefix}{i}" for i in range(len(trap_ids))]
         return cast(
             Register, self.define_register(*trap_ids, qubit_ids=qubit_ids)
-        )
-
-    def __str__(self) -> str:
-        return (
-            f"TriangularLatticeLayout({self.number_of_traps}, "
-            f"{self._spacing}µm)"
         )
 
     def _to_dict(self) -> dict[str, Any]:

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -25,11 +25,18 @@ from pulser.register.special_layouts import (
     TriangularLatticeLayout,
 )
 
-layout = RegisterLayout([[0, 0], [1, 1], [1, 0], [0, 1]])
-layout3d = RegisterLayout([[0, 0, 0], [1, 1, 1], [0, 1, 0], [1, 0, 1]])
+
+@pytest.fixture
+def layout():
+    return RegisterLayout([[0, 0], [1, 1], [1, 0], [0, 1]], slug="2DLayout")
 
 
-def test_creation():
+@pytest.fixture
+def layout3d():
+    return RegisterLayout([[0, 0, 0], [1, 1, 1], [0, 1, 0], [1, 0, 1]])
+
+
+def test_creation(layout, layout3d):
     with pytest.raises(
         ValueError, match="must be an array or list of coordinates"
     ):
@@ -49,7 +56,14 @@ def test_creation():
         assert np.all(layout.traps_dict[i] == coord)
 
 
-def test_register_definition():
+def test_slug(layout, layout3d):
+    assert layout.slug == "2DLayout"
+    assert layout3d.slug is None
+    assert str(layout) == "2DLayout"
+    assert str(layout3d) == repr(layout3d)
+
+
+def test_register_definition(layout, layout3d):
     with pytest.raises(ValueError, match="must be a unique integer"):
         layout.define_register(0, 1, 1)
 
@@ -96,7 +110,7 @@ def test_register_definition():
         reg2d.rotate(30)
 
 
-def test_draw():
+def test_draw(layout, layout3d):
     with patch("matplotlib.pyplot.show"):
         layout.draw()
 
@@ -107,13 +121,13 @@ def test_draw():
         layout3d.draw(projection=False)
 
 
-def test_repr():
+def test_repr(layout):
     hash_ = sha256(bytes(2))
     hash_.update(layout.coords.tobytes())
     assert repr(layout) == f"RegisterLayout_{hash_.hexdigest()}"
 
 
-def test_eq():
+def test_eq(layout, layout3d):
     assert RegisterLayout([[0, 0], [1, 0]]) != Register.from_coordinates(
         [[0, 0], [1, 0]]
     )
@@ -124,7 +138,7 @@ def test_eq():
     assert hash(layout1) == hash(layout2)
 
 
-def test_traps_from_coordinates():
+def test_traps_from_coordinates(layout):
     assert layout._coords_to_traps == {
         (0, 0): 0,
         (0, 1): 1,


### PR DESCRIPTION
Adds an optional `slug` parameter to the `RegisterLayout` to allow easier identification of layouts.