### PR TITLE
Implement custom exception for device deserialization

### DIFF
--- a/pulser-core/pulser/json/abstract_repr/deserializer.py
+++ b/pulser-core/pulser/json/abstract_repr/deserializer.py
@@ -288,22 +288,20 @@ def _deserialize_channel(obj: dict[str, Any]) -> Channel:
         if param.init and param.name != "eom_config":
             params[param.name] = obj[param.name]
     try:
-        ch_obj = channel_cls(**params)
+        return channel_cls(**params)
     except (ValueError, NotImplementedError) as e:
         raise AbstractReprError("Channel deserialization failed.") from e
-    return ch_obj
 
 
 def _deserialize_layout(layout_obj: dict[str, Any]) -> RegisterLayout:
     try:
-        reg_layout = RegisterLayout(
+        return RegisterLayout(
             layout_obj["coordinates"], slug=layout_obj.get("slug")
         )
     except ValueError as e:
         raise AbstractReprError(
             "Register layout deserialization failed."
         ) from e
-    return reg_layout
 
 
 def _deserialize_device_object(obj: dict[str, Any]) -> Device | VirtualDevice:
@@ -330,10 +328,9 @@ def _deserialize_device_object(obj: dict[str, Any]) -> Device | VirtualDevice:
         else:
             params[param.name] = obj[param.name]
     try:
-        device = device_cls(**params)
+        return device_cls(**params)
     except (ValueError, TypeError) as e:
         raise AbstractReprError("Device deserialization failed.") from e
-    return device
 
 
 def deserialize_abstract_sequence(obj_str: str) -> Sequence:
@@ -441,11 +438,10 @@ def deserialize_device(obj_str: str) -> BaseDevice:
         obj = json.loads(obj_str)
         # Validate the format of the data against the JSON schema.
         jsonschema.validate(instance=obj, schema=schemas["device"])
-        device = _deserialize_device_object(obj)
+        return _deserialize_device_object(obj)
     except (
         json.JSONDecodeError,  # From json.loads
         jsonschema.exceptions.ValidationError,  # From jsonschema.validate
         AbstractReprError,  # From _deserialize_device_object
     ) as e:
         raise DeserializeDeviceError from e
-    return device

--- a/pulser-core/pulser/json/abstract_repr/deserializer.py
+++ b/pulser-core/pulser/json/abstract_repr/deserializer.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Type, Union, cast, overload
 
 import jsonschema
+import jsonschema.exceptions
 
 import pulser
 import pulser.devices as devices
@@ -32,7 +33,7 @@ from pulser.json.abstract_repr.signatures import (
     BINARY_OPERATORS,
     UNARY_OPERATORS,
 )
-from pulser.json.exceptions import AbstractReprError
+from pulser.json.exceptions import AbstractReprError, DeserializeDeviceError
 from pulser.parametrized import ParamObj, Variable
 from pulser.pulse import Pulse
 from pulser.register.mappable_reg import MappableRegister
@@ -263,30 +264,48 @@ def _deserialize_channel(obj: dict[str, Any]) -> Channel:
         params["eom_config"] = None
         if obj["eom_config"] is not None:
             data = obj["eom_config"]
-            params["eom_config"] = RydbergEOM(
-                mod_bandwidth=data["mod_bandwidth"],
-                limiting_beam=RydbergBeam[data["limiting_beam"]],
-                max_limiting_amp=data["max_limiting_amp"],
-                intermediate_detuning=data["intermediate_detuning"],
-                controlled_beams=tuple(
-                    RydbergBeam[beam] for beam in data["controlled_beams"]
-                ),
-            )
+            try:
+                params["eom_config"] = RydbergEOM(
+                    mod_bandwidth=data["mod_bandwidth"],
+                    limiting_beam=RydbergBeam[data["limiting_beam"]],
+                    max_limiting_amp=data["max_limiting_amp"],
+                    intermediate_detuning=data["intermediate_detuning"],
+                    controlled_beams=tuple(
+                        RydbergBeam[beam] for beam in data["controlled_beams"]
+                    ),
+                )
+            except ValueError as e:
+                raise AbstractReprError(
+                    f"RydbergEOM deserialization failed with error: {e}"
+                )
     elif obj["basis"] == "digital":
         channel_cls = Raman
     elif obj["basis"] == "XY":
         channel_cls = Microwave
+    # No other basis allowed by the schema
 
     for param in dataclasses.fields(channel_cls):
         if param.init and param.name != "eom_config":
             params[param.name] = obj[param.name]
-    return channel_cls(**params)
+    try:
+        ch_obj = channel_cls(**params)
+    except (ValueError, NotImplementedError) as e:
+        raise AbstractReprError(
+            f"Channel deserialization failed with error: {e}"
+        )
+    return ch_obj
 
 
 def _deserialize_layout(layout_obj: dict[str, Any]) -> RegisterLayout:
-    return RegisterLayout(
-        layout_obj["coordinates"], slug=layout_obj.get("slug")
-    )
+    try:
+        reg_layout = RegisterLayout(
+            layout_obj["coordinates"], slug=layout_obj.get("slug")
+        )
+    except ValueError as e:
+        raise AbstractReprError(
+            f"Register layout deserialization failed with error: {e}"
+        )
+    return reg_layout
 
 
 def _deserialize_device_object(obj: dict[str, Any]) -> Device | VirtualDevice:
@@ -312,7 +331,13 @@ def _deserialize_device_object(obj: dict[str, Any]) -> Device | VirtualDevice:
             )
         else:
             params[param.name] = obj[param.name]
-    return device_cls(**params)
+    try:
+        device = device_cls(**params)
+    except (ValueError, TypeError) as e:
+        raise AbstractReprError(
+            f"Device deserialization failed with error: {e}"
+        )
+    return device
 
 
 def deserialize_abstract_sequence(obj_str: str) -> Sequence:
@@ -405,8 +430,25 @@ def deserialize_device(obj_str: str) -> BaseDevice:
 
     Returns:
         BaseDevice: The Pulser device.
+
+    Raises:
+        DeserializeDeviceError: Whenever the device deserialization
+        fails due to an invalid 'obj_str'.
     """
-    obj = json.loads(obj_str)
-    # Validate the format of the data against the JSON schema.
-    jsonschema.validate(instance=obj, schema=schemas["device"])
-    return _deserialize_device_object(obj)
+    if not isinstance(obj_str, str):
+        raise DeserializeDeviceError(
+            f"'obj_str' must be a string, not {type(obj_str)}."
+        )
+
+    try:
+        obj = json.loads(obj_str)
+        # Validate the format of the data against the JSON schema.
+        jsonschema.validate(instance=obj, schema=schemas["device"])
+        device = _deserialize_device_object(obj)
+    except (
+        json.JSONDecodeError,  # From json.loads
+        jsonschema.exceptions.ValidationError,  # From jsonschema.validate
+        AbstractReprError,  # From _deserialize_device_object
+    ) as e:
+        raise DeserializeDeviceError(e)
+    return device

--- a/pulser-core/pulser/json/abstract_repr/deserializer.py
+++ b/pulser-core/pulser/json/abstract_repr/deserializer.py
@@ -276,8 +276,8 @@ def _deserialize_channel(obj: dict[str, Any]) -> Channel:
                 )
             except ValueError as e:
                 raise AbstractReprError(
-                    f"RydbergEOM deserialization failed with error: {e}"
-                )
+                    "RydbergEOM deserialization failed."
+                ) from e
     elif obj["basis"] == "digital":
         channel_cls = Raman
     elif obj["basis"] == "XY":
@@ -290,9 +290,7 @@ def _deserialize_channel(obj: dict[str, Any]) -> Channel:
     try:
         ch_obj = channel_cls(**params)
     except (ValueError, NotImplementedError) as e:
-        raise AbstractReprError(
-            f"Channel deserialization failed with error: {e}"
-        )
+        raise AbstractReprError("Channel deserialization failed.") from e
     return ch_obj
 
 
@@ -303,8 +301,8 @@ def _deserialize_layout(layout_obj: dict[str, Any]) -> RegisterLayout:
         )
     except ValueError as e:
         raise AbstractReprError(
-            f"Register layout deserialization failed with error: {e}"
-        )
+            "Register layout deserialization failed."
+        ) from e
     return reg_layout
 
 
@@ -334,9 +332,7 @@ def _deserialize_device_object(obj: dict[str, Any]) -> Device | VirtualDevice:
     try:
         device = device_cls(**params)
     except (ValueError, TypeError) as e:
-        raise AbstractReprError(
-            f"Device deserialization failed with error: {e}"
-        )
+        raise AbstractReprError("Device deserialization failed.") from e
     return device
 
 
@@ -436,9 +432,10 @@ def deserialize_device(obj_str: str) -> BaseDevice:
         fails due to an invalid 'obj_str'.
     """
     if not isinstance(obj_str, str):
-        raise DeserializeDeviceError(
+        type_error = TypeError(
             f"'obj_str' must be a string, not {type(obj_str)}."
         )
+        raise DeserializeDeviceError from type_error
 
     try:
         obj = json.loads(obj_str)
@@ -450,5 +447,5 @@ def deserialize_device(obj_str: str) -> BaseDevice:
         jsonschema.exceptions.ValidationError,  # From jsonschema.validate
         AbstractReprError,  # From _deserialize_device_object
     ) as e:
-        raise DeserializeDeviceError(e)
+        raise DeserializeDeviceError from e
     return device

--- a/pulser-core/pulser/json/exceptions.py
+++ b/pulser-core/pulser/json/exceptions.py
@@ -28,3 +28,9 @@ class AbstractReprError(Exception):
     """
 
     pass
+
+
+class DeserializeDeviceError(Exception):
+    """Exception raised when device deserialization fails."""
+
+    pass

--- a/pulser-core/pulser/register/register_layout.py
+++ b/pulser-core/pulser/register/register_layout.py
@@ -72,11 +72,12 @@ class RegisterLayout(RegDrawer):
         )
 
         try:
-            shape = np.array(trap_coordinates).shape
+            coords_arr = np.array(trap_coordinates, dtype=float)
         # Following lines are only being covered starting Python 3.11.1
         except ValueError as e:  # pragma: no cover
             raise array_type_error_msg from e  # pragma: no cover
 
+        shape = coords_arr.shape
         if len(shape) != 2:
             raise array_type_error_msg
 
@@ -84,6 +85,12 @@ class RegisterLayout(RegDrawer):
             raise ValueError(
                 f"Each coordinate must be of size 2 or 3, not {shape[1]}."
             )
+
+        if len(np.unique(trap_coordinates, axis=0)) != shape[0]:
+            raise ValueError(
+                "All trap coordinates of a register layout must be unique."
+            )
+
         object.__setattr__(self, "_trap_coordinates", trap_coordinates)
         object.__setattr__(self, "slug", slug)
 

--- a/pulser-core/pulser/register/register_layout.py
+++ b/pulser-core/pulser/register/register_layout.py
@@ -73,9 +73,8 @@ class RegisterLayout(RegDrawer):
 
         try:
             coords_arr = np.array(trap_coordinates, dtype=float)
-        # Following lines are only being covered starting Python 3.11.1
-        except ValueError as e:  # pragma: no cover
-            raise array_type_error_msg from e  # pragma: no cover
+        except ValueError as e:
+            raise array_type_error_msg from e
 
         shape = coords_arr.shape
         if len(shape) != 2:

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -14,8 +14,10 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Callable
-from typing import Any
+from copy import deepcopy
+from typing import Any, Type
 from unittest.mock import patch
 
 import jsonschema
@@ -23,7 +25,7 @@ import numpy as np
 import pytest
 
 from pulser import Pulse, Register, Register3D, Sequence, devices
-from pulser.devices import Chadoq2, IroiseMVP, MockDevice
+from pulser.devices import Chadoq2, Device, IroiseMVP, MockDevice
 from pulser.json.abstract_repr.deserializer import (
     VARIABLE_TYPE_MAP,
     deserialize_device,
@@ -33,7 +35,7 @@ from pulser.json.abstract_repr.serializer import (
     AbstractReprEncoder,
     abstract_repr,
 )
-from pulser.json.exceptions import AbstractReprError
+from pulser.json.exceptions import AbstractReprError, DeserializeDeviceError
 from pulser.parametrized.decorators import parametrize
 from pulser.parametrized.paramobj import ParamObj
 from pulser.parametrized.variable import VariableItem
@@ -63,16 +65,127 @@ class TestDevice:
         device = request.param
         return json.loads(device.to_abstract_repr())
 
-    def test_device_schema(self, abstract_device):
+    @pytest.fixture
+    def device_schema(self):
         with open(
             "pulser-core/pulser/json/abstract_repr/schemas/device-schema.json"
         ) as f:
             dev_schema = json.load(f)
-        jsonschema.validate(instance=abstract_device, schema=dev_schema)
+        return dev_schema
+
+    def test_device_schema(self, abstract_device, device_schema):
+        jsonschema.validate(instance=abstract_device, schema=device_schema)
 
     def test_roundtrip(self, abstract_device):
         device = deserialize_device(json.dumps(abstract_device))
         assert json.loads(device.to_abstract_repr()) == abstract_device
+
+    def test_exceptions(self, abstract_device, device_schema):
+        def check_error_raised(
+            obj_str: str, original_err: Type[Exception], err_msg: str = ""
+        ) -> Exception:
+            with pytest.raises(DeserializeDeviceError) as exc_info:
+                deserialize_device(obj_str)
+
+            cause = exc_info.value.__cause__
+            assert isinstance(cause, original_err)
+            assert re.search(re.escape(err_msg), str(cause)) is not None
+            return cause
+
+        good_device = deserialize_device(json.dumps(abstract_device))
+
+        check_error_raised(
+            abstract_device, TypeError, "'obj_str' must be a string"
+        )
+
+        # JSONDecodeError from json.loads()
+        bad_str = "\ufeff"
+        with pytest.raises(
+            json.JSONDecodeError, match="Unexpected UTF-8 BOM"
+        ) as err:
+            json.loads(bad_str)
+        err_msg = str(err.value)
+        check_error_raised(bad_str, json.JSONDecodeError, err_msg)
+
+        # jsonschema.exceptions.ValidationError from jsonschema
+        invalid_dev = abstract_device.copy()
+        invalid_dev["rydberg_level"] = "70"
+        with pytest.raises(jsonschema.exceptions.ValidationError) as err:
+            jsonschema.validate(instance=invalid_dev, schema=device_schema)
+        check_error_raised(
+            json.dumps(invalid_dev),
+            jsonschema.exceptions.ValidationError,
+            str(err.value),
+        )
+
+        # AbstractReprError from invalid RydbergEOM configuration
+        if good_device.channels["rydberg_global"].eom_config:
+            bad_eom_dev = deepcopy(abstract_device)
+            for ch_dict in bad_eom_dev["channels"]:
+                if ch_dict["eom_config"]:
+                    assert "max_limiting_amp" in ch_dict["eom_config"]
+                    ch_dict["eom_config"]["max_limiting_amp"] = 0.0
+                    break
+            prev_err = check_error_raised(
+                json.dumps(bad_eom_dev),
+                AbstractReprError,
+                "RydbergEOM deserialization failed.",
+            )
+            assert isinstance(prev_err.__cause__, ValueError)
+
+        # AbstractReprError from ValueError in channel creation
+        bad_ch_dev1 = deepcopy(abstract_device)
+        bad_ch_dev1["channels"][0]["min_duration"] = -1
+        prev_err = check_error_raised(
+            json.dumps(bad_ch_dev1),
+            AbstractReprError,
+            "Channel deserialization failed.",
+        )
+        assert isinstance(prev_err.__cause__, ValueError)
+
+        # AbstractReprError from NotImplementedError in channel creation
+        bad_ch_dev2 = deepcopy(abstract_device)
+        bad_ch_dev2["channels"][0]["mod_bandwidth"] = 1000
+        prev_err = check_error_raised(
+            json.dumps(bad_ch_dev2),
+            AbstractReprError,
+            "Channel deserialization failed.",
+        )
+        assert isinstance(prev_err.__cause__, NotImplementedError)
+
+        # AbstractReprError from bad layout (only in physical devices)
+        if isinstance(good_device, Device):
+            bad_layout_dev = abstract_device.copy()
+            # Identical coords fail
+            bad_layout_obj = {"coordinates": [[0, 0], [0.0, 0.0]]}
+            bad_layout_dev["pre_calibrated_layouts"] = [bad_layout_obj]
+            prev_err = check_error_raised(
+                json.dumps(bad_layout_dev),
+                AbstractReprError,
+                "Register layout deserialization failed.",
+            )
+            assert isinstance(prev_err.__cause__, ValueError)
+
+        # AbstractReprError from TypeError in device init
+        if "XY" in good_device.supported_bases:
+            bad_xy_coeff_dev = abstract_device.copy()
+            bad_xy_coeff_dev["interaction_coeff_xy"] = None
+            prev_err = check_error_raised(
+                json.dumps(bad_xy_coeff_dev),
+                AbstractReprError,
+                "Device deserialization failed.",
+            )
+            assert isinstance(prev_err.__cause__, TypeError)
+
+        # AbstractReprError from ValueError in device init
+        bad_dev = abstract_device.copy()
+        bad_dev["min_atom_distance"] = -1
+        prev_err = check_error_raised(
+            json.dumps(bad_dev),
+            AbstractReprError,
+            "Device deserialization failed.",
+        )
+        assert isinstance(prev_err.__cause__, ValueError)
 
 
 def validate_schema(instance):

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -58,6 +58,12 @@ def test_creation(layout, layout3d):
     with pytest.raises(ValueError, match="size 2 or 3"):
         RegisterLayout([[0], [1], [2]])
 
+    with pytest.raises(
+        ValueError,
+        match="All trap coordinates of a register layout must be unique.",
+    ):
+        RegisterLayout([[0, 1], [0.0, 1.0]])
+
     assert np.all(layout.coords == [[0, 0], [0, 1], [1, 0], [1, 1]])
     assert np.all(
         layout3d.coords == [[0, 0, 0], [0, 1, 0], [1, 0, 1], [1, 1, 1]]

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import re
 from hashlib import sha256
 from unittest.mock import patch
@@ -39,13 +38,7 @@ def layout3d():
 
 
 def test_creation(layout, layout3d):
-    np_version = tuple(map(int, np.__version__.split(".")))
-    context_manager = (
-        pytest.warns(np.VisibleDeprecationWarning)
-        if np_version < (1, 24)
-        else contextlib.nullcontext()
-    )
-    with context_manager, pytest.raises(
+    with pytest.raises(
         ValueError, match="must be an array or list of coordinates"
     ):
         RegisterLayout([[0, 0, 0], [1, 1], [1, 0], [0, 1]])


### PR DESCRIPTION
- Creates `DeserializeDeviceError` and makes it the only error raised by `deserialize_device()`
- Adds an additional check to `RegisterLayout()` to forbid duplicates in trap coordinates

Fixes #478 .