### PR TITLE
Sorting targets in Sequence.__str__() for consistency

### DIFF
--- a/pulser-core/pulser/sequence/_seq_str.py
+++ b/pulser-core/pulser/sequence/_seq_str.py
@@ -38,8 +38,13 @@ def seq_to_str(sequence: Sequence) -> str:
                 full += delay_line.format(ts.ti, ts.tf)
                 continue
 
-            tgts = list(ts.targets)
-            tgt_txt = ", ".join([str(t) for t in tgts])
+            try:
+                tgts = sorted(ts.targets)
+            except TypeError:
+                raise NotImplementedError(
+                    "Can't print sequence with qubit IDs of different types."
+                )
+            tgt_txt = ", ".join(map(str, tgts))
             if isinstance(ts.type, Pulse):
                 full += pulse_line.format(ts.ti, ts.tf, ts.type, tgt_txt)
             elif ts.type == "target":

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -334,6 +334,22 @@ def test_str():
     )
     assert seq.__str__() == msg
 
+    seq2 = Sequence(Register({"q0": (0, 0), 1: (5, 5)}), device)
+    seq2.declare_channel("ch1", "rydberg_global")
+    with pytest.raises(
+        NotImplementedError,
+        match="Can't print sequence with qubit IDs of different types.",
+    ):
+        str(seq2)
+
+    # Check qubit IDs are sorted
+    seq3 = Sequence(Register({"q1": (0, 0), "q0": (5, 5)}), device)
+    seq3.declare_channel("ch2", "rydberg_global")
+    assert str(seq3) == (
+        "Channel: ch2\n"
+        "t: 0 | Initial targets: q0, q1 | Phase Reference: 0.0 \n\n"
+    )
+
 
 def test_sequence():
     seq = Sequence(reg, device)


### PR DESCRIPTION
As the targets of a channel are stored in a `set`, printing a sequence gave variable results because there was no order in the targets. With this change they are sorted and thus printing the same sequence will always give the same result.