### PR TITLE
Adapt CoherentResults.get_state() for density matrix states

### DIFF
--- a/tests/test_simresults.py
+++ b/tests/test_simresults.py
@@ -97,8 +97,7 @@ def test_initialization():
 @pytest.mark.parametrize("noisychannel", [True, False])
 def test_get_final_state(noisychannel):
     _results = results_noisych if noisychannel else results
-    if noisychannel:
-        assert _results.get_final_state().isoper
+    assert _results.get_final_state().isoper or not noisychannel
     with pytest.raises(TypeError, match="Can't reduce"):
         _results.get_final_state(reduce_to_basis="digital")
     assert (


### PR DESCRIPTION
Skip `ignore_global_phase` if the state is a density matrix state.
raise a not ImplementedError if the basis is `digital` or `all basis`

Fixes #493 