### PR TITLE
Disable `fail-fast` on `matrix` jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7", "3.11"]
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,7 @@ jobs:
     needs: deploy
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
   full-tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]


### PR DESCRIPTION
By default, when a job in a Github Actions `matrix`, all other pending jobs are cancelled. This has two major drawbacks:
- It prevents checking whether the issue is specific to a single version or OS
- It makes re-running failed jobs take longer because the cancelled jobs have to be re-run too

These changes should change this behaviour. The potential drawback is that resources will be wasted if there is indeed a bug that makes all jobs fail, but this shouldn't happen on extensive workflows like `test` because they screened by leaner workflows like `build` - it is highly unlikely that something would get past `build` and completely fail on `test`.