### PR TITLE
Impose qubit order in MappableRegister

### DIFF
--- a/pulser-core/pulser/json/abstract_repr/serializer.py
+++ b/pulser-core/pulser/json/abstract_repr/serializer.py
@@ -153,7 +153,7 @@ def serialize_abstract_sequence(
         og_dim = target_array.ndim
         if og_dim == 0:
             target_array = target_array[np.newaxis]
-        indices = seq._register.find_indices(target_array.tolist())
+        indices = seq.get_register().find_indices(target_array.tolist())
         return indices[0] if og_dim == 0 else indices
 
     def get_kwarg_default(call_name: str, kwarg_name: str) -> Any:

--- a/pulser-core/pulser/json/abstract_repr/serializer.py
+++ b/pulser-core/pulser/json/abstract_repr/serializer.py
@@ -153,14 +153,7 @@ def serialize_abstract_sequence(
         og_dim = target_array.ndim
         if og_dim == 0:
             target_array = target_array[np.newaxis]
-        try:
-            indices = seq.register.find_indices(target_array.tolist())
-        # RuntimeError raised when calling seq.register for a MappableRegister
-        except RuntimeError:
-            raise NotImplementedError(
-                "Serialization of sequences with local operations and"
-                " a mappable register is currently not supported."
-            )
+        indices = seq._register.find_indices(target_array.tolist())
         return indices[0] if og_dim == 0 else indices
 
     def get_kwarg_default(call_name: str, kwarg_name: str) -> Any:

--- a/pulser-core/pulser/json/abstract_repr/serializer.py
+++ b/pulser-core/pulser/json/abstract_repr/serializer.py
@@ -153,7 +153,9 @@ def serialize_abstract_sequence(
         og_dim = target_array.ndim
         if og_dim == 0:
             target_array = target_array[np.newaxis]
-        indices = seq.get_register().find_indices(target_array.tolist())
+        indices = seq.get_register(include_mappable=True).find_indices(
+            target_array.tolist()
+        )
         return indices[0] if og_dim == 0 else indices
 
     def get_kwarg_default(call_name: str, kwarg_name: str) -> Any:

--- a/pulser-core/pulser/register/mappable_reg.py
+++ b/pulser-core/pulser/register/mappable_reg.py
@@ -72,6 +72,11 @@ class MappableRegister:
             raise ValueError(
                 "All qubits must be labeled with pre-declared qubit IDs."
             )
+        elif set(chosen_ids) != set(self.qubit_ids[: len(chosen_ids)]):
+            raise ValueError(
+                f"'qubits' should contain the {len(qubits.keys())} first "
+                "elements of the 'qubit_ids'."
+            )
         register_ordered_qubits = {
             id: qubits[id] for id in self._qubit_ids if id in chosen_ids
         }

--- a/pulser-core/pulser/register/mappable_reg.py
+++ b/pulser-core/pulser/register/mappable_reg.py
@@ -74,8 +74,9 @@ class MappableRegister:
             )
         elif set(chosen_ids) != set(self.qubit_ids[: len(chosen_ids)]):
             raise ValueError(
-                f"'qubits' should contain the {len(qubits.keys())} first "
-                "elements of the 'qubit_ids'."
+                f"To declare {len(qubits.keys())} qubits, 'qubits' should "
+                f"contain the first {len(qubits.keys())} elements of the "
+                "'qubit_ids'."
             )
         register_ordered_qubits = {
             id: qubits[id] for id in self._qubit_ids if id in chosen_ids

--- a/pulser-core/pulser/register/mappable_reg.py
+++ b/pulser-core/pulser/register/mappable_reg.py
@@ -80,10 +80,8 @@ class MappableRegister:
             qubit_ids=tuple(register_ordered_qubits.keys()),
         )
 
-    def find_indices(
-        self, chosen_ids: set[QubitId], id_list: abcSequence[QubitId]
-    ) -> list[int]:
-        """Computes indices of qubits according to a register mapping.
+    def find_indices(self, id_list: abcSequence[QubitId]) -> list[int]:
+        """Computes indices of qubits.
 
         This can especially be useful when building a Pulser Sequence
         with a parameter denoting qubits.
@@ -92,41 +90,31 @@ class MappableRegister:
             Let ``reg`` be a mappable register with qubit Ids "a", "b", "c"
             and "d".
 
-            >>> qubit_map = dict(b=1, a=2, d=0)
-            >>> reg.find_indices(
-            >>>   qubit_map.keys(),
-            >>>   ["a", "b", "d", "a"])
+            >>> reg.find_indices(["a", "b", "d", "a"])
 
-            It returns ``[0, 1, 2, 0]``, following the qubits order of the
-            mappable register, but keeping only the chosen ones.
+            It returns ``[0, 1, 3, 0]``, following the qubits order of the
+            mappable register (defined by qubit_ids).
 
             Then, it is possible to use these indices when building a
             sequence, typically to instanciate an array of variables
             that can be provided as an argument to ``target_index``
             and ``phase_shift_index``.
 
-            ``qubit_map`` should be provided when building the sequence,
-            to tell how to instantiate the register from the mappable register.
+            When building a sequence and declaring N qubits, their ids should
+            refer to the first N elements of qubit_id.
 
         Args:
-            chosen_ids: IDs of the qubits that are chosen to
-                map the MappableRegister
             id_list: IDs of the qubits to denote.
 
         Returns:
             Indices of the qubits to denote, only valid for the
             given mapping.
         """
-        if not chosen_ids <= set(self._qubit_ids):
+        if not set(id_list) <= set(self._qubit_ids):
             raise ValueError(
-                "Chosen IDs must be selected among pre-declared qubit IDs."
+                "The IDs list must be selected among pre-declared qubit IDs."
             )
-        if not set(id_list) <= chosen_ids:
-            raise ValueError(
-                "The IDs list must be selected among the chosen IDs."
-            )
-        ordered_ids = [id for id in self.qubit_ids if id in chosen_ids]
-        return [ordered_ids.index(id) for id in id_list]
+        return [self.qubit_ids.index(id) for id in id_list]
 
     def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(self, self._layout, *self._qubit_ids)

--- a/pulser-core/pulser/sequence/_decorators.py
+++ b/pulser-core/pulser/sequence/_decorators.py
@@ -97,21 +97,6 @@ def store(func: F) -> F:
     return cast(F, wrapper)
 
 
-def check_allow_qubit_index(func: F) -> F:
-    """Checks if using qubit indices is allowed."""
-
-    @wraps(func)
-    def wrapper(self: Sequence, *args: Any, **kwargs: Any) -> Any:
-        if not self.is_parametrized() and self.is_register_mappable():
-            raise RuntimeError(
-                f"Sequence.{func.__name__} cannot be called in"
-                " non-parametrized sequences using a mappable register."
-            )
-        func(self, *args, **kwargs)
-
-    return cast(F, wrapper)
-
-
 def mark_non_empty(func: F) -> F:
     """Marks the sequence as non-empty."""
 

--- a/pulser-core/pulser/sequence/_seq_drawer.py
+++ b/pulser-core/pulser/sequence/_seq_drawer.py
@@ -323,10 +323,10 @@ def draw_sequence(
 
     # Draw masked register
     if draw_register:
-        pos = np.array(seq.register._coords)
-        if isinstance(seq.register, Register3D):
+        pos = np.array(seq._register._coords)
+        if isinstance(seq._register, Register3D):
             labels = "xyz"
-            fig_reg, axes_reg = seq.register._initialize_fig_axes_projection(
+            fig_reg, axes_reg = seq._register._initialize_fig_axes_projection(
                 pos,
                 blockade_radius=35,
                 draw_half_radius=True,
@@ -336,10 +336,10 @@ def draw_sequence(
             for ax_reg, (ix, iy) in zip(
                 axes_reg, combinations(np.arange(3), 2)
             ):
-                seq.register._draw_2D(
+                seq._register._draw_2D(
                     ax=ax_reg,
                     pos=pos,
-                    ids=seq.register._ids,
+                    ids=seq._register._ids,
                     plane=(ix, iy),
                     masked_qubits=seq._slm_mask_targets,
                 )
@@ -350,16 +350,16 @@ def draw_sequence(
                     + "-plane"
                 )
 
-        elif isinstance(seq.register, Register):
-            fig_reg, ax_reg = seq.register._initialize_fig_axes(
+        elif isinstance(seq._register, Register):
+            fig_reg, ax_reg = seq._register._initialize_fig_axes(
                 pos,
                 blockade_radius=35,
                 draw_half_radius=True,
             )
-            seq.register._draw_2D(
+            seq._register._draw_2D(
                 ax=ax_reg,
                 pos=pos,
-                ids=seq.register._ids,
+                ids=seq._register._ids,
                 masked_qubits=seq._slm_mask_targets,
             )
             ax_reg.set_title("Masked register", pad=10)

--- a/pulser-core/pulser/sequence/_seq_str.py
+++ b/pulser-core/pulser/sequence/_seq_str.py
@@ -14,6 +14,7 @@
 """Function for representing the sequence in a string."""
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 from pulser.pulse import Pulse
@@ -30,6 +31,15 @@ def seq_to_str(sequence: Sequence) -> str:
     delay_line = "t: {}->{} | Delay \n"
     det_delay_line = "t: {}->{} | Detuned Delay | Detuning: {:.3g} rad/µs\n"
     for ch, seq in sequence._schedule.items():
+        if (
+            seq.channel_obj.addressing == "Global"
+            and sequence.is_register_mappable()
+        ):
+            warnings.warn(
+                "Showing the register for a sequence with a mappable register."
+                f"Target qubits of channel {ch} will be defined in build.",
+                UserWarning,
+            )
         basis = sequence.declared_channels[ch].basis
         full += f"Channel: {ch}\n"
         first_slot = True

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -50,10 +50,8 @@ from pulser.json.utils import obj_to_dict
 from pulser.parametrized import Parametrized, Variable
 from pulser.parametrized.variable import VariableItem
 from pulser.pulse import Pulse
-from pulser.register import Register
 from pulser.register.base_register import BaseRegister, QubitId
 from pulser.register.mappable_reg import MappableRegister
-from pulser.register.register_layout import RegisterLayout
 from pulser.sequence._basis_ref import _QubitRef
 from pulser.sequence._call import _Call
 from pulser.sequence._schedule import _ChannelSchedule, _Schedule, _TimeSlot
@@ -122,26 +120,15 @@ class Sequence(Generic[DeviceType]):
             raise TypeError(
                 f"'device' must be of type 'BaseDevice', not {type(device)}."
             )
-        self._is_register_mappable: bool = isinstance(
-            register, MappableRegister
-        )
-        self._register: BaseRegister
-        if self._is_register_mappable:
-            # Checks if register is compatible with the device
-            map_reg = cast(MappableRegister, register)
-            n_ids = len(map_reg.qubit_ids)
-            device.validate_layout(map_reg.layout)
-            device.validate_layout_filling(map_reg)
-            self.initial_layout = map_reg.layout
-            self._register = Register(
-                dict(zip(map_reg.qubit_ids, map_reg.layout.coords[:n_ids])),
-                layout=map_reg.layout,
-                trap_ids=range(n_ids),
-            )
-        else:
-            self._register = cast(BaseRegister, register)
-            device.validate_register(self.register)
 
+        # Checks if register is compatible with the device
+        if isinstance(register, MappableRegister):
+            device.validate_layout(register.layout)
+            device.validate_layout_filling(register)
+        else:
+            device.validate_register(register)
+
+        self._register: Union[BaseRegister, MappableRegister] = register
         self._device = device
         self._in_xy: bool = False
         self._mag_field: Optional[tuple[float, float, float]] = None
@@ -177,12 +164,11 @@ class Sequence(Generic[DeviceType]):
     def qubit_info(self) -> dict[QubitId, np.ndarray]:
         """Dictionary with the qubit's IDs and positions."""
         if self.is_register_mappable():
-            warnings.warn(
-                "Accessing the qubit information whereas the register can "
-                "still be modified in build.",
-                UserWarning,
+            raise RuntimeError(
+                "Can't access the qubit information when the register is "
+                "mappable."
             )
-        return self._register.qubits
+        return cast(BaseRegister, self._register).qubits
 
     @property
     def device(self) -> DeviceType:
@@ -193,12 +179,11 @@ class Sequence(Generic[DeviceType]):
     def register(self) -> BaseRegister:
         """Register with the qubit's IDs and positions."""
         if self.is_register_mappable():
-            warnings.warn(
-                "Accessing the sequence's register whereas the register can"
-                "still be modified in build.",
-                UserWarning,
+            raise RuntimeError(
+                "Can't access the sequence's register because the register "
+                "is mappable."
             )
-        return self._register
+        return cast(BaseRegister, self._register)
 
     @property
     def declared_channels(self) -> dict[str, Channel]:
@@ -296,7 +281,7 @@ class Sequence(Generic[DeviceType]):
         Returns:
             Whether the register is a MappableRegister.
         """
-        return self._is_register_mappable
+        return isinstance(self._register, MappableRegister)
 
     def is_measured(self) -> bool:
         """States whether the sequence has been measured."""
@@ -406,6 +391,11 @@ class Sequence(Generic[DeviceType]):
         if not self._device.supports_slm_mask:
             raise ValueError(
                 f"The '{self._device}' device does not have an SLM mask."
+            )
+
+        if self.is_register_mappable():
+            raise RuntimeError(
+                "The SLM mask can't be combined with a mappable register."
             )
 
         try:
@@ -553,15 +543,7 @@ class Sequence(Generic[DeviceType]):
             else:
                 raise TypeError(ch_match_err)
         # Initialize the new sequence (works for Sequence subclasses too)
-        new_seq = type(self)(
-            register=self._register
-            if not self.is_register_mappable()
-            else MappableRegister(
-                cast(RegisterLayout, self._register.layout),
-                *self._register._ids,
-            ),
-            device=new_device,
-        )
+        new_seq = type(self)(register=self._register, device=new_device)
 
         # Copy the variables to the new sequence
         new_seq._variables = self.declared_variables
@@ -977,6 +959,7 @@ class Sequence(Generic[DeviceType]):
         self._target(qubits, channel)
 
     @seq_decorators.store
+    @seq_decorators.check_allow_qubit_index
     def target_index(
         self,
         qubits: Union[int, Iterable[int], Parametrized],
@@ -1072,6 +1055,7 @@ class Sequence(Generic[DeviceType]):
         self._phase_shift(phi, *targets, basis=basis)
 
     @seq_decorators.store
+    @seq_decorators.check_allow_qubit_index
     def phase_shift_index(
         self,
         phi: Union[float, Parametrized],
@@ -1174,12 +1158,10 @@ class Sequence(Generic[DeviceType]):
         """
         if self.is_register_mappable():
             if qubits is None:
-                warnings.warn(
-                    "'qubits' not specified while sequence was created with a "
-                    "MappableRegister. Joining Trap coordinates with qubit ids"
-                    " using indices of register._ids.",
-                ),
-                self._is_register_mappable = False
+                raise ValueError(
+                    "'qubits' must be specified when the sequence is created "
+                    "with a MappableRegister."
+                )
 
         elif qubits is not None:
             raise ValueError(
@@ -1214,11 +1196,7 @@ class Sequence(Generic[DeviceType]):
             self._variables[name]._assign(value)
 
         if qubits:
-            map_reg = MappableRegister(
-                cast(RegisterLayout, self._register.layout),
-                *self._register._ids,
-            )
-            reg = map_reg.build_register(qubits)
+            reg = cast(MappableRegister, self._register).build_register(qubits)
             self._set_register(seq, reg)
 
         for call in self._to_build_calls:
@@ -1391,9 +1369,9 @@ class Sequence(Generic[DeviceType]):
                 )
                 draw_interp_pts = False
         if draw_register and self.is_register_mappable():
-            warnings.warn(
-                "Drawing the register of a sequence with a mappable register.",
-                UserWarning,
+            raise ValueError(
+                "Can't draw the register for a sequence without a defined "
+                "register."
             )
         fig_reg, fig = self._plot(
             draw_phase_area=draw_phase_area,
@@ -1527,9 +1505,7 @@ class Sequence(Generic[DeviceType]):
             else:
                 qubits = cast(Tuple[int, ...], qubits)
                 try:
-                    return {
-                        self._register.qubit_ids[index] for index in qubits
-                    }
+                    return {self.register.qubit_ids[index] for index in qubits}
                 except IndexError:
                     raise IndexError("Indices must exist for the register.")
         ids = set(cast(Tuple[QubitId, ...], qubits))
@@ -1666,7 +1642,6 @@ class Sequence(Generic[DeviceType]):
                 " have not been assigned a trap."
             )
         seq._register = reg
-        seq._is_register_mappable = False
         seq._qids = qids
         seq._calls[0] = _Call("__init__", (seq._register, seq._device), {})
 

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -959,7 +959,6 @@ class Sequence(Generic[DeviceType]):
         self._target(qubits, channel)
 
     @seq_decorators.store
-    @seq_decorators.check_allow_qubit_index
     def target_index(
         self,
         qubits: Union[int, Iterable[int], Parametrized],
@@ -1055,7 +1054,6 @@ class Sequence(Generic[DeviceType]):
         self._phase_shift(phi, *targets, basis=basis)
 
     @seq_decorators.store
-    @seq_decorators.check_allow_qubit_index
     def phase_shift_index(
         self,
         phi: Union[float, Parametrized],
@@ -1161,6 +1159,13 @@ class Sequence(Generic[DeviceType]):
                 raise ValueError(
                     "'qubits' must be specified when the sequence is created "
                     "with a MappableRegister."
+                )
+            elif not self.is_parametrized() and qubits.keys() != set(
+                self._register.qubit_ids[: len(qubits.keys())]
+            ):
+                raise ValueError(
+                    f"'qubits' should contain the {len(qubits.keys())} first "
+                    "elements of the 'qubit_ids' of the MappableRegister."
                 )
 
         elif qubits is not None:
@@ -1505,7 +1510,9 @@ class Sequence(Generic[DeviceType]):
             else:
                 qubits = cast(Tuple[int, ...], qubits)
                 try:
-                    return {self.register.qubit_ids[index] for index in qubits}
+                    return {
+                        self._register.qubit_ids[index] for index in qubits
+                    }
                 except IndexError:
                     raise IndexError("Indices must exist for the register.")
         ids = set(cast(Tuple[QubitId, ...], qubits))

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -185,9 +185,21 @@ class Sequence(Generic[DeviceType]):
             )
         return cast(BaseRegister, self._register)
 
-    def get_register(self) -> BaseRegister | MappableRegister:
+    @overload
+    def get_register(self, include_mappable: Literal[False]) -> BaseRegister:
+        pass
+
+    @overload
+    def get_register(
+        self, include_mappable: Literal[True]
+    ) -> BaseRegister | MappableRegister:
+        pass
+
+    def get_register(
+        self, include_mappable: bool = True
+    ) -> BaseRegister | MappableRegister:
         """The atom register on which to apply the pulses."""
-        return self._register
+        return self._register if include_mappable else self.register
 
     @property
     def declared_channels(self) -> dict[str, Channel]:

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -556,7 +556,10 @@ class Sequence(Generic[DeviceType]):
         new_seq = type(self)(
             register=self._register
             if not self.is_register_mappable()
-            else MappableRegister(self._register.layout, *self._register._ids),
+            else MappableRegister(
+                cast(RegisterLayout, self._register.layout),
+                *self._register._ids,
+            ),
             device=new_device,
         )
 
@@ -1212,7 +1215,8 @@ class Sequence(Generic[DeviceType]):
 
         if qubits:
             map_reg = MappableRegister(
-                self._register.layout, *self._register._ids
+                cast(RegisterLayout, self._register.layout),
+                *self._register._ids,
             )
             reg = map_reg.build_register(qubits)
             self._set_register(seq, reg)

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -1160,13 +1160,6 @@ class Sequence(Generic[DeviceType]):
                     "'qubits' must be specified when the sequence is created "
                     "with a MappableRegister."
                 )
-            elif not self.is_parametrized() and qubits.keys() != set(
-                self._register.qubit_ids[: len(qubits.keys())]
-            ):
-                raise ValueError(
-                    f"'qubits' should contain the {len(qubits.keys())} first "
-                    "elements of the 'qubit_ids' of the MappableRegister."
-                )
 
         elif qubits is not None:
             raise ValueError(

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -185,6 +185,10 @@ class Sequence(Generic[DeviceType]):
             )
         return cast(BaseRegister, self._register)
 
+    def get_register(self) -> BaseRegister | MappableRegister:
+        """The atom register on which to apply the pulses."""
+        return self._register
+
     @property
     def declared_channels(self) -> dict[str, Channel]:
         """Channels declared in this Sequence."""

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -625,13 +625,21 @@ class TestSerialization:
         ):
             seq.to_abstract_repr(var=0)
 
-        with pytest.raises(TypeError, match="Did not receive values"):
-            seq.to_abstract_repr(qubits={"q1": 0})
+        with pytest.raises(
+            ValueError,
+            match="The given 'defaults' produce an invalid sequence.",
+        ):
+            seq.to_abstract_repr(var=0, qubits={"q1": 0})
 
-        abstract = json.loads(seq.to_abstract_repr(var=0, qubits={"q1": 0}))
+        with pytest.raises(TypeError, match="Did not receive values"):
+            seq.to_abstract_repr(qubits={"q0": 0})
+
+        assert not seq.is_parametrized()
+
+        abstract = json.loads(seq.to_abstract_repr(var=0, qubits={"q0": 0}))
         assert abstract["register"] == [
-            {"qid": "q0"},
-            {"qid": "q1", "default_trap": 0},
+            {"qid": "q0", "default_trap": 0},
+            {"qid": "q1"},
         ]
         assert abstract["variables"]["var"] == dict(type="int", value=[0])
 
@@ -722,7 +730,6 @@ class TestSerialization:
             "basis", "ground-rydberg"
         )
 
-    @pytest.mark.xfail(reason="Can't get index of mappable register qubits.")
     @pytest.mark.parametrize(
         "op,args",
         [
@@ -875,7 +882,7 @@ class TestDeserialization:
     def test_deserialize_mappable_register(self):
         layout_coords = (5 * np.arange(8)).reshape((4, 2))
         s = _get_serialized_seq(
-            register=[{"qid": "q0"}, {"qid": "q1", "default_trap": 2}],
+            register=[{"qid": "q0", "default_trap": 2}, {"qid": "q1"}],
             layout={
                 "coordinates": layout_coords.tolist(),
                 "slug": "test_layout",

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -226,23 +226,12 @@ def test_mappable_register_creation():
     mapp_reg = tri.make_mappable_register(5)
     assert mapp_reg.qubit_ids == ("q0", "q1", "q2", "q3", "q4")
 
-    assert mapp_reg.find_indices(
-        {"q2", "q4", "q1"}, ["q4", "q2", "q1", "q2"]
-    ) == [2, 1, 0, 1]
+    assert mapp_reg.find_indices(["q4", "q2", "q1", "q2"]) == [4, 2, 1, 2]
 
     with pytest.raises(
         ValueError, match="must be selected among pre-declared qubit IDs"
     ):
-        mapp_reg.find_indices(
-            {"q2", "q4", "q1", "q5"}, ["q4", "q2", "q1", "q2"]
-        )
-
-    with pytest.raises(
-        ValueError, match="must be selected among the chosen IDs"
-    ):
-        mapp_reg.find_indices(
-            {"q2", "q4", "q1"}, ["q4", "q2", "q1", "q2", "q3"]
-        )
+        mapp_reg.find_indices(["q4", "q2", "q1", "q5"])
 
     with pytest.raises(
         ValueError, match="labeled with pre-declared qubit IDs"
@@ -255,6 +244,4 @@ def test_mappable_register_creation():
         {"q0": tri.traps_dict[10], "q1": tri.traps_dict[49]}
     )
     names = ["q1", "q0", "q0"]
-    assert mapp_reg.find_indices(qubit_map.keys(), names) == reg.find_indices(
-        names
-    )
+    assert mapp_reg.find_indices(names) == reg.find_indices(names)

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -237,6 +237,10 @@ def test_mappable_register_creation():
         ValueError, match="labeled with pre-declared qubit IDs"
     ):
         mapp_reg.build_register({"q0": 0, "q5": 2})
+    with pytest.raises(
+        ValueError, match="'qubits' should contain the 2 first elements"
+    ):
+        mapp_reg.build_register({"q0": 0, "q2": 2})
 
     qubit_map = {"q0": 10, "q1": 49}
     reg = mapp_reg.build_register(qubit_map)

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -237,9 +237,7 @@ def test_mappable_register_creation():
         ValueError, match="labeled with pre-declared qubit IDs"
     ):
         mapp_reg.build_register({"q0": 0, "q5": 2})
-    with pytest.raises(
-        ValueError, match="'qubits' should contain the 2 first elements"
-    ):
+    with pytest.raises(ValueError, match="To declare 2 qubits"):
         mapp_reg.build_register({"q0": 0, "q2": 2})
 
     qubit_map = {"q0": 10, "q1": 49}

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1213,7 +1213,7 @@ def test_mappable_register(patch_plt_show):
         seq.build(qubits={"q2": 20, "q0": 10, "q1": 0}, a=5)
 
     with pytest.raises(ValueError, match="'qubits' should contain the 3"):
-        seq.build(qubits={"q2": 20, "q0": 10, "q3": 0}, a=5)
+        seq.build(qubits={"q2": 20, "q0": 10, "q3": 0})
 
     seq_ = seq.build(qubits={"q2": 20, "q0": 10, "q1": 0})
     assert seq_._last("ryd_glob").targets == {"q0", "q1", "q2"}
@@ -1259,9 +1259,9 @@ index_function_non_mappable_register_values: Any = [
 index_function_mappable_register_values = [
     (
         TriangularLatticeLayout(100, 5).make_mappable_register(10),
-        dict(qubits=dict(q0=1, q4=2, q3=0)),
-        2,
-        "q4",
+        dict(qubits=dict(q0=1, q2=2, q1=0)),
+        1,
+        "q1",
     ),
 ]
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -27,6 +27,7 @@ from pulser import Pulse, Register, Register3D, Sequence
 from pulser.channels import Raman, Rydberg
 from pulser.devices import Chadoq2, IroiseMVP, MockDevice
 from pulser.devices._device_datacls import Device, VirtualDevice
+from pulser.register.base_register import BaseRegister
 from pulser.register.mappable_reg import MappableRegister
 from pulser.register.register_layout import RegisterLayout
 from pulser.register.special_layouts import TriangularLatticeLayout
@@ -1165,6 +1166,7 @@ def test_mappable_register(patch_plt_show):
     mapp_reg = layout.make_mappable_register(10)
     seq = Sequence(mapp_reg, Chadoq2)
     assert seq.is_register_mappable()
+    assert isinstance(seq.get_register(), MappableRegister)
     reserved_qids = tuple([f"q{i}" for i in range(10)])
     assert seq._qids == set(reserved_qids)
     with pytest.raises(RuntimeError, match="Can't access the qubit info"):
@@ -1223,6 +1225,7 @@ def test_mappable_register(patch_plt_show):
     assert init_call.name == "__init__"
     assert isinstance(init_call.kwargs["register"], MappableRegister)
     assert not seq_.is_register_mappable()
+    assert isinstance(seq_.get_register(), BaseRegister)
     assert seq_.register == Register(
         {
             "q0": layout.traps_dict[10],
@@ -1341,30 +1344,6 @@ def test_non_parametrized_non_mappable_register_index_functions(
     seq.phase_shift_index(phi, index)
     assert seq._last("ch0").targets == {expected_target}
     assert seq.current_phase_ref(expected_target, "digital") == phi
-
-
-# @pytest.mark.parametrize(
-#     index_function_params, index_function_mappable_register_values
-# )
-# def test_non_parametrized_mappable_register_index_functions_failure(
-#     register, build_params, index, expected_target
-# ):
-#     seq = Sequence(register, Chadoq2)
-#     seq.declare_channel("ch0", "rydberg_local")
-#     seq.declare_channel("ch1", "raman_local")
-#     phi = np.pi / 4
-#     with pytest.raises(
-#         RuntimeError,
-#         match="Sequence.target_index cannot be called in"
-#         " non-parametrized sequences",
-#     ):
-#         seq.target_index(index, channel="ch0")
-#     with pytest.raises(
-#         RuntimeError,
-#         match="Sequence.phase_shift_index cannot be called in"
-#         " non-parametrized sequences",
-#     ):
-#         seq.phase_shift_index(phi, index)
 
 
 def test_multiple_index_targets(reg):

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1167,6 +1167,10 @@ def test_mappable_register(patch_plt_show):
     seq = Sequence(mapp_reg, Chadoq2)
     assert seq.is_register_mappable()
     assert isinstance(seq.get_register(), MappableRegister)
+    with pytest.raises(
+        RuntimeError, match="Can't access the sequence's register"
+    ):
+        seq.get_register(include_mappable=False)
     reserved_qids = tuple([f"q{i}" for i in range(10)])
     assert seq._qids == set(reserved_qids)
     with pytest.raises(RuntimeError, match="Can't access the qubit info"):
@@ -1214,7 +1218,7 @@ def test_mappable_register(patch_plt_show):
     with pytest.warns(UserWarning, match="No declared variables named: a"):
         seq.build(qubits={"q2": 20, "q0": 10, "q1": 0}, a=5)
 
-    with pytest.raises(ValueError, match="'qubits' should contain the 3"):
+    with pytest.raises(ValueError, match="To declare 3 qubits"):
         seq.build(qubits={"q2": 20, "q0": 10, "q3": 0})
 
     seq_ = seq.build(qubits={"q2": 20, "q0": 10, "q1": 0})
@@ -1226,6 +1230,7 @@ def test_mappable_register(patch_plt_show):
     assert isinstance(init_call.kwargs["register"], MappableRegister)
     assert not seq_.is_register_mappable()
     assert isinstance(seq_.get_register(), BaseRegister)
+    assert isinstance(seq_.get_register(include_mappable=False), BaseRegister)
     assert seq_.register == Register(
         {
             "q0": layout.traps_dict[10],

--- a/tutorials/advanced_features/Register Layouts.ipynb
+++ b/tutorials/advanced_features/Register Layouts.ipynb
@@ -525,7 +525,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To define the register, we can then call `Sequence.build()`, indicated in the `qubits` argument the map between qubit IDs and trap IDs (note that not all the qubit IDs need to be associated to a trap ID). \n",
+    "To define the register, we can then call `Sequence.build()`, indicating in the `qubits` argument the map between qubit IDs and trap IDs. Note that not all the qubit IDs need to be associated to a trap ID, and that the qubit IDs have to be defined in their order of appearance in `MappableRegister.qubit_ids` (it is not possible to associate a trap ID to qubit ID \"q4\" if no trap ID was assigned to qubit ID \"q3\").\n",
     "\n",
     "In this way, we can build multiple sequences, with only the `Register` changing from one to the other:"
    ]
@@ -536,10 +536,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "seq1 = seq.build(qubits={\"q0\": 16, \"q1\": 19, \"q4\": 34})\n",
+    "seq1 = seq.build(qubits={\"q0\": 16, \"q1\": 19, \"q2\": 34})\n",
     "print(\"First register:\", seq1.register.qubits)\n",
     "\n",
-    "seq2 = seq.build(qubits={\"q0\": 0, \"q1\": 15, \"q2\": 20})\n",
+    "seq2 = seq.build(qubits={\"q0\": 0, \"q2\": 15, \"q1\": 20, \"q3\": 50})\n",
     "print(\"Second register:\", seq2.register.qubits)"
    ]
   }


### PR DESCRIPTION
- I propose to do it by defining a default `Sequence._register` if the provided register is a `MappableRegister`, mapping each qubit id from the `qubit_ids` of the mappable register with the trap of same index in the `layout` of the mappable register.
- `_register` is used as a dummy register during all the operations prior to the `build` operation.
- `layout` of the mappable register is given as an optional parameter of `_register`, such that it can be used in `build` to perform the same operation as before.
Closes #502 