### PR TITLE
Maximum Layout Filling Fraction

### DIFF
--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -272,7 +272,7 @@ class BaseDevice(ABC):
             raise ValueError(
                 "Given the number of traps in the layout and the "
                 "device's maximum layout filling fraction, the given"
-                f"register has too many qubits ({n_qubits}). "
+                f" register has too many qubits ({n_qubits}). "
                 "On this device, this layout can hold at most "
                 f"{max_qubits} qubits."
             )

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -64,6 +64,8 @@ class BaseDevice(ABC):
             different Rydberg states. Needed only if there is a Microwave
             channel in the device. If unsure, 3700.0 is a good default value.
         supports_slm_mask: Whether the device supports the SLM mask feature.
+        max_layout_filling: The largest fraction of a layout that can be filled
+            with atoms.
     """
     name: str
     dimensions: DIMENSIONS
@@ -382,6 +384,8 @@ class Device(BaseDevice):
             which sets the van der Waals interaction strength between atoms in
             different Rydberg states.
         supports_slm_mask: Whether the device supports the SLM mask feature.
+        max_layout_filling: The largest fraction of a layout that can be filled
+            with atoms.
         pre_calibrated_layouts: RegisterLayout instances that are already
             available on the Device.
     """
@@ -456,15 +460,17 @@ class Device(BaseDevice):
 
     def _specs(self, for_docs: bool = False) -> str:
         lines = [
-            "\nRegister requirements:",
+            "\nRegister parameters:",
             f" - Dimensions: {self.dimensions}D",
-            rf" - Rydberg level: {self.rydberg_level}",
+            f" - Rydberg level: {self.rydberg_level}",
             f" - Maximum number of atoms: {self.max_atom_num}",
             f" - Maximum distance from origin: {self.max_radial_distance} μm",
             (
                 " - Minimum distance between neighbouring atoms: "
                 f"{self.min_atom_distance} μm"
             ),
+            f" - Maximum layout filling fraction: {self.max_layout_filling}",
+            f" - SLM Mask: {'Yes' if self.supports_slm_mask else 'No'}",
             "\nChannels:",
         ]
 
@@ -532,6 +538,8 @@ class VirtualDevice(BaseDevice):
             which sets the van der Waals interaction strength between atoms in
             different Rydberg states.
         supports_slm_mask: Whether the device supports the SLM mask feature.
+        max_layout_filling: The largest fraction of a layout that can be filled
+            with atoms.
         reusable_channels: Whether each channel can be declared multiple times
             on the same pulse sequence.
     """

--- a/pulser-core/pulser/register/mappable_reg.py
+++ b/pulser-core/pulser/register/mappable_reg.py
@@ -38,11 +38,10 @@ class MappableRegister:
     def __init__(self, register_layout: RegisterLayout, *qubit_ids: QubitId):
         """Initializes the mappable register."""
         self._layout = register_layout
-        if len(qubit_ids) > self._layout.max_atom_num:
+        if len(qubit_ids) > self._layout.number_of_traps:
             raise ValueError(
-                "The number of required traps is greater than the maximum "
-                "number of qubits allowed for this layout "
-                f"({self._layout.max_atom_num})."
+                "The number of required qubits is greater than the number of "
+                f"traps in this layout ({self._layout.number_of_traps})."
             )
         self._qubit_ids = qubit_ids
 

--- a/pulser-core/pulser/register/register_layout.py
+++ b/pulser-core/pulser/register/register_layout.py
@@ -171,7 +171,7 @@ class RegisterLayout(RegDrawer):
             raise ValueError("Every 'trap_id' must be a unique integer.")
 
         if not trap_ids_set.issubset(self.traps_dict):
-            # This check makes it redudant to check  # qubits <= # traps
+            # This check makes it redundant to check # qubits <= # traps
             raise ValueError(
                 "All 'trap_ids' must correspond to the ID of a trap."
             )

--- a/pulser-core/pulser/register/register_layout.py
+++ b/pulser-core/pulser/register/register_layout.py
@@ -171,6 +171,7 @@ class RegisterLayout(RegDrawer):
             raise ValueError("Every 'trap_id' must be a unique integer.")
 
         if not trap_ids_set.issubset(self.traps_dict):
+            # This check makes it redudant to check  # qubits <= # traps
             raise ValueError(
                 "All 'trap_ids' must correspond to the ID of a trap."
             )
@@ -186,11 +187,6 @@ class RegisterLayout(RegDrawer):
                     f"provided 'trap_ids' ({len(trap_ids)})."
                 )
 
-        if len(trap_ids) > self.number_of_traps:
-            raise ValueError(
-                "The number of required traps is greater than the number "
-                f"of traps in this layout ({self.number_of_traps})."
-            )
         ids = (
             qubit_ids if qubit_ids else [f"q{i}" for i in range(len(trap_ids))]
         )

--- a/pulser-core/pulser/register/register_layout.py
+++ b/pulser-core/pulser/register/register_layout.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from hashlib import sha256
 from sys import version_info
 from typing import Any, Optional, cast
+from warnings import warn
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -112,7 +113,15 @@ class RegisterLayout(RegDrawer):
     @property
     def max_atom_num(self) -> int:
         """Maximum number of atoms that can be trapped to form a Register."""
-        return self.number_of_traps // 2
+        warn(
+            "'RegisterLayout.max_atom_num' is deprecated and will be removed"
+            " in version 0.9.0.\n"
+            "It is now the same as 'RegisterLayout.number_of_traps' and "
+            "should be replaced accordingly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.number_of_traps
 
     @property
     def dimensionality(self) -> int:
@@ -177,11 +186,10 @@ class RegisterLayout(RegDrawer):
                     f"provided 'trap_ids' ({len(trap_ids)})."
                 )
 
-        if len(trap_ids) > self.max_atom_num:
+        if len(trap_ids) > self.number_of_traps:
             raise ValueError(
-                "The number of required traps is greater than the maximum "
-                "number of qubits allowed for this layout "
-                f"({self.max_atom_num})."
+                "The number of required traps is greater than the number "
+                f"of traps in this layout ({self.number_of_traps})."
             )
         ids = (
             qubit_ids if qubit_ids else [f"q{i}" for i in range(len(trap_ids))]

--- a/pulser-core/pulser/register/special_layouts.py
+++ b/pulser-core/pulser/register/special_layouts.py
@@ -80,7 +80,7 @@ class SquareLatticeLayout(RegisterLayout):
         """
         if rows > self._rows or columns > self._columns:
             raise ValueError(
-                f"A '{rows} x {columns}' array doesn't fit a "
+                f"A '{rows}x{columns}' array doesn't fit a "
                 f"{self._rows}x{self._columns} SquareLatticeLayout."
             )
         points = patterns.square_rect(rows, columns) * self._spacing
@@ -152,7 +152,7 @@ class TriangularLatticeLayout(RegisterLayout):
         """
         if rows * atoms_per_row > self.number_of_traps:
             raise ValueError(
-                f"A '{rows} x {atoms_per_row}' rectangular subset of a "
+                f"A '{rows}x{atoms_per_row}' rectangular subset of a "
                 "triangular lattice has more atoms than there are traps in "
                 f"this TriangularLatticeLayout ({self.number_of_traps})."
             )

--- a/pulser-core/pulser/register/special_layouts.py
+++ b/pulser-core/pulser/register/special_layouts.py
@@ -78,11 +78,6 @@ class SquareLatticeLayout(RegisterLayout):
         Returns:
             The register instance created from this layout.
         """
-        if rows * columns > self.max_atom_num:
-            raise ValueError(
-                f"A '{rows} x {columns}' array has more atoms than those "
-                f"available in this SquareLatticeLayout ({self.max_atom_num})."
-            )
         if rows > self._rows or columns > self._columns:
             raise ValueError(
                 f"A '{rows} x {columns}' array doesn't fit a "
@@ -127,10 +122,11 @@ class TriangularLatticeLayout(RegisterLayout):
         Returns:
             The register instance created from this layout.
         """
-        if n_atoms > self.max_atom_num:
+        if n_atoms > self.number_of_traps:
             raise ValueError(
-                f"This RegisterLayout can hold at most {self.max_atom_num} "
-                f"atoms, not '{n_atoms}'."
+                f"The desired register has more atoms ({n_atoms}) than there"
+                " are traps in this TriangularLatticeLayout"
+                f" ({self.number_of_traps})."
             )
         points = patterns.triangular_hex(n_atoms) * self._spacing
         trap_ids = self.get_traps_from_coordinates(*points)
@@ -154,11 +150,11 @@ class TriangularLatticeLayout(RegisterLayout):
         Returns:
             The register instance created from this layout.
         """
-        if rows * atoms_per_row > self.max_atom_num:
+        if rows * atoms_per_row > self.number_of_traps:
             raise ValueError(
                 f"A '{rows} x {atoms_per_row}' rectangular subset of a "
-                "triangular lattice has more atoms than those available in "
-                f"this TriangularLatticeLayout ({self.max_atom_num})."
+                "triangular lattice has more atoms than there are traps in "
+                f"this TriangularLatticeLayout ({self.number_of_traps})."
             )
         points = patterns.triangular_rect(rows, atoms_per_row) * self._spacing
         trap_ids = self.get_traps_from_coordinates(*points)

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -114,6 +114,7 @@ class Sequence:
         # Checks if register is compatible with the device
         if isinstance(register, MappableRegister):
             device.validate_layout(register.layout)
+            device.validate_layout_filling(register)
         else:
             device.validate_register(register)
 

--- a/tutorials/advanced_features/Register Layouts.ipynb
+++ b/tutorials/advanced_features/Register Layouts.ipynb
@@ -114,22 +114,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, `RegisterLayout.max_atom_num` fixes the maximum number of atoms it can hold (for now, this value is always equal to half the number of traps):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"Maximum number of atoms supported:\", layout.max_atom_num)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Register definition"
    ]
   },
@@ -363,6 +347,7 @@
     "    rydberg_level=70,\n",
     "    max_atom_num=100,\n",
     "    max_radial_distance=50,\n",
+    "    max_layout_filling=0.4,\n",
     "    min_atom_distance=4,\n",
     "    _channels=(\n",
     "        (\"rydberg_global\", Rydberg.Global(2 * np.pi * 20, 2 * np.pi * 2.5)),\n",
@@ -406,7 +391,7 @@
     "layout = TestDevice.calibrated_register_layouts[\n",
     "    \"SquareLatticeLayout(10x10, 4µm)\"\n",
     "]\n",
-    "reg = layout.square_register(7)\n",
+    "reg = layout.square_register(6)\n",
     "seq = Sequence(reg, TestDevice)"
    ]
   },
@@ -450,6 +435,40 @@
     ")  # On its own, this register is valid in TestDevice\n",
     "try:\n",
     "    seq = Sequence(good_reg, TestDevice)\n",
+    "except ValueError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Maximum Layout Filling Fraction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Through the `Device.max_layout_filling`, a device also specifies how much a layout can be filled. Although the default value is 0.5, some devices might have slightly higher or lower values. \n",
+    "\n",
+    "In the case of our `TestDevice`, we specified the maximum layout filling fraction to be 0.4 . This means that we can use up to 40% of a `RegisterLayout` to form our register.\n",
+    "\n",
+    "Let us see what would happen if we were to go over this value (e.g. by making a register of 49 atoms from a layout with 100 atoms):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layout = TestDevice.calibrated_register_layouts[\n",
+    "    \"SquareLatticeLayout(10x10, 4µm)\"\n",
+    "]\n",
+    "too_big_reg = layout.square_register(7)\n",
+    "try:\n",
+    "    seq = Sequence(too_big_reg, TestDevice)\n",
     "except ValueError as e:\n",
     "    print(e)"
    ]


### PR DESCRIPTION
This PR changes slightly how a register can be defined from a layout by the introducing the **maximum layout filling fraction** of a device.

Before:
- The maximum filling fraction was implicitly assumed to be 50% -> the layout knows the maximum amount of atoms it can hold
    - When defining a register on a layout, it checked right away if the number of atoms did not go over 0.5 * `number_of_traps`
    - When validated against a Device, a layout could have a maximum of (2 * `max_atom_num`) traps
    
Now:
- The maximum filling fraction is determined by the device -> the layout no longer knows the maximum amount of atoms it can hold
    - When defining a register on a layout, it only checks  if the number of atoms does not go over the `number_of_traps`
    - When validated against a Device, there is no longer a limit on the number of traps it can hold (though there is an implicit upper bound from enforcing `max_radial_distance` and `min_atom_distance`)
- When validating a register created from a layout against a device, we check that the (number of atoms <= number of traps in the layout* max_layout_filling) 

