### PR TITLE
Cleaning up all warnings during tests

### DIFF
--- a/pulser-core/pulser/parametrized/paramobj.py
+++ b/pulser-core/pulser/parametrized/paramobj.py
@@ -303,8 +303,8 @@ class ParamObj(Parametrized, OpSupport):
     def __getattr__(self, name: str) -> ParamObj:
         if hasattr(self.cls, name):
             warnings.warn(
-                "Serialization of 'getattr' calls to parametrized "
-                "objects is not supported, so this object can't be serialied.",
+                "Serialization of 'getattr' calls to parametrized objects "
+                "is not supported, so this object can't be serialized.",
                 stacklevel=2,
             )
             return ParamObj(getattr, self, name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,11 @@ line-length = 79
 profile = "black"
 line_length = 79
 src_paths = ["pulser-core", "pulser-simulation", "pulser-pasqal"]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    # All warnings are turned into errors
+    "error",
+    # Except this particular warnings, which is ignored
+    'ignore:A duration of \d+ ns is not a multiple of:UserWarning',
+    ]

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -140,7 +140,8 @@ def test_rare_cases():
     with pytest.raises(
         ValueError, match="Serialization of calls to parametrized objects"
     ):
-        s = encode(wf.draw())
+        with pytest.warns(UserWarning, match="Serialization of 'getattr'"):
+            s = encode(wf.draw())
     s = encode(wf)
 
     with pytest.raises(ValueError, match="not encode a Sequence"):

--- a/tests/test_parametrized.py
+++ b/tests/test_parametrized.py
@@ -97,8 +97,9 @@ def test_paramobj():
     assert str(pulse2) == f"Pulse({str(bwf)}, {str(bwf)}, 1)"
     with pytest.raises(AttributeError):
         bwf._duration
-    time = bwf.duration
-    samps = bwf.samples
+    with pytest.warns(UserWarning, match="Serialization of 'getattr'"):
+        time = bwf.duration
+        samps = bwf.samples
     cwf = CompositeWaveform(bwf, bwf)
     t._assign(1000)
     a._assign(np.pi)

--- a/tests/test_pasqal.py
+++ b/tests/test_pasqal.py
@@ -87,10 +87,11 @@ def check_pasqal_cloud(fixt, seq, device_type, expected_seq_representation):
         "jobs": [{"runs": 10, "variables": {"qubits": None, "a": [3, 5]}}],
     }
 
-    fixt.pasqal_cloud.create_batch(
-        seq,
-        **create_batch_kwargs,
-    )
+    with pytest.warns(UserWarning, match="No declared variables named: a"):
+        fixt.pasqal_cloud.create_batch(
+            seq,
+            **create_batch_kwargs,
+        )
 
     fixt.mock_cloud_sdk.create_batch.assert_called_once_with(
         serialized_sequence=expected_seq_representation,
@@ -116,7 +117,9 @@ def check_pasqal_cloud(fixt, seq, device_type, expected_seq_representation):
     ],
 )
 def test_pasqal_cloud_emu(fixt, device_type, device):
-    reg = Register(dict(enumerate([(0, 0), (0, 10)])))
+    reg = Register.from_coordinates(
+        [(0, 0), (0, 10)], center=False, prefix="q"
+    )
     seq = Sequence(reg, device)
 
     check_pasqal_cloud(
@@ -169,14 +172,17 @@ def test_wrong_parameters(fixt):
     with pytest.raises(
         TypeError, match="Did not receive values for variables"
     ):
-        fixt.pasqal_cloud.create_batch(
-            seq,
-            jobs=[JobParameters(runs=10, variables=JobVariables(a=[3, 5]))],
-            device_type=DeviceType.QPU,
-            configuration=Configuration(
-                dt=0.1,
-                precision="normal",
-                extra_config=None,
-            ),
-            wait=True,
-        )
+        with pytest.warns(UserWarning, match="No declared variables named: a"):
+            fixt.pasqal_cloud.create_batch(
+                seq,
+                jobs=[
+                    JobParameters(runs=10, variables=JobVariables(a=[3, 5]))
+                ],
+                device_type=DeviceType.QPU,
+                configuration=Configuration(
+                    dt=0.1,
+                    precision="normal",
+                    extra_config=None,
+                ),
+                wait=True,
+            )

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -126,7 +126,8 @@ def test_initialization_and_construction_of_hamiltonian(seq):
             assert sh == sim.dim**sim._size
 
     assert not seq.is_parametrized()
-    seq_copy = seq.build()  # Take a copy of the sequence
+    with pytest.warns(UserWarning, match="returns a copy of itself"):
+        seq_copy = seq.build()  # Take a copy of the sequence
     x = seq_copy.declare_variable("x")
     seq_copy.add(Pulse.ConstantPulse(x, 1, 0, 0), "ryd")
     assert seq_copy.is_parametrized()


### PR DESCRIPTION
- Gets rid of all the warnings that were being raised during the units tests.
- Changes the pytest configuration to consider warnings as errors, so that they don't slip by in the future

Fixes #449 .