### PR TITLE
Incorporate EOM mode operation in `Sequence`

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -72,6 +72,7 @@ computers and simulators, check the pages in :doc:`review`.
    tutorials/interpolated_wfs
    tutorials/serialization
    tutorials/slm_mask
+   tutorials/output_mod_eom
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/tutorials/output_mod_eom.nblink
+++ b/docs/source/tutorials/output_mod_eom.nblink
@@ -1,0 +1,3 @@
+{
+  "path": "../../../tutorials/advanced_features/Output Modulation and EOM Mode.ipynb"
+}

--- a/pulser-core/pulser/channels/eom.py
+++ b/pulser-core/pulser/channels/eom.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass, fields
 from enum import Flag
 from itertools import chain
-from typing import Any, List, cast
+from typing import Any
 
 import numpy as np
 
@@ -122,7 +122,7 @@ class RydbergEOM(BaseEOM):
 
     def detuning_off_options(
         self, rabi_frequency: float, detuning_on: float
-    ) -> list[float]:
+    ) -> np.ndarray:
         """Calculates the possible detuning values when the amplitude is off.
 
         Args:
@@ -157,7 +157,7 @@ class RydbergEOM(BaseEOM):
             lightshifts.append(0.0)
 
         # We sum the offset to all lightshifts to get the effective detuning
-        return cast(List[float], (offset + np.array(lightshifts)).tolist())
+        return np.array(lightshifts) + offset
 
     def _lightshift(
         self, rabi_frequency: float, *beams_on: RydbergBeam

--- a/pulser-core/pulser/channels/eom.py
+++ b/pulser-core/pulser/channels/eom.py
@@ -184,7 +184,7 @@ class RydbergEOM(BaseEOM):
             beam_amp = np.sqrt(2 * rabi_frequency * self.intermediate_detuning)
             return {beam: beam_amp for beam in RydbergBeam}
 
-        # The limiting beam is at the its maximum amplitude while the other
+        # The limiting beam is at its maximum amplitude while the other
         # has the necessary amplitude to reach the desired effective rabi freq
         return {
             self.limiting_beam: self.max_limiting_amp,

--- a/pulser-core/pulser/sampler/samples.py
+++ b/pulser-core/pulser/sampler/samples.py
@@ -86,6 +86,7 @@ class ChannelSamples:
     det: np.ndarray
     phase: np.ndarray
     slots: list[_TargetSlot] = field(default_factory=list)
+    # (t_start, t_end) of each EOM mode block
     eom_intervals: list[tuple[int, int]] = field(default_factory=list)
 
     def __post_init__(self) -> None:

--- a/pulser-core/pulser/sequence/_schedule.py
+++ b/pulser-core/pulser/sequence/_schedule.py
@@ -25,6 +25,7 @@ from pulser.channels.base_channel import Channel
 from pulser.pulse import Pulse
 from pulser.register.base_register import QubitId
 from pulser.sampler.samples import ChannelSamples, _TargetSlot
+from pulser.waveforms import ConstantWaveform
 
 
 class _TimeSlot(NamedTuple):
@@ -37,12 +38,22 @@ class _TimeSlot(NamedTuple):
 
 
 @dataclass
+class _EOMSettings:
+    rabi_freq: float
+    detuning_on: float
+    detuning_off: float
+    ti: int
+    tf: Optional[int] = None
+
+
+@dataclass
 class _ChannelSchedule:
     channel_id: str
     channel_obj: Channel
 
     def __post_init__(self) -> None:
         self.slots: list[_TimeSlot] = []
+        self.eom_blocks: list[_EOMSettings] = []
 
     def last_target(self) -> int:
         """Last time a target happened on the channel."""
@@ -50,6 +61,40 @@ class _ChannelSchedule:
             if slot.type == "target":
                 return slot.tf
         return 0  # pragma: no cover
+
+    def last_pulse_slot(self) -> _TimeSlot:
+        """The last slot with a Pulse."""
+        for slot in self.slots[::-1]:
+            if isinstance(slot.type, Pulse) and not self.is_eom_delay(slot):
+                return slot
+        raise RuntimeError("There is no slot with a pulse.")
+
+    def in_eom_mode(self, time_slot: Optional[_TimeSlot] = None) -> bool:
+        """States if a time slot is inside an EOM mode block."""
+        if time_slot is None:
+            return bool(self.eom_blocks) and (self.eom_blocks[-1].tf is None)
+        return any(
+            start <= time_slot.ti < end
+            for start, end in self.get_eom_mode_intervals()
+        )
+
+    def is_eom_delay(self, slot: _TimeSlot) -> bool:
+        """Tells if a pulse slot is actually an EOM delay."""
+        return (
+            self.in_eom_mode(time_slot=slot)
+            and isinstance(slot.type, Pulse)
+            and isinstance(slot.type.amplitude, ConstantWaveform)
+            and slot.type.amplitude[0] == 0.0
+        )
+
+    def get_eom_mode_intervals(self) -> list[tuple[int, int]]:
+        return [
+            (
+                block.ti,
+                block.tf if block.tf is not None else self.get_duration(),
+            )
+            for block in self.eom_blocks
+        ]
 
     def get_duration(self, include_fall_time: bool = False) -> int:
         temp_tf = 0
@@ -61,7 +106,11 @@ class _ChannelSchedule:
                     break
             if isinstance(op.type, Pulse):
                 temp_tf = max(
-                    temp_tf, op.tf + op.type.fall_time(self.channel_obj)
+                    temp_tf,
+                    op.tf
+                    + op.type.fall_time(
+                        self.channel_obj, in_eom_mode=self.in_eom_mode()
+                    ),
                 )
                 break
             elif temp_tf - op.tf >= 2 * self.channel_obj.rise_time:
@@ -101,7 +150,7 @@ class _ChannelSchedule:
             # Account for the extended duration of the pulses
             # after modulation, which is at most fall_time
             fall_time = pulse.fall_time(
-                self.channel_obj, in_eom_mode=self.in_eom_mode(t=s.ti)
+                self.channel_obj, in_eom_mode=self.in_eom_mode(time_slot=s)
             )
             tf += (
                 min(fall_time, channel_slots[ind + 1].ti - s.tf)
@@ -111,7 +160,9 @@ class _ChannelSchedule:
 
             slots.append(_TargetSlot(s.ti, tf, s.targets))
 
-        ch_samples = ChannelSamples(amp, det, phase, slots)
+        ch_samples = ChannelSamples(
+            amp, det, phase, slots, self.get_eom_mode_intervals()
+        )
 
         return ch_samples
 
@@ -168,6 +219,34 @@ class _Schedule(Dict[str, _ChannelSchedule]):
                 break
         return mask_time
 
+    def enable_eom(
+        self,
+        channel_id: str,
+        amp_on: float,
+        detuning_on: float,
+        detuning_off: float,
+    ) -> None:
+        channel_obj = self[channel_id].channel_obj
+        if any(isinstance(op.type, Pulse) for op in self[channel_id]):
+            # Wait for the last pulse to ramp down (if needed)
+            self.wait_for_fall(channel_id)
+            # Account for time needed to ramp to desired amplitude
+            self.add_delay(2 * channel_obj.rise_time, channel_id)
+
+        # Set up the EOM
+        eom_settings = _EOMSettings(
+            rabi_freq=amp_on,
+            detuning_on=detuning_on,
+            detuning_off=detuning_off,
+            ti=self[channel_id][-1].tf,
+        )
+
+        self[channel_id].eom_blocks.append(eom_settings)
+
+    def disable_eom(self, channel_id: str) -> None:
+        self[channel_id].eom_blocks[-1].tf = self[channel_id][-1].tf
+        self.wait_for_fall(channel_id)
+
     def add_pulse(
         self,
         pulse: Pulse,
@@ -181,25 +260,37 @@ class _Schedule(Dict[str, _ChannelSchedule]):
         current_max_t = max(t0, *phase_barrier_ts)
         phase_jump_buffer = 0
         for ch, ch_schedule in self.items():
-            if protocol == "no-delay" and ch != channel:
+            if protocol == "no-delay" or ch == channel:
                 continue
             this_chobj = self[ch].channel_obj
+            in_eom_mode = self[ch].in_eom_mode()
             for op in ch_schedule[::-1]:
                 if not isinstance(op.type, Pulse):
                     if op.tf + 2 * this_chobj.rise_time <= current_max_t:
                         # No pulse behind 'op' needing a delay
                         break
-                elif ch == channel:
-                    if op.type.phase != pulse.phase:
-                        phase_jump_buffer = this_chobj.phase_jump_time - (
-                            t0 - op.tf
-                        )
-                    break
-                elif op.tf + op.type.fall_time(this_chobj) <= current_max_t:
+                elif (
+                    op.tf
+                    + op.type.fall_time(this_chobj, in_eom_mode=in_eom_mode)
+                    <= current_max_t
+                ):
                     break
                 elif op.targets & last.targets or protocol == "wait-for-all":
-                    current_max_t = op.tf + op.type.fall_time(this_chobj)
+                    current_max_t = op.tf + op.type.fall_time(
+                        this_chobj, in_eom_mode=in_eom_mode
+                    )
                     break
+
+        try:
+            last_pulse_slot = self[channel].last_pulse_slot()
+            last_pulse = cast(Pulse, last_pulse_slot.type)
+            if last_pulse.phase != pulse.phase:
+                phase_jump_buffer = self[
+                    channel
+                ].channel_obj.phase_jump_time - (t0 - last_pulse_slot.tf)
+        except RuntimeError:
+            # No previous pulse
+            pass
 
         delay_duration = max(current_max_t - t0, phase_jump_buffer)
         if delay_duration > 0:
@@ -214,19 +305,30 @@ class _Schedule(Dict[str, _ChannelSchedule]):
         last = self[channel][-1]
         ti = last.tf
         tf = ti + self[channel].channel_obj.validate_duration(duration)
-        self[channel].slots.append(_TimeSlot("delay", ti, tf, last.targets))
+        if (
+            self[channel].in_eom_mode()
+            and self[channel].eom_blocks[-1].detuning_off != 0
+        ):
+            try:
+                last_pulse = cast(Pulse, self[channel].last_pulse_slot().type)
+                phase = last_pulse.phase
+            except RuntimeError:
+                phase = 0.0
+            delay_pulse = Pulse.ConstantPulse(
+                tf - ti, 0.0, self[channel].eom_blocks[-1].detuning_off, phase
+            )
+            self[channel].slots.append(
+                _TimeSlot(delay_pulse, ti, tf, last.targets)
+            )
+        else:
+            self[channel].slots.append(
+                _TimeSlot("delay", ti, tf, last.targets)
+            )
 
     def add_target(self, qubits_set: set[QubitId], channel: str) -> None:
         channel_obj = self[channel].channel_obj
         if self[channel].slots:
-            fall_time = (
-                self[channel].get_duration(include_fall_time=True)
-                - self[channel].get_duration()
-            )
-            if fall_time > 0:
-                self.add_delay(
-                    self[channel].adjust_duration(fall_time), channel
-                )
+            self.wait_for_fall(channel)
 
             last = self[channel][-1]
             if last.targets == qubits_set:
@@ -248,3 +350,12 @@ class _Schedule(Dict[str, _ChannelSchedule]):
         self[channel].slots.append(
             _TimeSlot("target", ti, tf, set(qubits_set))
         )
+
+    def wait_for_fall(self, channel: str) -> None:
+        """Adds a delay to let the channel's amplitude ramp down."""
+        fall_time = (
+            self[channel].get_duration(include_fall_time=True)
+            - self[channel].get_duration()
+        )
+        if fall_time > 0:
+            self.add_delay(self[channel].adjust_duration(fall_time), channel)

--- a/pulser-core/pulser/sequence/_seq_str.py
+++ b/pulser-core/pulser/sequence/_seq_str.py
@@ -28,7 +28,7 @@ def seq_to_str(sequence: Sequence) -> str:
     pulse_line = "t: {}->{} | {} | Targets: {}\n"
     target_line = "t: {}->{} | Target: {} | Phase Reference: {}\n"
     delay_line = "t: {}->{} | Delay \n"
-    # phase_line = "t: {} | Phase shift of: {:.3f} | Targets: {}\n"
+    eom_delay_line = "t: {}->{} | EOM Delay | Detuning: {:.3g} rad/µs\n"
     for ch, seq in sequence._schedule.items():
         basis = sequence.declared_channels[ch].basis
         full += f"Channel: {ch}\n"
@@ -46,7 +46,11 @@ def seq_to_str(sequence: Sequence) -> str:
                 )
             tgt_txt = ", ".join(map(str, tgts))
             if isinstance(ts.type, Pulse):
-                full += pulse_line.format(ts.ti, ts.tf, ts.type, tgt_txt)
+                if seq.is_eom_delay(ts):
+                    det = ts.type.detuning[0]
+                    full += eom_delay_line.format(ts.ti, ts.tf, det)
+                else:
+                    full += pulse_line.format(ts.ti, ts.tf, ts.type, tgt_txt)
             elif ts.type == "target":
                 phase = sequence._basis_ref[basis][tgts[0]].phase[ts.tf]
                 if first_slot:

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -722,7 +722,7 @@ class Sequence:
         channel: str,
         amp_on: Union[float, Parametrized],
         detuning_on: Union[float, Parametrized],
-        optimal_detuning_off: float = 0.0,
+        optimal_detuning_off: Union[float, Parametrized] = 0.0,
     ) -> None:
         """Puts a channel in EOM mode operation.
 
@@ -750,7 +750,7 @@ class Sequence:
             detuning_on: The detuning of the EOM pulses (in rad/µs).
             optimal_detuning_off: The optimal value of detuning when there is
                 no pulse being played. It will choose the closest value among
-                the existing option.
+                the existing options.
         """
         if self.is_in_eom_mode(channel):
             raise RuntimeError(
@@ -772,14 +772,15 @@ class Sequence:
                 RydbergEOM, channel_obj.eom_config
             ).detuning_off_options(amp_on, detuning_on)
 
-            closest_option = np.abs(
-                off_options - optimal_detuning_off
-            ).argmin()
-            detuning_off = off_options[closest_option]
-            off_pulse = Pulse.ConstantPulse(
-                channel_obj.min_duration, 0.0, detuning_off, 0.0
-            )
-            channel_obj.validate_pulse(off_pulse)
+            if not isinstance(optimal_detuning_off, Parametrized):
+                closest_option = np.abs(
+                    off_options - optimal_detuning_off
+                ).argmin()
+                detuning_off = off_options[closest_option]
+                off_pulse = Pulse.ConstantPulse(
+                    channel_obj.min_duration, 0.0, detuning_off, 0.0
+                )
+                channel_obj.validate_pulse(off_pulse)
 
             if not self.is_parametrized():
                 self._schedule.enable_eom(

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -632,11 +632,11 @@ class Sequence:
             ).detuning_off_options(amp_on, detuning_on)
 
             if detuning_off_choice == "closest-to-zero":
-                detuning_off = np.min(np.abs(off_options))
+                detuning_off = min(off_options, key=abs)
             elif detuning_off_choice == "lowest":
-                detuning_off = np.min(off_options)
+                detuning_off = min(off_options)
             elif detuning_off_choice == "highest":
-                detuning_off = np.max(off_options)
+                detuning_off = max(off_options)
             off_pulse = Pulse.ConstantPulse(
                 channel_obj.min_duration, 0.0, detuning_off, 0.0
             )

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -748,9 +748,9 @@ class Sequence:
             channel: The name of the channel to put in EOM mode.
             amp_on: The amplitude of the EOM pulses (in rad/µs).
             detuning_on: The detuning of the EOM pulses (in rad/µs).
-            optimal_detuning_off: The optimal value of detuning when there is
-                no pulse being played. It will choose the closest value among
-                the existing options.
+            optimal_detuning_off: The optimal value of detuning (in rad/µs)
+                when there is no pulse being played. It will choose the closest
+                value among the existing options.
         """
         if self.is_in_eom_mode(channel):
             raise RuntimeError(

--- a/tests/test_paramseq.py
+++ b/tests/test_paramseq.py
@@ -292,11 +292,6 @@ def test_parametrized_before_eom_mode(mod_device):
         seq.add_eom_pulse("ch0", 100, 0.0)
 
     with pytest.raises(
-        ValueError, match="Invalid option for the detuning choice"
-    ):
-        seq.enable_eom_mode("ch0", amp, 0.0, detuning_off_choice="zero")
-
-    with pytest.raises(
         TypeError, match="Channel 'raman' does not have an EOM"
     ):
         seq.enable_eom_mode("raman", 1.0, 0.0)

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -692,7 +692,7 @@ def test_str(mod_device):
     seq.target("q7", "ch0")
 
     seq.declare_channel("ch1", "rydberg_global")
-    seq.enable_eom_mode("ch1", 2, 0, detuning_off_choice="highest")
+    seq.enable_eom_mode("ch1", 2, 0, optimal_detuning_off=10.0)
     seq.add_eom_pulse("ch1", duration=100, phase=0, protocol="no-delay")
     seq.delay(500, "ch1")
 
@@ -1310,9 +1310,7 @@ def test_eom_mode(mod_device):
 
     amp_on = 1.0
     detuning_on = 0.0
-    seq.enable_eom_mode(
-        "ch0", amp_on, detuning_on, detuning_off_choice="lowest"
-    )
+    seq.enable_eom_mode("ch0", amp_on, detuning_on, optimal_detuning_off=-100)
     assert seq.is_in_eom_mode("ch0")
 
     delay_duration = 200

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -968,12 +968,14 @@ def test_simulation_with_modulation(mod_device, reg):
         ("control1", slice(mod_dt, 2 * mod_dt)),
     ]:
         np.testing.assert_allclose(
-            raman_samples[qid]["amp"][time_slice], pulse1_mod_samples
+            raman_samples[qid]["amp"][time_slice],
+            pulse1_mod_samples,
+            atol=1e-2,
         )
         np.testing.assert_equal(
             raman_samples[qid]["det"][time_slice], sim._doppler_detune[qid]
         )
-        np.testing.assert_equal(
+        np.testing.assert_allclose(
             raman_samples[qid]["phase"][time_slice], pulse1.phase
         )
 
@@ -996,7 +998,7 @@ def test_simulation_with_modulation(mod_device, reg):
         np.testing.assert_equal(
             rydberg_samples[qid]["det"][time_slice], sim._doppler_detune[qid]
         )
-        np.testing.assert_equal(
+        np.testing.assert_allclose(
             rydberg_samples[qid]["phase"][time_slice], pulse1.phase
         )
 

--- a/tutorials/advanced_features/Output Modulation and EOM Mode.ipynb
+++ b/tutorials/advanced_features/Output Modulation and EOM Mode.ipynb
@@ -38,7 +38,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When programming physical devices, you will likely come across the notion of *modulation bandwidth*. When a channel has a finite modulation bandwidth, its output (what actually comes out of the channel) is modulated when compared to its input (what is programmed in Pulser) because the component takes some ammount of time to reach the desired value. \n",
+    "When programming physical devices, you will likely come across the notion of *modulation bandwidth*. When a channel has a finite modulation bandwidth, its output (what actually comes out of the channel) is modulated when compared to its input (what is programmed in Pulser) because the component takes some amount of time to reach the desired value. \n",
     "\n",
     "To illustrate this, let us start by creating a channel with a defined modulation bandwidth."
    ]

--- a/tutorials/advanced_features/Output Modulation and EOM Mode.ipynb
+++ b/tutorials/advanced_features/Output Modulation and EOM Mode.ipynb
@@ -243,7 +243,7 @@
     "\n",
     "   1. EOM mode must be explicitly enabled (`Sequence.enable_eom_mode()`) and disabled (`Sequence.disable_eom_mode()`).\n",
     "   2. A buffering time is automatically added before the EOM mode is enabled and after it is disabled, as it needs to be isolated from regular channel operation.\n",
-    "   3. When enabling the EOM mode, one must choose the amplitude and detuning value that all square pulses will have. These values will also determine a set of options for the detuning during delays, out of which one value chosen.\n",
+    "   3. When enabling the EOM mode, one must choose the amplitude and detuning value that all square pulses will have. These values will also determine a set of options for the detuning during delays, out of which one is value chosen.\n",
     "   4. While in EOM mode, one can only add delays or pulses of variable duration (through `Sequence.add_eom_pulse()`) – changing the phase between pulses is also allowed, but the necessary buffer time for a phase jump will still be enforced."
    ]
   },

--- a/tutorials/advanced_features/Output Modulation and EOM Mode.ipynb
+++ b/tutorials/advanced_features/Output Modulation and EOM Mode.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Output Modulation & EOM Mode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from pulser import Sequence, Register, Pulse\n",
+    "from pulser.devices import VirtualDevice\n",
+    "from pulser.channels import Rydberg, Raman"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Output Modulation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Modulation Bandwidth"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When programming physical devices, you will likely come across the notion of *modulation bandwidth*. When a channel has a finite modulation bandwidth, its output (what actually comes out of the channel) is modulated when compared to its input (what is programmed in Pulser) because the component takes some ammount of time to reach the desired value. \n",
+    "\n",
+    "To illustrate this, let us start by creating a channel with a defined modulation bandwidth."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rydberg_ch = Rydberg.Global(\n",
+    "    max_abs_detuning=20 * 2 * np.pi,\n",
+    "    max_amp=10 * 2 * np.pi,\n",
+    "    mod_bandwidth=5,  # MHz\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With this channel object, we can check what the modulation of a waveform will look like. Let's take, for instance, a short square waveform:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pulser.waveforms import ConstantWaveform\n",
+    "\n",
+    "constant_wf = ConstantWaveform(duration=100, value=1)\n",
+    "constant_wf.draw(output_channel=rydberg_ch)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We observe two things:\n",
+    "    \n",
+    "   1. The output is streched when compared with the input. This is always the case, and we refer to the time it takes the output to ramp up as the `rise time`. \n",
+    "   2. The output does not have enough time to reach the maximum value set in the input. This happens only when the input pulse is too short.\n",
+    "\n",
+    "If we make the pulse long enough, we will see that it will still be extended on both sides by the rise time, but now it reaches the maximum value:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "constant_wf2 = ConstantWaveform(duration=300, value=1)\n",
+    "constant_wf2.draw(output_channel=rydberg_ch)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note also that all inputs are modulated, but the effect is most pronounced in square pulses. If we take, for example, a `BlackmanWaveform` of similar duration, we see the difference between input and output is more subtle (on the other hand, the output never gets a chance to reach the maximum value because the input is not held at the maximum value)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pulser.waveforms import BlackmanWaveform\n",
+    "\n",
+    "blackman_wf = BlackmanWaveform(300, 0.13)\n",
+    "blackman_wf.draw(output_channel=rydberg_ch)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Influence in a Sequence"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When creating a sequence on a device whose channels have a finite modulation bandwitdh, its effects are manifested in multiple ways. Let us start by creating such a device and making a simple pulse sequence with it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raman_ch = Raman.Local(\n",
+    "    max_abs_detuning=0,\n",
+    "    max_amp=20 * 2 * np.pi,\n",
+    "    fixed_retarget_t=50,\n",
+    "    mod_bandwidth=4,\n",
+    ")\n",
+    "\n",
+    "test_device = VirtualDevice(\n",
+    "    name=\"test_device\",\n",
+    "    dimensions=2,\n",
+    "    rydberg_level=60,\n",
+    "    _channels=(\n",
+    "        (\"rydberg_global\", rydberg_ch),\n",
+    "        (\"raman_local\", raman_ch),\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seq = Sequence(Register.square(2, prefix=\"q\"), test_device)\n",
+    "\n",
+    "seq.declare_channel(\"raman\", \"raman_local\", initial_target=\"q0\")\n",
+    "seq.declare_channel(\"rydberg\", \"rydberg_global\")\n",
+    "\n",
+    "seq.add(Pulse.ConstantDetuning(blackman_wf, -5, 0), \"rydberg\")\n",
+    "\n",
+    "short_pulse = Pulse.ConstantPulse(100, 1, 0, 0)\n",
+    "seq.add(short_pulse, \"raman\")\n",
+    "seq.target(\"q1\", \"raman\")\n",
+    "seq.add(short_pulse, \"raman\")\n",
+    "seq.delay(100, \"raman\")\n",
+    "long_pulse = Pulse.ConstantPulse(500, 1, 0, 0)\n",
+    "seq.add(long_pulse, \"raman\")\n",
+    "\n",
+    "seq.add(Pulse.ConstantDetuning(blackman_wf, 5, np.pi), \"rydberg\")\n",
+    "\n",
+    "seq.draw(draw_phase_curve=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default, `Sequence.draw()` will display both the programmed input and the modulated output. In this way, one can compare how the output will change with respect to the intended input.\n",
+    "\n",
+    "From looking at the output, there are multiple things to note:\n",
+    "\n",
+    "1. Not only the amplitude but also the detuning and phase are modulated, all with the same modulation bandwidth.\n",
+    "2. Alignment between channels takes into account the extended duration of the pulses in the other channels. Note, for instance, how the last pulse on the `rydberg` channel starts only after the output of the `raman` channel goes to zero.\n",
+    "3. Similarly, changing the target in a local channel will also wait for the output to ramp down before starting the retargeting.\n",
+    "4. For consecutive pulses in the same channel, there is no automatically imposed delay between them to allow one pulse to finish before the next one starts. As such, whenever the interval between two pulses is too short, they will be \"merged\" together, as is illustrated in the `raman` channel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Usage in Simulation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to get the most realistic results when simulating a sequence, it may be valuable to use the expected output rather than the programmed input. To do so, one can simply initialize the `Simulation` class with `with_modulation=True`.\n",
+    "Below, we simulate the sequence with and without modulation to assess the effect it has on the overlap between the resulting final states."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pulser_simulation import Simulation\n",
+    "\n",
+    "sim_in = Simulation(seq)\n",
+    "sim_out = Simulation(seq, with_modulation=True)\n",
+    "\n",
+    "input_final_state = sim_in.run().get_final_state()\n",
+    "output_final_state = sim_out.run().get_final_state()\n",
+    "\n",
+    "print(\"Final state overlap:\", input_final_state.overlap(output_final_state))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## EOM Mode Operation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The modulation bandwidth of a channel can impose significant limitations on how a pulse sequence is programmed. Perhaps most importantly, it can force the user to program longer pulses than would otherwise be required, resulting in longer sequences and consequently noisier results.\n",
+    "\n",
+    "To overcome these limitations, a channel can be equipped with an EOM that allows the execution of pulses with a higher modulation bandwidth. For now, EOM mode operation is reserved for `Rydberg` channels and works under very specific conditions:\n",
+    "\n",
+    "   1. EOM mode must be explicitly enabled (`Sequence.enable_eom_mode()`) and disabled (`Sequence.disable_eom_mode()`).\n",
+    "   2. A buffering time is automatically added before the EOM mode is enabled and after it is disabled, as it needs to be isolated from regular channel operation.\n",
+    "   3. When enabling the EOM mode, one must choose the amplitude and detuning value that all square pulses will have. These values will also determine a set of options for the detuning during delays, out of which one value chosen.\n",
+    "   4. While in EOM mode, one can only add delays or pulses of variable duration (through `Sequence.add_eom_pulse()`) – changing the phase between pulses is also allowed, but the necessary buffer time for a phase jump will still be enforced."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let us showcase these features with the `IroiseMVP` device, which features an EOM on its `rydberg_global` channel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pulser.devices import IroiseMVP\n",
+    "\n",
+    "seq = Sequence(Register.square(2, spacing=6), IroiseMVP)\n",
+    "seq.declare_channel(\"rydberg\", \"rydberg_global\")\n",
+    "\n",
+    "seq.add(Pulse.ConstantPulse(100, 1, 0, 0), \"rydberg\")\n",
+    "seq.enable_eom_mode(\"rydberg\", amp_on=1.0, detuning_on=0.0)\n",
+    "seq.add_eom_pulse(\"rydberg\", duration=100, phase=0.0)\n",
+    "seq.delay(200, \"rydberg\")\n",
+    "seq.add_eom_pulse(\"rydberg\", duration=60, phase=0.0)\n",
+    "seq.disable_eom_mode(\"rydberg\")\n",
+    "seq.add(Pulse.ConstantPulse(100, 1, 0, 0), \"rydberg\")\n",
+    "\n",
+    "seq.draw()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(seq)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As expected, inside the isolated EOM mode block in the middle we see that the pulses are much sharper, but we can only do square pulses with a fixed amplitude and there is some non-zero detuning in between them."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
- Adds EOM mode operation to `Sequence`
- Incorporates EOM mode modulation in the `sampler`
- Adds a tutorial on output modulation and EOM mode operation (purposefully stored without output; to check the output, see the readthedocs CI build)

Closes #367 , #418.