### PR TITLE
 Set an upper bound on the supported modulation bandwidth

### DIFF
--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -182,6 +182,13 @@ class Channel(ABC):
                 " greater than or equal to 'min_duration'"
                 f"({self.min_duration})."
             )
+        if (
+            self.mod_bandwidth is not None
+            and self.mod_bandwidth > MODBW_TO_TR * 1e3
+        ):
+            raise NotImplementedError(
+                f"'mod_bandwidth' must be lower than {MODBW_TO_TR*1e3} MHz"
+            )
 
     @property
     def rise_time(self) -> int:

--- a/pulser-core/pulser/channels/eom.py
+++ b/pulser-core/pulser/channels/eom.py
@@ -58,6 +58,10 @@ class BaseEOM:
                 "'mod_bandwidth' must be greater than zero, not"
                 f" {self.mod_bandwidth}."
             )
+        elif self.mod_bandwidth > MODBW_TO_TR * 1e3:
+            raise NotImplementedError(
+                f"'mod_bandwidth' must be lower than {MODBW_TO_TR*1e3} MHz"
+            )
 
     @property
     def rise_time(self) -> int:

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -19,7 +19,7 @@ import pytest
 
 import pulser
 from pulser.channels import Microwave, Raman, Rydberg
-from pulser.channels.eom import BaseEOM, RydbergBeam, RydbergEOM
+from pulser.channels.eom import MODBW_TO_TR, BaseEOM, RydbergBeam, RydbergEOM
 from pulser.waveforms import BlackmanWaveform, ConstantWaveform
 
 
@@ -32,12 +32,17 @@ from pulser.waveforms import BlackmanWaveform, ConstantWaveform
         ("min_duration", 0),
         ("max_duration", 0),
         ("mod_bandwidth", 0),
+        ("mod_bandwidth", MODBW_TO_TR * 1e3 + 1),
     ],
 )
 def test_bad_init_global_channel(bad_param, bad_value):
     kwargs = dict(max_abs_detuning=None, max_amp=None)
     kwargs[bad_param] = bad_value
-    with pytest.raises(ValueError, match=f"'{bad_param}' must be"):
+    if bad_param == "mod_bandwidth" and bad_value > 1:
+        error_type = NotImplementedError
+    else:
+        error_type = ValueError
+    with pytest.raises(error_type, match=f"'{bad_param}' must be"):
         Microwave.Global(**kwargs)
 
 
@@ -53,12 +58,17 @@ def test_bad_init_global_channel(bad_param, bad_value):
         ("min_duration", -2),
         ("max_duration", -1),
         ("mod_bandwidth", -1e4),
+        ("mod_bandwidth", MODBW_TO_TR * 1e3 + 1),
     ],
 )
 def test_bad_init_local_channel(bad_param, bad_value):
     kwargs = dict(max_abs_detuning=None, max_amp=None)
     kwargs[bad_param] = bad_value
-    with pytest.raises(ValueError, match=f"'{bad_param}' must be"):
+    if bad_param == "mod_bandwidth" and bad_value > 1:
+        error_type = NotImplementedError
+    else:
+        error_type = ValueError
+    with pytest.raises(error_type, match=f"'{bad_param}' must be"):
         Rydberg.Local(**kwargs)
 
 

--- a/tests/test_eom.py
+++ b/tests/test_eom.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from pulser.channels.eom import RydbergBeam, RydbergEOM
+from pulser.channels.eom import MODBW_TO_TR, RydbergBeam, RydbergEOM
 
 
 @pytest.fixture
@@ -33,6 +33,7 @@ def params():
     [
         ("mod_bandwidth", 0),
         ("mod_bandwidth", -3),
+        ("mod_bandwidth", MODBW_TO_TR * 1e3 + 1),
         ("max_limiting_amp", 0),
         ("intermediate_detuning", -500),
         ("intermediate_detuning", 0),
@@ -40,9 +41,15 @@ def params():
 )
 def test_bad_value_init_eom(bad_param, bad_value, params):
     params[bad_param] = bad_value
-    with pytest.raises(
-        ValueError, match=f"'{bad_param}' must be greater than zero"
-    ):
+    if bad_param == "mod_bandwidth" and bad_value > 0:
+        error_type = NotImplementedError
+        error_message = (
+            f"'mod_bandwidth' must be lower than {MODBW_TO_TR*1e3} MHz"
+        )
+    else:
+        error_type = ValueError
+        error_message = f"'{bad_param}' must be greater than zero"
+    with pytest.raises(error_type, match=error_message):
         RydbergEOM(**params)
 
 


### PR DESCRIPTION
I have set the upper bound to `MODBW_TO_TR*1e3` because this guarantees that the rise time `int(MODBW_TO_TR*1e3/mod_bandwidth)` is always above or equal to 1.