### PR TITLE
Ensure that `Channel`s with an `eom_config` have a modulation bandwidth

### DIFF
--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -169,6 +169,13 @@ class Channel(ABC):
                 " greater than or equal to 'min_duration'"
                 f"({self.min_duration})."
             )
+
+        if self.eom_config is not None and self.mod_bandwidth is None:
+            raise ValueError(
+                "'eom_config' can't be defined in a Channel without a "
+                "modulation bandwidth."
+            )
+
         if (
             self.mod_bandwidth is not None
             and self.mod_bandwidth > MODBW_TO_TR * 1e3

--- a/pulser-core/pulser/channels/channels.py
+++ b/pulser-core/pulser/channels/channels.py
@@ -48,17 +48,13 @@ class Rydberg(Channel):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        if self.eom_config is not None:
-            if not isinstance(self.eom_config, RydbergEOM):
-                raise TypeError(
-                    "When defined, 'eom_config' must be a valid 'RydbergEOM'"
-                    f" instance, not {type(self.eom_config)}."
-                )
-            if self.mod_bandwidth is None:
-                raise ValueError(
-                    "'eom_config' can't be defined in a Channel without a "
-                    "modulation bandwidth."
-                )
+        if self.eom_config is not None and not isinstance(
+            self.eom_config, RydbergEOM
+        ):
+            raise TypeError(
+                "When defined, 'eom_config' must be a valid 'RydbergEOM'"
+                f" instance, not {type(self.eom_config)}."
+            )
 
     @property
     def basis(self) -> Literal["ground-rydberg"]:


### PR DESCRIPTION
This generalizes the `Rydberg` channel's check by pushing it into the base class.

Fixes: #497

----

I've spent too long trying to run the tests locally—it's possible `dev_requirements.txt` is missing some packages—will open an issue about it later.