### PR TITLE
Facilitating the subclassing of `Channel`, `BaseDevice` and `Sequence`

### DIFF
--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -19,7 +19,7 @@ import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, fields
 from sys import version_info
-from typing import Any, Optional, cast
+from typing import Any, Optional, Type, TypeVar, cast
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -43,6 +43,8 @@ else:  # pragma: no cover
 
 # Warnings of adjusted waveform duration appear just once
 warnings.filterwarnings("once", "A duration of")
+
+ChannelType = TypeVar("ChannelType", bound="Channel")
 
 
 @dataclass(init=True, repr=False, frozen=True)  # type: ignore[misc]
@@ -224,14 +226,14 @@ class Channel(ABC):
 
     @classmethod
     def Local(
-        cls,
+        cls: Type[ChannelType],
         max_abs_detuning: Optional[float],
         max_amp: Optional[float],
         min_retarget_interval: int = 0,
         fixed_retarget_t: int = 0,
         max_targets: Optional[int] = None,
         **kwargs: Any,
-    ) -> Channel:
+    ) -> ChannelType:
         """Initializes the channel with local addressing.
 
         Args:
@@ -267,11 +269,11 @@ class Channel(ABC):
 
     @classmethod
     def Global(
-        cls,
+        cls: Type[ChannelType],
         max_abs_detuning: Optional[float],
         max_amp: Optional[float],
         **kwargs: Any,
-    ) -> Channel:
+    ) -> ChannelType:
         """Initializes the channel with global addressing.
 
         Args:

--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -492,11 +492,11 @@ class Channel(ABC):
         """Generates the default ID for indexing this channel in a Device."""
         return f"{self.name.lower()}_{self.addressing.lower()}"
 
-    def _to_dict(self) -> dict[str, Any]:
+    def _to_dict(self, _module="pulser.channels") -> dict[str, Any]:
         params = {
             f.name: getattr(self, f.name) for f in fields(self) if f.init
         }
-        return obj_to_dict(self, _module="pulser.channels", **params)
+        return obj_to_dict(self, _module=_module, **params)
 
     def _to_abstract_repr(self, id: str) -> dict[str, Any]:
         params = {f.name: getattr(self, f.name) for f in fields(self)}

--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -99,6 +99,15 @@ class Channel(ABC):
         """The addressed basis name."""
         pass
 
+    @property
+    def _internal_param_valid_options(self) -> dict[str, tuple[str, ...]]:
+        """Internal parameters and their valid options."""
+        return dict(
+            name=("Rydberg", "Raman", "Microwave"),
+            basis=("ground-rydberg", "digital", "XY"),
+            addressing=("Local", "Global"),
+        )
+
     def __post_init__(self) -> None:
         """Validates the channel's parameters."""
         for param, options in self._internal_param_valid_options.items():
@@ -173,15 +182,6 @@ class Channel(ABC):
                 " greater than or equal to 'min_duration'"
                 f"({self.min_duration})."
             )
-
-    @property
-    def _internal_param_valid_options(self) -> dict[str, tuple[str, ...]]:
-        """Internal parameters and their valid options."""
-        return dict(
-            name=("Rydberg", "Raman", "Microwave"),
-            basis=("ground-rydberg", "digital", "XY"),
-            addressing=("Local", "Global"),
-        )
 
     @property
     def rise_time(self) -> int:

--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -91,10 +91,7 @@ class Channel(ABC):
     @property
     def name(self) -> str:
         """The name of the channel."""
-        _name = type(self).__name__
-        options = self._internal_param_valid_options["name"]
-        assert _name, f"The channel must be one of {options}, not {_name}."
-        return _name
+        return type(self).__name__
 
     @property
     @abstractmethod

--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -492,7 +492,7 @@ class Channel(ABC):
         """Generates the default ID for indexing this channel in a Device."""
         return f"{self.name.lower()}_{self.addressing.lower()}"
 
-    def _to_dict(self, _module="pulser.channels") -> dict[str, Any]:
+    def _to_dict(self, _module: str = "pulser.channels") -> dict[str, Any]:
         params = {
             f.name: getattr(self, f.name) for f in fields(self) if f.init
         }

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -403,11 +403,15 @@ class BaseDevice(ABC):
         if not 49 < ryd_lvl < 101:
             raise ValueError("Rydberg level should be between 50 and 100.")
 
-    def _params(self) -> dict[str, Any]:
+    def _params(self, init_only: bool = False) -> dict[str, Any]:
         # This is used instead of dataclasses.asdict() because asdict()
         # is recursive and we have Channel dataclasses in the args that
         # we don't want to convert to dict
-        return {f.name: getattr(self, f.name) for f in fields(self)}
+        return {
+            f.name: getattr(self, f.name)
+            for f in fields(self)
+            if not init_only or f.init
+        }
 
     def _validate_coords(
         self, coords_dict: dict[QubitId, np.ndarray], kind: str = "atoms"

--- a/pulser-core/pulser/json/coders.py
+++ b/pulser-core/pulser/json/coders.py
@@ -101,7 +101,7 @@ class PulserDecoder(JSONDecoder):
         if not build:
             return cls
 
-        if obj_name == "Sequence":
+        if "Sequence" in obj_name:
             seq = cls(*obj["__args__"], **obj["__kwargs__"])
             for name, args, kwargs in obj["calls"]:
                 getattr(seq, name)(*args, **kwargs)

--- a/pulser-core/pulser/json/supported.py
+++ b/pulser-core/pulser/json/supported.py
@@ -73,7 +73,7 @@ SUPPORTED_MODULES = {
         [dev.name for dev in devices._valid_devices] + ["VirtualDevice"]
     ),
     "pulser.channels": ("Rydberg", "Raman", "Microwave"),
-    "pulser.channels.eom": ("RydbergEOM", "RydbergBeam"),
+    "pulser.channels.eom": ("BaseEOM", "RydbergEOM", "RydbergBeam"),
     "pulser.pulse": ("Pulse",),
     "pulser.waveforms": (
         "CompositeWaveform",

--- a/pulser-core/pulser/json/supported.py
+++ b/pulser-core/pulser/json/supported.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 import pulser.devices as devices
-from pulser.channels.base_channel import CH_TYPE, get_args
 from pulser.json.exceptions import SerializationError
 
 SUPPORTED_BUILTINS = ("float", "int", "str", "set")
@@ -73,7 +72,7 @@ SUPPORTED_MODULES = {
     "pulser.devices": tuple(
         [dev.name for dev in devices._valid_devices] + ["VirtualDevice"]
     ),
-    "pulser.channels": tuple(get_args(CH_TYPE)),
+    "pulser.channels": ("Rydberg", "Raman", "Microwave"),
     "pulser.channels.eom": ("RydbergEOM", "RydbergBeam"),
     "pulser.pulse": ("Pulse",),
     "pulser.waveforms": (

--- a/pulser-core/pulser/sequence/_schedule.py
+++ b/pulser-core/pulser/sequence/_schedule.py
@@ -237,9 +237,12 @@ class _Schedule(Dict[str, _ChannelSchedule]):
         amp_on: float,
         detuning_on: float,
         detuning_off: float,
+        _skip_buffer: bool = False,
     ) -> None:
         channel_obj = self[channel_id].channel_obj
-        if any(isinstance(op.type, Pulse) for op in self[channel_id]):
+        if not _skip_buffer and any(
+            isinstance(op.type, Pulse) for op in self[channel_id]
+        ):
             # Wait for the last pulse to ramp down (if needed)
             self.wait_for_fall(channel_id)
             # Account for time needed to ramp to desired amplitude
@@ -270,9 +273,10 @@ class _Schedule(Dict[str, _ChannelSchedule]):
 
         self[channel_id].eom_blocks.append(eom_settings)
 
-    def disable_eom(self, channel_id: str) -> None:
+    def disable_eom(self, channel_id: str, _skip_buffer: bool = False) -> None:
         self[channel_id].eom_blocks[-1].tf = self[channel_id][-1].tf
-        self.wait_for_fall(channel_id)
+        if not _skip_buffer:
+            self.wait_for_fall(channel_id)
 
     def add_pulse(
         self,

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -122,7 +122,9 @@ class Sequence:
         self._device: BaseDevice = device
         self._in_xy: bool = False
         self._mag_field: Optional[tuple[float, float, float]] = None
-        self._calls: list[_Call] = [_Call("__init__", (register, device), {})]
+        self._calls: list[_Call] = [
+            _Call("__init__", (), {"register": register, "device": device})
+        ]
         self._schedule: _Schedule = _Schedule()
         self._basis_ref: dict[str, dict[QubitId, _QubitRef]] = {}
         # IDs of all qubits in device
@@ -1488,11 +1490,11 @@ class Sequence:
             for qubit in target_ids:
                 self._basis_ref[basis][qubit].increment_phase(phi)
 
-    def _to_dict(self) -> dict[str, Any]:
+    def _to_dict(self, _module: str = "pulser.sequence") -> dict[str, Any]:
         d = obj_to_dict(
             self,
             *self._calls[0].args,
-            _module="pulser.sequence",
+            _module=_module,
             **self._calls[0].kwargs,
         )
         d["__version__"] = pulser.__version__

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -502,8 +502,8 @@ class Sequence:
                 raise ValueError(strict_error_message)
             else:
                 raise TypeError(ch_type_er_mess)
-        # Initialize the new sequence
-        new_seq = Sequence(self.register, new_device)
+        # Initialize the new sequence (works for Sequence subclasses too)
+        new_seq = type(self)(register=self.register, device=new_device)
 
         for call in self._calls[1:]:
             if not (call.name == "declare_channel"):

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -365,6 +365,20 @@ def test_convert_to_virtual():
     )
 
 
+def test_device_params():
+    all_params = Chadoq2._params()
+    init_params = Chadoq2._params(init_only=True)
+    assert set(all_params) - set(init_params) == {"reusable_channels"}
+
+    virtual_chadoq2 = Chadoq2.to_virtual()
+    all_virtual_params = virtual_chadoq2._params()
+    init_virtual_params = virtual_chadoq2._params(init_only=True)
+    assert all_virtual_params == init_virtual_params
+    assert set(all_params) - set(all_virtual_params) == {
+        "pre_calibrated_layouts"
+    }
+
+
 @pytest.mark.parametrize(
     "conflict_param, conflict_value",
     [("channel_objects", Rydberg.Global(0, 20)), ("channel_ids", "custom_id")],

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1070,7 +1070,7 @@ def test_mappable_register():
     assert seq.is_register_mappable()
     init_call = seq._calls[0]
     assert init_call.name == "__init__"
-    assert isinstance(init_call.args[0], MappableRegister)
+    assert isinstance(init_call.kwargs["register"], MappableRegister)
     assert not seq_.is_register_mappable()
     assert seq_.register == Register(
         {"q0": layout.traps_dict[10], "q2": layout.traps_dict[20]}


### PR DESCRIPTION
These changes are inconsequential for the functioning of `pulser-core` in isolation, but facilitate the subclassing of certain classes, which is useful for external projects and extensions.