### PR TITLE
Fix UT bug creating wrong numpy array

### DIFF
--- a/pulser-core/pulser/register/register_layout.py
+++ b/pulser-core/pulser/register/register_layout.py
@@ -68,11 +68,19 @@ class RegisterLayout(RegDrawer):
         self, trap_coordinates: ArrayLike, slug: Optional[str] = None
     ):
         """Initializes a RegisterLayout."""
-        shape = np.array(trap_coordinates).shape
+        array_type_error_msg = ValueError(
+            "'trap_coordinates' must be an array or list of coordinates."
+        )
+
+        try:
+            shape = np.array(trap_coordinates).shape
+        # Following lines are only being covered starting Python 3.11.1
+        except ValueError as e:  # pragma: no cover
+            raise array_type_error_msg from e  # pragma: no cover
+
         if len(shape) != 2:
-            raise ValueError(
-                "'trap_coordinates' must be an array or list of coordinates."
-            )
+            raise array_type_error_msg
+
         if shape[1] not in (2, 3):
             raise ValueError(
                 f"Each coordinate must be of size 2 or 3, not {shape[1]}."

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -45,7 +45,7 @@ def test_creation(layout, layout3d):
         RegisterLayout([[0, 0, 0], [1, 1], [1, 0], [0, 1]])
 
     with pytest.raises(
-            ValueError, match="must be an array or list of coordinates"
+        ValueError, match="must be an array or list of coordinates"
     ):
         RegisterLayout([0, 1, 2])
 

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -44,6 +44,11 @@ def test_creation(layout, layout3d):
     ):
         RegisterLayout([[0, 0, 0], [1, 1], [1, 0], [0, 1]])
 
+    with pytest.raises(
+            ValueError, match="must be an array or list of coordinates"
+    ):
+        RegisterLayout([0, 1, 2])
+
     with pytest.raises(ValueError, match="size 2 or 3"):
         RegisterLayout([[0], [1], [2]])
 


### PR DESCRIPTION
Fixes the following UT in *test_register_layout.py* which is newly failing:

```python
def test_creation(layout, layout3d):
    with pytest.raises(
        ValueError, match="must be an array or list of coordinates"
    ):
RegisterLayout([[0, 0, 0], [1, 1], [1, 0], [0, 1]])
```

This has happened on trying to merge #406 on the job https://github.com/pasqal-io/Pulser/actions/runs/3741008851/jobs/6350057707, only on Python 3.11.1, which may have changed the behavior of creating numpy arrays with inconsistent list sizes.