### PR TITLE
Fixes for emulation of empty sequences 

### DIFF
--- a/pulser-core/pulser/sampler/samples.py
+++ b/pulser-core/pulser/sampler/samples.py
@@ -91,6 +91,7 @@ class ChannelSamples:
     phase: np.ndarray
     slots: list[_TargetSlot] = field(default_factory=list)
     eom_blocks: list[_EOMSettings] = field(default_factory=list)
+    initial_targets: set[QubitId] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         assert len(self.amp) == len(self.det) == len(self.phase)
@@ -373,6 +374,10 @@ class SequenceSamples:
                     d[_LOCAL][basis][t][_DET][:start_t] += cs.det[:start_t]
                     d[_LOCAL][basis][t][_PHASE][:start_t] += cs.phase[:start_t]
             else:
+                if not cs.slots:
+                    # Fill the defaultdict entries to not return an empty dict
+                    for t in cs.initial_targets:
+                        d[_LOCAL][basis][t]
                 for s in cs.slots:
                     for t in s.targets:
                         ti = s.ti

--- a/pulser-core/pulser/sequence/_schedule.py
+++ b/pulser-core/pulser/sequence/_schedule.py
@@ -138,6 +138,7 @@ class _ChannelSchedule:
         dt = self.get_duration()
         amp, det, phase = np.zeros(dt), np.zeros(dt), np.zeros(dt)
         slots: list[_TargetSlot] = []
+        initial_targets = self.slots[0].targets if self.slots else set()
 
         for ind, s in enumerate(channel_slots):
             pulse = cast(Pulse, s.type)
@@ -181,7 +182,9 @@ class _ChannelSchedule:
             # the same, so the last phase is automatically kept till the end
             phase[t_start:] = pulse.phase
 
-        return ChannelSamples(amp, det, phase, slots, self.eom_blocks)
+        return ChannelSamples(
+            amp, det, phase, slots, self.eom_blocks, initial_targets
+        )
 
     @overload
     def __getitem__(self, key: int) -> _TimeSlot:

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -894,10 +894,8 @@ class QutipEmulator:
 
                 .. _docs: https://bit.ly/3il9A2u
         """
-        if "max_step" in options.keys():
-            solv_ops = qutip.Options(**options)
-        else:
-            min_pulse_duration = min(
+        if "max_step" not in options:
+            pulse_durations = [
                 slot.tf - slot.ti
                 for ch_sample in self.samples_obj.samples_list
                 for slot in ch_sample.slots
@@ -905,9 +903,11 @@ class QutipEmulator:
                     np.all(np.isclose(ch_sample.amp[slot.ti : slot.tf], 0))
                     and np.all(np.isclose(ch_sample.det[slot.ti : slot.tf], 0))
                 )
-            )
-            auto_max_step = 0.5 * (min_pulse_duration / 1000)
-            solv_ops = qutip.Options(max_step=auto_max_step, **options)
+            ]
+            if pulse_durations:
+                options["max_step"] = 0.5 * min(pulse_durations) / 1000
+
+        solv_ops = qutip.Options(**options)
 
         meas_errors: Optional[Mapping[str, float]] = None
         if "SPAM" in self.config.noise:

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -328,10 +328,18 @@ def test_empty_sequences(reg):
         QutipEmulator(sampler.sample(seq), seq.register, seq.device)
 
     seq = Sequence(reg, MockDevice)
-    seq.declare_channel("test", "rydberg_local", "target")
+    seq.declare_channel("test", "raman_local", "target")
     seq.declare_channel("test2", "rydberg_global")
     with pytest.raises(ValueError, match="No instructions given"):
         Simulation(seq)
+
+    seq.delay(100, "test")
+    emu = QutipEmulator.from_sequence(seq, config=SimConfig(noise="SPAM"))
+    assert not emu.samples["Global"]
+    for basis in emu.samples["Local"]:
+        for q in emu.samples["Local"][basis]:
+            for qty_values in emu.samples["Local"][basis][q].values():
+                np.testing.assert_equal(qty_values, 0)
 
 
 def test_get_hamiltonian():


### PR DESCRIPTION
- Allows for emulation of sequences with only delays by adding `intial_targets` information to `ChannelSamples`
- Fixes determination of `max_step` in `QutipEmulator.run()` when there is no non-zero pulse