### PR TITLE
Make `Device.interaction_coeff_xy` optional by default

### DIFF
--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -60,7 +60,8 @@ class BaseDevice(ABC):
         min_atom_distance: The closest together two atoms can be (in μm).
         interaction_coeff_xy: :math:`C_3/\hbar` (in :math:`\mu m^3 / \mu s`),
             which sets the van der Waals interaction strength between atoms in
-            different Rydberg states.
+            different Rydberg states. Needed only if there is a Microwave
+            channel in the device. If unsure, 3700.0 is a good default value.
         supports_slm_mask: Whether the device supports the SLM mask feature.
     """
     name: str
@@ -70,7 +71,7 @@ class BaseDevice(ABC):
     min_atom_distance: float
     max_atom_num: Optional[int]
     max_radial_distance: Optional[int]
-    interaction_coeff_xy: float = 3700.0
+    interaction_coeff_xy: Optional[float] = None
     supports_slm_mask: bool = False
     reusable_channels: bool = field(default=False, init=False)
 
@@ -130,7 +131,14 @@ class BaseDevice(ABC):
             if not valid:
                 raise ValueError(msg)
 
-        type_check("interaction_coeff_xy", float)
+        if any(
+            ch.basis == "XY" for _, ch in self._channels
+        ) and not isinstance(self.interaction_coeff_xy, float):
+            raise TypeError(
+                "When the device has a 'Microwave' channel, "
+                "'interaction_coeff_xy' must be a 'float',"
+                f" not '{type(self.interaction_coeff_xy)}'."
+            )
         type_check("supports_slm_mask", bool)
         type_check("reusable_channels", bool)
 

--- a/pulser-core/pulser/devices/_mock_device.py
+++ b/pulser-core/pulser/devices/_mock_device.py
@@ -22,6 +22,7 @@ MockDevice = VirtualDevice(
     max_atom_num=None,
     max_radial_distance=None,
     min_atom_distance=0.0,
+    interaction_coeff_xy=3700.0,
     supports_slm_mask=True,
     _channels=(
         ("rydberg_global", Rydberg.Global(None, None, max_duration=None)),

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -650,7 +650,7 @@ class Simulation:
                 ) / (dist * mag_norm)
             U = (
                 0.5
-                * self._seq._device.interaction_coeff_xy
+                * cast(float, self._seq._device.interaction_coeff_xy)
                 * (1 - 3 * cosine**2)
                 / dist**3
             )

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -20,7 +20,7 @@ import numpy as np
 import pytest
 
 import pulser
-from pulser.channels import Rydberg
+from pulser.channels import Microwave, Rydberg
 from pulser.devices import Chadoq2, Device, VirtualDevice
 from pulser.register import Register, Register3D
 from pulser.register.register_layout import RegisterLayout
@@ -44,7 +44,6 @@ def test_params():
     "param, value, msg",
     [
         ("name", 1, None),
-        ("interaction_coeff_xy", 1000, None),
         ("supports_slm_mask", 0, None),
         ("reusable_channels", "true", None),
         ("max_atom_num", 1e9, None),
@@ -59,6 +58,13 @@ def test_params():
             "_channels",
             (("ch1", "Rydberg.Global(None, None)"),),
             "All channels must be of type 'Channel', not 'str'",
+        ),
+        (
+            "_channels",
+            (("mw_ch", Microwave.Global(None, None)),),
+            "When the device has a 'Microwave' channel, "
+            "'interaction_coeff_xy' must be a 'float',"
+            " not '<class 'NoneType'>'.",
         ),
     ],
 )
@@ -127,7 +133,6 @@ def test_valid_devices():
         assert dev.max_radial_distance > 10
         assert dev.min_atom_distance > 0
         assert dev.interaction_coeff > 0
-        assert dev.interaction_coeff_xy > 0
         assert isinstance(dev.channels, dict)
         with pytest.raises(FrozenInstanceError):
             dev.name = "something else"


### PR DESCRIPTION
To accompany upcoming changes in the abstract representation schema, the `Device.interaction_coeff_xy` parameter type is now `Optional[float]` and defaults to `None`. If there is a `Microwave` channel in the device, however, it is enforced to be a `float`.