### PR TITLE
Delete pinning jsonschema to version 4.4.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 # For generating documentation.
 Sphinx
 sphinx-rtd-theme # documentation theme
-sphinx_autodoc_typehints
+sphinx_autodoc_typehints == 1.21.3
 nbsphinx
 nbsphinx-link
 ipython != 8.7.0 # Avoids bug with code highlighting

--- a/pulser-core/requirements.txt
+++ b/pulser-core/requirements.txt
@@ -1,4 +1,4 @@
-jsonschema == 4.4.0
+jsonschema
 matplotlib
 numpy >= 1.20
 scipy


### PR DESCRIPTION
I have deleted the requirement `jsonschema==4.4.0`.

Closes #454