### PR TITLE
Replace Iterable type checking in variable validation

### DIFF
--- a/pulser-core/pulser/sequence/_decorators.py
+++ b/pulser-core/pulser/sequence/_decorators.py
@@ -14,7 +14,7 @@
 """Custom decorators used by the Sequence class."""
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from functools import wraps
 from itertools import chain
 from typing import TYPE_CHECKING, Any, TypeVar, cast
@@ -58,10 +58,14 @@ def verify_variable(seq: Sequence, x: Any) -> None:
                     "Sequence's 'declare_variable' method as your"
                     "variables."
                 )
-    elif isinstance(x, Iterable) and not isinstance(x, str):
+    elif not isinstance(x, str):
         # Recursively look for parametrized objs inside the arguments
-        for y in x:
-            verify_variable(seq, y)
+        try:
+            for y in x:
+                verify_variable(seq, y)
+        except TypeError:
+            # x is not iterable, do nothing
+            pass
 
 
 def verify_parametrization(func: F) -> F:

--- a/tests/test_paramseq.py
+++ b/tests/test_paramseq.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+from collections.abc import Iterable
 
 import numpy as np
 import pytest
@@ -325,3 +326,15 @@ def test_parametrized_before_eom_mode(mod_device):
 
     # Just check that building works
     seq.build(amp=3.0)
+
+
+def test_iterable_variable_check():
+    seq = Sequence(reg, device)
+    seq.declare_channel("ch0", "rydberg_global")
+    #
+    delay_t = np.array(100)
+    # A 0-D array is identified as an Iterable but then fails iteration
+    # Giving this as an argument to a sequence call should still work
+    assert isinstance(delay_t, Iterable)
+    seq.delay(delay_t, "ch0")
+    assert seq.get_duration() == delay_t


### PR DESCRIPTION
When validating the arguments to calls where the arguments are potentially parametrized, there was a check for recursiveness for cases where e.g a parametrized element is inside an iterable. This check relied on a type check of the kind  `isinstance(x, Iterable)`, which essentially relied on the existence of an `__iter__` method in the object. This posed two issues:
1. Some objects are iterable because they define a `__getitem__` but not an `__iter__`
2. Crucially, some objects (in particular 0-D numpy arrays) have an `__iter__` method but then raise an error when it is called.

Because of these issues, I propose we replace the type check with a duck typing approach, where we simply try to iterate over the object and handle the case where it fails with a `try...except` block. This fixes both of the issues outlined above.