### PR TITLE
Temporarily pin pydantic to fix broken CI

### DIFF
--- a/pulser-pasqal/requirements.txt
+++ b/pulser-pasqal/requirements.txt
@@ -1,1 +1,2 @@
 pasqal-cloud ~= 0.2.3
+pydantic < 2.0


### PR DESCRIPTION
`pydantic` is installed as a dependency of `pasqal-cloud`. The latest release of `pasqal-cloud` handles this issue, but that update is currently under review in #541 and might still take a bit to merge.

This will temporarily fix the CI tests, but it should be reverted in #541.