### PR TITLE
Update Pulser-Pasqal to the latest cloud-sdk syntax

### DIFF
--- a/pulser-pasqal/pulser_pasqal/__init__.py
+++ b/pulser-pasqal/pulser_pasqal/__init__.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 """Classes for interfacing with Pasqal backends."""
 
-from sdk import DeviceType, Endpoints
-from sdk.device.configuration import BaseConfig
+from sdk import BaseConfig, DeviceType, Endpoints
 
 from pulser_pasqal._version import __version__
 from pulser_pasqal.job_parameters import JobParameters, JobVariables

--- a/pulser-pasqal/pulser_pasqal/__init__.py
+++ b/pulser-pasqal/pulser_pasqal/__init__.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 """Classes for interfacing with Pasqal backends."""
 
-from sdk import Configuration, DeviceType, Endpoints
+from sdk import DeviceType, Endpoints
+from sdk.device.configuration import BaseConfig
 
 from pulser_pasqal._version import __version__
 from pulser_pasqal.job_parameters import JobParameters, JobVariables

--- a/pulser-pasqal/pulser_pasqal/job_parameters.py
+++ b/pulser-pasqal/pulser_pasqal/job_parameters.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Parameters to build a sequence sent to the PASQAL cloud plaftorm"""
+"""Parameters to build a sequence sent to the PASQAL cloud plaftorm."""
 from __future__ import annotations
 
 import dataclasses

--- a/pulser-pasqal/pulser_pasqal/job_parameters.py
+++ b/pulser-pasqal/pulser_pasqal/job_parameters.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Parameters to build a sequence sent to the cloud."""
+"""Parameters to build a sequence sent to the PASQAL cloud plaftorm"""
 from __future__ import annotations
 
 import dataclasses

--- a/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
+++ b/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
@@ -56,8 +56,9 @@ class PasqalCloud:
         seq: Sequence,
         jobs: list[JobParameters],
         device_type: sdk.DeviceType = sdk.DeviceType.QPU,
-        configuration: Optional[Union[sdk.device.configuration.BaseConfig, Dict[str, Any]]] = None,
+        configuration: Optional[sdk.device.configuration.BaseConfig] = None,
         wait: bool = False,
+        fetch_results: bool = False,
     ) -> sdk.Batch:
         """Create a new batch and send it to the API.
 
@@ -70,9 +71,9 @@ class PasqalCloud:
             device_type: The type of device to use, either an emulator or a QPU
                 If set to QPU, the device_type will be set to the one
                 stored in the serialized sequence.
-            configuration: A dictionary with extra configuration for the
-                emulators that accept it.
-            wait: Whether to wait for results to be sent back.
+            configuration: Optional xtra configuration for emulators.
+            wait: Whether to wait for the batch to be done.
+            fetch_results: Whether to download the results. Implies waiting for the batch.
 
         Returns:
             Batch: The new batch that has been created in the database.
@@ -96,6 +97,7 @@ class PasqalCloud:
             device_type=device_type,
             configuration=configuration,
             wait=wait,
+            fetch_results=fetch_results,
         )
 
     def _serialize_seq(
@@ -105,7 +107,7 @@ class PasqalCloud:
             return seq.serialize()
         return seq.to_abstract_repr()
 
-    def get_batch(self, id: int, fetch_results: bool = False) -> sdk.Batch:
+    def get_batch(self, id: str, fetch_results: bool = False) -> sdk.Batch:
         """Retrieve a batch's data and all its jobs.
 
         Args:

--- a/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
+++ b/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Allows to connect to the cloud powered by Pasqal to run sequences."""
+"""Allows to connect to PASQAL's cloud platform to run sequences."""
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Dict, Optional, Union
 
 import sdk
 
@@ -24,29 +24,30 @@ from pulser_pasqal.job_parameters import JobParameters
 
 
 class PasqalCloud:
-    """Manager of the connection to the cloud powered by Pasqal.
+    """Manager of the connection to PASQAL's cloud platform.
 
     The cloud connection enables to run sequences on simulators or on real
     QPUs.
 
     Args:
-        client_id: client_id of the API key you are holding for Pasqal
-            cloud.
-        client_secret: client_secret of the API key you are holding for
-            Pasqal cloud.
+        username: your username in the PASQAL cloud platform.
+        password: the password for your PASQAL cloud platform account.
+        group_id: the group_id associated to the account.
         kwargs: Additional arguments to provide to SDK
     """
 
     def __init__(
         self,
-        client_id: str,
-        client_secret: str,
+        username: str,
+        password: str,
+        group_id: str,
         **kwargs: Any,
     ):
-        """Initializes a connection to the cloud."""
+        """Initializes a connection to the Pasqal cloud platform."""
         self._sdk_connection = sdk.SDK(
-            client_id=client_id,
-            client_secret=client_secret,
+            username=username,
+            password=password,
+            group_id=group_id,
             **kwargs,
         )
 
@@ -55,7 +56,7 @@ class PasqalCloud:
         seq: Sequence,
         jobs: list[JobParameters],
         device_type: sdk.DeviceType = sdk.DeviceType.QPU,
-        configuration: Optional[sdk.Configuration] = None,
+        configuration: Optional[Union[sdk.device.configuration.BaseConfig, Dict[str, Any]]] = None,
         wait: bool = False,
     ) -> sdk.Batch:
         """Create a new batch and send it to the API.

--- a/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
+++ b/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
@@ -56,7 +56,7 @@ class PasqalCloud:
         seq: Sequence,
         jobs: list[JobParameters],
         device_type: sdk.DeviceType = sdk.DeviceType.QPU,
-        configuration: Optional[sdk.device.configuration.BaseConfig] = None,
+        configuration: Optional[sdk.BaseConfig] = None,
         wait: bool = False,
         fetch_results: bool = False,
     ) -> sdk.Batch:
@@ -71,7 +71,7 @@ class PasqalCloud:
             device_type: The type of device to use, either an emulator or a QPU
                 If set to QPU, the device_type will be set to the one
                 stored in the serialized sequence.
-            configuration: Optional xtra configuration for emulators.
+            configuration: Optional extra configuration for emulators.
             wait: Whether to wait for the batch to be done.
             fetch_results: Whether to download the results. Implies waiting for the batch. # noqa: 501
 
@@ -90,22 +90,13 @@ class PasqalCloud:
             seq.build(**params.variables.get_dict())  # type: ignore
 
         return self._sdk_connection.create_batch(
-            serialized_sequence=self._serialize_seq(
-                seq=seq, device_type=device_type
-            ),
+            serialized_sequence=seq.to_abstract_repr(),
             jobs=[j.get_dict() for j in jobs],
             device_type=device_type,
             configuration=configuration,
             wait=wait,
             fetch_results=fetch_results,
         )
-
-    def _serialize_seq(
-        self, seq: Sequence, device_type: sdk.DeviceType
-    ) -> str:
-        if device_type == sdk.DeviceType.QPU:
-            return seq.serialize()
-        return seq.to_abstract_repr()
 
     def get_batch(self, id: str, fetch_results: bool = False) -> sdk.Batch:
         """Retrieve a batch's data and all its jobs.

--- a/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
+++ b/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
@@ -14,7 +14,7 @@
 """Allows to connect to PASQAL's cloud platform to run sequences."""
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional
 
 import sdk
 
@@ -73,7 +73,7 @@ class PasqalCloud:
                 stored in the serialized sequence.
             configuration: Optional xtra configuration for emulators.
             wait: Whether to wait for the batch to be done.
-            fetch_results: Whether to download the results. Implies waiting for the batch.
+            fetch_results: Whether to download the results. Implies waiting for the batch. # noqa: 501
 
         Returns:
             Batch: The new batch that has been created in the database.

--- a/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
+++ b/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
@@ -38,9 +38,9 @@ class PasqalCloud:
 
     def __init__(
         self,
-        username: str,
-        password: str,
-        group_id: str,
+        username: str = "",
+        password: str = "",
+        group_id: str = "",
         **kwargs: Any,
     ):
         """Initializes a connection to the Pasqal cloud platform."""

--- a/pulser-pasqal/requirements.txt
+++ b/pulser-pasqal/requirements.txt
@@ -1,1 +1,1 @@
-pasqal-sdk == 0.1.6
+pasqal-sdk == 0.1.12

--- a/pulser-pasqal/requirements.txt
+++ b/pulser-pasqal/requirements.txt
@@ -1,1 +1,1 @@
-pasqal-sdk == 0.1.12
+pasqal-sdk ~= 0.1.12

--- a/tests/test_pasqal.py
+++ b/tests/test_pasqal.py
@@ -25,7 +25,7 @@ import pulser_pasqal
 from pulser.devices import Chadoq2
 from pulser.register import Register
 from pulser.sequence import Sequence
-from pulser_pasqal import Configuration, DeviceType, Endpoints, PasqalCloud
+from pulser_pasqal import BaseConfig, DeviceType, Endpoints, PasqalCloud
 from pulser_pasqal.job_parameters import JobParameters, JobVariables
 
 root = Path(__file__).parent.parent
@@ -45,8 +45,9 @@ class CloudFixture:
 def fixt():
     with patch("sdk.SDK", autospec=True) as mock_cloud_sdk_class:
         pasqal_cloud_kwargs = dict(
-            client_id="abc",
-            client_secret="def",
+            username="abc",
+            password="def",
+            group_id="ghi",
             endpoints=Endpoints(core="core_url", account="account_url"),
             webhook="xyz",
         )
@@ -74,11 +75,10 @@ def check_pasqal_cloud(fixt, seq, device_type, expected_seq_representation):
     create_batch_kwargs = dict(
         jobs=[JobParameters(runs=10, variables=JobVariables(a=[3, 5]))],
         device_type=device_type,
-        configuration=Configuration(
-            dt=0.1,
-            precision="normal",
-            extra_config=None,
-        ),
+        configuration={
+            "dt": 10.0,
+            "precision": "normal",
+        },
         wait=True,
     )
 
@@ -112,7 +112,7 @@ def check_pasqal_cloud(fixt, seq, device_type, expected_seq_representation):
     "device_type, device",
     [
         [device_type, device]
-        for device_type in (DeviceType.EMU_FREE, DeviceType.EMU_SV)
+        for device_type in (DeviceType.EMU_FREE, DeviceType.EMU_TN)
         for device in (test_device, virtual_device)
     ],
 )
@@ -155,11 +155,6 @@ def test_virtual_device_on_qpu_error(fixt):
             seq,
             jobs=[JobParameters(runs=10, variables=JobVariables(a=[3, 5]))],
             device_type=DeviceType.QPU,
-            configuration=Configuration(
-                dt=0.1,
-                precision="normal",
-                extra_config=None,
-            ),
             wait=True,
         )
 
@@ -176,10 +171,5 @@ def test_wrong_parameters(fixt):
             seq,
             jobs=[JobParameters(runs=10, variables=JobVariables(a=[3, 5]))],
             device_type=DeviceType.QPU,
-            configuration=Configuration(
-                dt=0.1,
-                precision="normal",
-                extra_config=None,
-            ),
             wait=True,
         )

--- a/tests/test_pasqal.py
+++ b/tests/test_pasqal.py
@@ -75,11 +75,14 @@ def check_pasqal_cloud(fixt, seq, device_type, expected_seq_representation):
     create_batch_kwargs = dict(
         jobs=[JobParameters(runs=10, variables=JobVariables(a=[3, 5]))],
         device_type=device_type,
-        configuration={
-            "dt": 10.0,
-            "precision": "normal",
-        },
+        configuration=BaseConfig(
+            extra_config={
+                "dt": 10.0,
+                "precision": "normal",
+            }
+        ),
         wait=True,
+        fetch_results=False,
     )
 
     expected_create_batch_kwargs = {
@@ -99,7 +102,7 @@ def check_pasqal_cloud(fixt, seq, device_type, expected_seq_representation):
     )
 
     get_batch_kwargs = dict(
-        id=10,
+        id="uuid",
         fetch_results=True,
     )
 

--- a/tests/test_pasqal.py
+++ b/tests/test_pasqal.py
@@ -144,7 +144,7 @@ def test_pasqal_cloud_qpu(fixt):
         fixt=fixt,
         seq=seq,
         device_type=device_type,
-        expected_seq_representation=seq.serialize(),
+        expected_seq_representation=seq.to_abstract_repr(),
     )
 
 

--- a/tests/test_pasqal.py
+++ b/tests/test_pasqal.py
@@ -137,7 +137,7 @@ def test_pasqal_cloud_qpu(fixt):
     device_type = DeviceType.QPU
     device = test_device
 
-    reg = Register(dict(enumerate([(0, 0), (0, 10)])))
+    reg = Register.from_coordinates([(0, 0), (0, 10)], prefix="q")
     seq = Sequence(reg, device)
 
     check_pasqal_cloud(
@@ -149,7 +149,7 @@ def test_pasqal_cloud_qpu(fixt):
 
 
 def test_virtual_device_on_qpu_error(fixt):
-    reg = Register(dict(enumerate([(0, 0), (0, 10)])))
+    reg = Register.from_coordinates([(0, 0), (0, 10)], prefix="q")
     device = Chadoq2.to_virtual()
     seq = Sequence(reg, device)
 
@@ -163,7 +163,7 @@ def test_virtual_device_on_qpu_error(fixt):
 
 
 def test_wrong_parameters(fixt):
-    reg = Register(dict(enumerate([(0, 0), (0, 10)])))
+    reg = Register.from_coordinates([(0, 0), (0, 10)], prefix="q")
     seq = Sequence(reg, test_device)
     seq.declare_variable("unset", dtype=int)
 


### PR DESCRIPTION
The PulserPasqal packge has an old version of the cloud-sdk. This MR bumps the version and implements the required interface for the latest version.