### PR TITLE
Enable RTD fail on warning

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,13 +12,14 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: docs/source/conf.py
+  configuration: docs/source/conf.py
+  fail_on_warning: true
 
 # Optionally declare the Python requirements required to build your docs
 python:
-   install:
-     - requirements: docs/requirements.txt
-     - requirements: dev_requirements.txt
-     - requirements: pulser-core/rtd_requirements.txt
-     - requirements: pulser-simulation/rtd_requirements.txt
-     - requirements: pulser-pasqal/rtd_requirements.txt
+  install:
+    - requirements: docs/requirements.txt
+    - requirements: dev_requirements.txt
+    - requirements: pulser-core/rtd_requirements.txt
+    - requirements: pulser-simulation/rtd_requirements.txt
+    - requirements: pulser-pasqal/rtd_requirements.txt


### PR DESCRIPTION
As we have RTD automatically build the docs, sometimes there are warnings we miss that could have let us know something is not quite right.

Since our build runs without warnings under normal circumstances, we can let it fail in the presence of warnings so that we can catch them.