### PR TITLE
Fix for sporadic CI fail on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - develop
-  pull_request:
 
 jobs:
   full-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - develop
+  pull_request:
 
 jobs:
   full-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   full-tests:
     runs-on: ${{ matrix.os }}
+    env:
+      # Set Matplotlib backend to fix flaky execution on Windows
+      MPLBACKEND: agg
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The CI test runs on `windows-os` occasionally fail due claiming "This probably means that Tcl wasn't installed properly.". 

If I understand correctly, this happens when matplotlib is involved, as it tries to use a backend for plotting that requires Tcl, which apparently is poorly installed on some of Github's Windows runners. 
To circumvent this, we can set the backend to `agg`, which no longer requires Tcl and so should work every time.

Note: I'll be temporarily enabling the `full-tests` workflow to run on this PR to check things are running smoothly. I'll then revert that change before merging.