### PR TITLE
Minor changes for extensions of Simulation

### DIFF
--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -551,8 +551,8 @@ class Simulation:
 
         if local_noises:
             for ch, ch_samples in self.samples_obj.channel_samples.items():
-                addr = self._seq.declared_channels[ch].addressing
-                basis = self._seq.declared_channels[ch].basis
+                addr = self.samples_obj._ch_objs[ch].addressing
+                basis = self.samples_obj._ch_objs[ch].basis
                 samples_dict = samples["Local"][basis]
                 for slot in ch_samples.slots:
                     add_noise(slot, samples_dict, addr == "Global")


### PR DESCRIPTION
The changes don't impact simulations in Pulser, because `samples_obj` are created using `sampler.sample()` and thus `samples_obj._ch_obj` is the same as `_seq.declared_channels`.

However, it makes more sense to take the `ch_obj` from the samples as it doesn't rely in an underlying sequence being stored within the `Simulation` instance.