### PR TITLE
Update `qutip` version to include latest patch

### DIFF
--- a/pulser-simulation/requirements.txt
+++ b/pulser-simulation/requirements.txt
@@ -1,2 +1,2 @@
-qutip>=4.6.3
+qutip>=4.7.1
 typing-extensions; python_version == '3.7'


### PR DESCRIPTION
Qutip was failing to install on Python 3.11 (see https://github.com/qutip/qutip/issues/2036) . With the latest patch, this has been fixed.