### PR TITLE
Handle parametrized sequence, switching device and DMM, and serialize config_det_map as an operation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # For generating documentation.
-Sphinx
+Sphinx < 7
 sphinx-rtd-theme # documentation theme
 sphinx_autodoc_typehints == 1.21.3
 nbsphinx

--- a/pulser-core/pulser/channels/eom.py
+++ b/pulser-core/pulser/channels/eom.py
@@ -180,6 +180,22 @@ class RydbergEOM(_RydbergEOMDefaults, BaseEOM, _RydbergEOM):
                     f" enumeration, not {self.limiting_beam}."
                 )
 
+    def calculate_detuning_off(
+        self, amp_on: float, detuning_on: float, optimal_detuning_off: float
+    ) -> float:
+        """Calculates the detuning when the amplitude is off in EOM mode.
+
+        Args:
+            amp_on: The amplitude of the EOM pulses (in rad/µs).
+            detuning_on: The detuning of the EOM pulses (in rad/µs).
+            optimal_detuning_off: The optimal value of detuning (in rad/µs)
+                when there is no pulse being played. It will choose the closest
+                value among the existing options.
+        """
+        off_options = self.detuning_off_options(amp_on, detuning_on)
+        closest_option = np.abs(off_options - optimal_detuning_off).argmin()
+        return cast(float, off_options[closest_option])
+
     def detuning_off_options(
         self, rabi_frequency: float, detuning_on: float
     ) -> np.ndarray:

--- a/pulser-core/pulser/devices/_devices.py
+++ b/pulser-core/pulser/devices/_devices.py
@@ -14,7 +14,7 @@
 """Definitions of real devices."""
 import numpy as np
 
-from pulser.channels import Raman, Rydberg
+from pulser.channels import DMM, Raman, Rydberg
 from pulser.channels.eom import RydbergBeam, RydbergEOM
 from pulser.devices._device_datacls import Device
 from pulser.register.special_layouts import TriangularLatticeLayout
@@ -56,15 +56,14 @@ Chadoq2 = Device(
             max_duration=2**26,
         ),
     ),
-    # TODO: Add DMM once it is supported for serialization
-    # dmm_objects=(
-    #     DMM(
-    #         clock_period=4,
-    #         min_duration=16,
-    #         max_duration=2**26,
-    #         bottom_detuning=-20,
-    #     ),
-    # ),
+    dmm_objects=(
+        DMM(
+            clock_period=4,
+            min_duration=16,
+            max_duration=2**26,
+            bottom_detuning=-20,
+        ),
+    ),
 )
 
 IroiseMVP = Device(

--- a/pulser-core/pulser/devices/_mock_device.py
+++ b/pulser-core/pulser/devices/_mock_device.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pulser.channels import Microwave, Raman, Rydberg
+from pulser.channels import DMM, Microwave, Raman, Rydberg
 from pulser.devices._device_datacls import VirtualDevice
 
 MockDevice = VirtualDevice(
@@ -31,5 +31,5 @@ MockDevice = VirtualDevice(
         Raman.Local(None, None, max_duration=None),
         Microwave.Global(None, None, max_duration=None),
     ),
-    # TODO: Add DMM once it is supported for serialization
+    dmm_objects=(DMM(),),
 )

--- a/pulser-core/pulser/json/abstract_repr/deserializer.py
+++ b/pulser-core/pulser/json/abstract_repr/deserializer.py
@@ -264,6 +264,7 @@ def _deserialize_operation(seq: Sequence, op: dict, vars: dict) -> None:
             optimal_detuning_off=_deserialize_parameter(
                 op["optimal_detuning_off"], vars
             ),
+            correct_phase_drift=op.get("correct_phase_drift", False),
         )
     elif op["op"] == "add_eom_pulse":
         seq.add_eom_pulse(
@@ -274,9 +275,13 @@ def _deserialize_operation(seq: Sequence, op: dict, vars: dict) -> None:
                 op["post_phase_shift"], vars
             ),
             protocol=op["protocol"],
+            correct_phase_drift=op.get("correct_phase_drift", False),
         )
     elif op["op"] == "disable_eom_mode":
-        seq.disable_eom_mode(channel=op["channel"])
+        seq.disable_eom_mode(
+            channel=op["channel"],
+            correct_phase_drift=op.get("correct_phase_drift", False),
+        )
     elif op["op"] == "modulate_det_map":
         seq.modulate_det_map(
             waveform=_deserialize_waveform(op["waveform"], vars),

--- a/pulser-core/pulser/json/abstract_repr/deserializer.py
+++ b/pulser-core/pulser/json/abstract_repr/deserializer.py
@@ -283,6 +283,13 @@ def _deserialize_operation(seq: Sequence, op: dict, vars: dict) -> None:
             dmm_name=op["dmm_name"],
             protocol=op["protocol"],
         )
+    elif op["op"] == "config_slm_mask":
+        seq.config_slm_mask(qubits=op["qubits"], dmm_id=op["dmm_id"])
+    elif op["op"] == "config_detuning_map":
+        seq.config_detuning_map(
+            detuning_map=_deserialize_det_map(op["detuning_map"]),
+            dmm_id=op["dmm_id"],
+        )
 
 
 def _deserialize_channel(obj: dict[str, Any]) -> Channel:
@@ -454,34 +461,6 @@ def deserialize_abstract_sequence(obj_str: str) -> Sequence:
         # This is kept for backwards compatibility
         seq.config_slm_mask(obj["slm_mask_targets"])
 
-    to_config_det_map: dict[str, dict] = dict()
-    if "dmm_channels" in obj:
-        # Make a dictionnary with all the configured dmm channels
-        for dmm_name, ser_det_map in obj["dmm_channels"]:
-            splitted_dmm_name = dmm_name.split("_")  # dmm_id_num
-            dmm_id = "_".join(splitted_dmm_name[0:2])
-            call_num = (
-                0 if len(splitted_dmm_name) <= 2 else int(splitted_dmm_name[2])
-            )
-            if dmm_id not in to_config_det_map:
-                to_config_det_map[dmm_id] = {}
-            to_config_det_map[dmm_id][call_num] = ser_det_map
-
-        for dmm_id, ser_det_maps in to_config_det_map.items():
-            slm_mask_dmm = None
-            call_nums = list(ser_det_maps.keys())
-            # If an SLM Mask has been defined, an iteration will be taken
-            for i, call_num in enumerate(call_nums):
-                if call_nums != i:
-                    slm_mask_dmm = i
-            # Have to wait for the SLM Mask to be configured to finish
-            # configuring the last Detuning Maps
-            for call_num, ser_det_map in ser_det_maps.items():
-                if slm_mask_dmm is not None and call_num >= slm_mask_dmm:
-                    break
-                det_map = _deserialize_det_map(ser_det_map)
-                seq.config_detuning_map(detuning_map=det_map, dmm_id=dmm_id)
-
     # Variables
     vars = {}
     for name, desc in obj["variables"].items():
@@ -494,21 +473,7 @@ def deserialize_abstract_sequence(obj_str: str) -> Sequence:
 
     # Operations
     for op in obj["operations"]:
-        if op["op"] == "config_slm_mask":
-            seq.config_slm_mask(qubits=op["qubits"], dmm_id=op["dmm_id"])
-            # Finish configuration of detuning maps
-            if op["dmm_id"] in to_config_det_map and slm_mask_dmm is not None:
-                for call_num, ser_det_map in to_config_det_map[
-                    op["dmm_id"]
-                ].items():
-                    if call_num <= slm_mask_dmm:
-                        continue
-                    det_map = _deserialize_det_map(ser_det_map)
-                    seq.config_detuning_map(
-                        detuning_map=det_map, dmm_id=op["dmm_id"]
-                    )
-        else:
-            _deserialize_operation(seq, op, vars)
+        _deserialize_operation(seq, op, vars)
 
     # Measurement
     if obj["measurement"] is not None:

--- a/pulser-core/pulser/json/abstract_repr/deserializer.py
+++ b/pulser-core/pulser/json/abstract_repr/deserializer.py
@@ -277,8 +277,6 @@ def _deserialize_operation(seq: Sequence, op: dict, vars: dict) -> None:
         )
     elif op["op"] == "disable_eom_mode":
         seq.disable_eom_mode(channel=op["channel"])
-    elif op["op"] == "config_slm_mask":
-        seq.config_slm_mask(qubits=op["qubits"], dmm_id=op["dmm_id"])
     elif op["op"] == "modulate_det_map":
         seq.modulate_det_map(
             waveform=_deserialize_waveform(op["waveform"], vars),
@@ -386,6 +384,19 @@ def _deserialize_device_object(obj: dict[str, Any]) -> Device | VirtualDevice:
         raise AbstractReprError("Device deserialization failed.") from e
 
 
+def _deserialize_det_map(ser_det_map: dict) -> DetuningMap:
+    trap_coords = []
+    weights = []
+    for trap in ser_det_map["traps"]:
+        trap_coords.append((trap["x"], trap["y"]))
+        weights.append(trap["weight"])
+    return DetuningMap(
+        trap_coordinates=trap_coords,
+        weights=weights,
+        slug=ser_det_map.get("slug"),
+    )
+
+
 def deserialize_abstract_sequence(obj_str: str) -> Sequence:
     """Deserialize a sequence from an abstract JSON object.
 
@@ -443,20 +454,33 @@ def deserialize_abstract_sequence(obj_str: str) -> Sequence:
         # This is kept for backwards compatibility
         seq.config_slm_mask(obj["slm_mask_targets"])
 
-    # Detuning Map configuration
+    to_config_det_map: dict[str, dict] = dict()
     if "dmm_channels" in obj:
-        for dmm_id, ser_det_map in obj["dmm_channels"]:
-            trap_coords = []
-            weights = []
-            for trap in ser_det_map["traps"]:
-                trap_coords.append((trap["x"], trap["y"]))
-                weights.append(trap["weight"])
-            det_map = DetuningMap(
-                trap_coordinates=trap_coords,
-                weights=weights,
-                slug=ser_det_map.get("slug"),
+        # Make a dictionnary with all the configured dmm channels
+        for dmm_name, ser_det_map in obj["dmm_channels"]:
+            splitted_dmm_name = dmm_name.split("_")  # dmm_id_num
+            dmm_id = "_".join(splitted_dmm_name[0:2])
+            call_num = (
+                0 if len(splitted_dmm_name) <= 2 else int(splitted_dmm_name[2])
             )
-            seq.config_detuning_map(detuning_map=det_map, dmm_id=dmm_id)
+            if dmm_id not in to_config_det_map:
+                to_config_det_map[dmm_id] = {}
+            to_config_det_map[dmm_id][call_num] = ser_det_map
+
+        for dmm_id, ser_det_maps in to_config_det_map.items():
+            slm_mask_dmm = None
+            call_nums = list(ser_det_maps.keys())
+            # If an SLM Mask has been defined, an iteration will be taken
+            for i, call_num in enumerate(call_nums):
+                if call_nums != i:
+                    slm_mask_dmm = i
+            # Have to wait for the SLM Mask to be configured to finish
+            # configuring the last Detuning Maps
+            for call_num, ser_det_map in ser_det_maps.items():
+                if slm_mask_dmm is not None and call_num >= slm_mask_dmm:
+                    break
+                det_map = _deserialize_det_map(ser_det_map)
+                seq.config_detuning_map(detuning_map=det_map, dmm_id=dmm_id)
 
     # Variables
     vars = {}
@@ -470,7 +494,21 @@ def deserialize_abstract_sequence(obj_str: str) -> Sequence:
 
     # Operations
     for op in obj["operations"]:
-        _deserialize_operation(seq, op, vars)
+        if op["op"] == "config_slm_mask":
+            seq.config_slm_mask(qubits=op["qubits"], dmm_id=op["dmm_id"])
+            # Finish configuration of detuning maps
+            if op["dmm_id"] in to_config_det_map and slm_mask_dmm is not None:
+                for call_num, ser_det_map in to_config_det_map[
+                    op["dmm_id"]
+                ].items():
+                    if call_num <= slm_mask_dmm:
+                        continue
+                    det_map = _deserialize_det_map(ser_det_map)
+                    seq.config_detuning_map(
+                        detuning_map=det_map, dmm_id=op["dmm_id"]
+                    )
+        else:
+            _deserialize_operation(seq, op, vars)
 
     # Measurement
     if obj["measurement"] is not None:

--- a/pulser-core/pulser/json/abstract_repr/schemas/device-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/device-schema.json
@@ -7,6 +7,100 @@
       "description": "Hardware channel ID in the Device.",
       "type": "string"
     },
+    "DMMChannel": {
+      "additionalProperties": false,
+      "description": "A DMM channel that can be physical or virtual.",
+      "properties": {
+        "addressing": {
+          "const": "Global",
+          "type": "string"
+        },
+        "basis": {
+          "const": "ground-rydberg",
+          "description": "The addressed basis name.",
+          "type": "string"
+        },
+        "bottom_detuning": {
+          "description": "Minimum possible detuning (in rad/µs), must be below zero.",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "clock_period": {
+          "description": "The duration of a clock cycle (in ns).",
+          "type": "number"
+        },
+        "eom_config": {
+          "description": "Configuration of an associated EOM.",
+          "type": "null"
+        },
+        "fixed_retarget_t": {
+          "description": "Time taken to change the target (in ns).",
+          "type": "null"
+        },
+        "id": {
+          "$ref": "#/definitions/ChannelId",
+          "description": "The identifier of the channel within its device."
+        },
+        "max_abs_detuning": {
+          "description": "Maximum possible detuning (in rad/µs), in absolute value.",
+          "type": "null"
+        },
+        "max_amp": {
+          "const": 0,
+          "description": "Maximum pulse amplitude (in rad/µs).",
+          "type": "number"
+        },
+        "max_duration": {
+          "description": "The longest duration an instruction can take.",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "max_targets": {
+          "description": "How many atoms can be locally addressed at once by the same beam.",
+          "type": "null"
+        },
+        "min_avg_amp": {
+          "description": "The minimum average amplitude of a pulse (when not zero).",
+          "type": "number"
+        },
+        "min_duration": {
+          "description": "The shortest duration an instruction can take.",
+          "type": "number"
+        },
+        "min_retarget_interval": {
+          "description": "Minimum time required between the ends of two target instructions (in ns).",
+          "type": "null"
+        },
+        "mod_bandwidth": {
+          "description": "The modulation bandwidth at -3dB (50% reduction), in MHz.",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "addressing",
+        "basis",
+        "bottom_detuning",
+        "clock_period",
+        "eom_config",
+        "fixed_retarget_t",
+        "id",
+        "max_abs_detuning",
+        "max_amp",
+        "max_duration",
+        "max_targets",
+        "min_duration",
+        "min_retarget_interval",
+        "mod_bandwidth"
+      ],
+      "type": "object"
+    },
     "Device": {
       "anyOf": [
         {
@@ -29,6 +123,13 @@
                 3
               ],
               "type": "number"
+            },
+            "dmm_objects": {
+              "description": "The DMM subclass instances specifying each channel in the device.",
+              "items": {
+                "$ref": "#/definitions/PhysicalDMMChannel"
+              },
+              "type": "array"
             },
             "interaction_coeff_xy": {
               "description": "Coefficient setting the interaction stregth between atoms in different Rydberg states. Needed only if the device has a Microwave channel (otherwise can be null).",
@@ -133,6 +234,13 @@
                 3
               ],
               "type": "number"
+            },
+            "dmm_objects": {
+              "description": "The DMM subclass instances specifying each channel in the device.",
+              "items": {
+                "$ref": "#/definitions/DMMChannel"
+              },
+              "type": "array"
             },
             "interaction_coeff_xy": {
               "description": "Coefficient setting the interaction stregth between atoms in different Rydberg states. Needed only if the device has a Microwave channel (otherwise can be null).",
@@ -1313,6 +1421,93 @@
           "type": "object"
         }
       ]
+    },
+    "PhysicalDMMChannel": {
+      "additionalProperties": false,
+      "properties": {
+        "addressing": {
+          "const": "Global",
+          "type": "string"
+        },
+        "basis": {
+          "const": "ground-rydberg",
+          "description": "The addressed basis name.",
+          "type": "string"
+        },
+        "bottom_detuning": {
+          "description": "Minimum possible detuning (in rad/µs), must be below zero.",
+          "type": "number"
+        },
+        "clock_period": {
+          "description": "The duration of a clock cycle (in ns).",
+          "type": "number"
+        },
+        "eom_config": {
+          "description": "Configuration of an associated EOM.",
+          "type": "null"
+        },
+        "fixed_retarget_t": {
+          "description": "Time taken to change the target (in ns).",
+          "type": "null"
+        },
+        "id": {
+          "$ref": "#/definitions/ChannelId",
+          "description": "The identifier of the channel within its device."
+        },
+        "max_abs_detuning": {
+          "description": "Maximum possible detuning (in rad/µs), in absolute value.",
+          "type": "null"
+        },
+        "max_amp": {
+          "const": 0,
+          "description": "Maximum pulse amplitude (in rad/µs).",
+          "type": "number"
+        },
+        "max_duration": {
+          "description": "The longest duration an instruction can take.",
+          "type": "number"
+        },
+        "max_targets": {
+          "description": "How many atoms can be locally addressed at once by the same beam.",
+          "type": "null"
+        },
+        "min_avg_amp": {
+          "description": "The minimum average amplitude of a pulse (when not zero).",
+          "type": "number"
+        },
+        "min_duration": {
+          "description": "The shortest duration an instruction can take.",
+          "type": "number"
+        },
+        "min_retarget_interval": {
+          "description": "Minimum time required between the ends of two target instructions (in ns).",
+          "type": "null"
+        },
+        "mod_bandwidth": {
+          "description": "The modulation bandwidth at -3dB (50% reduction), in MHz.",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "addressing",
+        "basis",
+        "bottom_detuning",
+        "clock_period",
+        "eom_config",
+        "fixed_retarget_t",
+        "id",
+        "max_abs_detuning",
+        "max_amp",
+        "max_duration",
+        "max_targets",
+        "min_duration",
+        "min_retarget_interval",
+        "mod_bandwidth"
+      ],
+      "type": "object"
     },
     "RydbergBeam": {
       "enum": [

--- a/pulser-core/pulser/json/abstract_repr/schemas/sequence-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/sequence-schema.json
@@ -418,6 +418,29 @@
       ],
       "type": "object"
     },
+    "OpConfigDetMap": {
+      "additionalProperties": false,
+      "properties": {
+        "detuning_map": {
+          "$ref": "#/definitions/WeightMap",
+          "description": "DetuningMap to associate with the DMM channel."
+        },
+        "dmm_id": {
+          "$ref": "#/definitions/ChannelId",
+          "description": "ID of the DMM channel to configure."
+        },
+        "op": {
+          "const": "config_detuning_map",
+          "type": "string"
+        }
+      },
+      "required": [
+        "op",
+        "detuning_map",
+        "dmm_id"
+      ],
+      "type": "object"
+    },
     "OpConfigSLM": {
       "additionalProperties": false,
       "properties": {
@@ -742,6 +765,9 @@
           "$ref": "#/definitions/OpConfigSLM"
         },
         {
+          "$ref": "#/definitions/OpConfigDetMap"
+        },
+        {
           "$ref": "#/definitions/OpModDetMap"
         }
       ],
@@ -800,23 +826,6 @@
                 }
               ],
               "description": "A valid device in which to execute the Sequence"
-            },
-            "dmm_channels": {
-              "description": "DMM channels declared in this Sequence.",
-              "items": {
-                "items": [
-                  {
-                    "$ref": "#/definitions/ChannelId"
-                  },
-                  {
-                    "$ref": "#/definitions/WeightMap"
-                  }
-                ],
-                "maxItems": 2,
-                "minItems": 2,
-                "type": "array"
-              },
-              "type": "array"
             },
             "layout": {
               "$ref": "#/definitions/Layout",
@@ -914,23 +923,6 @@
                 }
               ],
               "description": "A valid device in which to execute the Sequence"
-            },
-            "dmm_channels": {
-              "description": "DMM channels declared in this Sequence.",
-              "items": {
-                "items": [
-                  {
-                    "$ref": "#/definitions/ChannelId"
-                  },
-                  {
-                    "$ref": "#/definitions/WeightMap"
-                  }
-                ],
-                "maxItems": 2,
-                "minItems": 2,
-                "type": "array"
-              },
-              "type": "array"
             },
             "layout": {
               "$ref": "#/definitions/Layout",

--- a/pulser-core/pulser/json/abstract_repr/schemas/sequence-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/sequence-schema.json
@@ -418,6 +418,32 @@
       ],
       "type": "object"
     },
+    "OpConfigSLM": {
+      "additionalProperties": false,
+      "properties": {
+        "dmm_id": {
+          "$ref": "#/definitions/ChannelId",
+          "description": "ID of the DMM channel to use for the SLM mask."
+        },
+        "op": {
+          "const": "config_slm_mask",
+          "type": "string"
+        },
+        "qubits": {
+          "description": "Qubit ID's to mask during the first global pulse of the sequence.",
+          "items": {
+            "$ref": "#/definitions/QubitId"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "op",
+        "qubits",
+        "dmm_id"
+      ],
+      "type": "object"
+    },
     "OpDelay": {
       "additionalProperties": false,
       "description": "Adds extra fixed delay before starting the pulse.",
@@ -449,6 +475,10 @@
           "$ref": "#/definitions/ChannelName",
           "description": "The name of the channel to take out of EOM mode."
         },
+        "correct_phase_drift": {
+          "description": "Performs a phase shift to correct for the phase drift that occured since the last pulse (or the start of the EOM mode, if no pulse was added).",
+          "type": "boolean"
+        },
         "op": {
           "const": "disable_eom_mode",
           "type": "string"
@@ -466,6 +496,10 @@
         "channel": {
           "$ref": "#/definitions/ChannelName",
           "description": "The name of the channel to add the pulse to."
+        },
+        "correct_phase_drift": {
+          "description": "Performs a phase shift to correct for the phase drift that occured since the last pulse (or the start of the EOM mode, if adding the first pulse).",
+          "type": "boolean"
         },
         "duration": {
           "$ref": "#/definitions/ParametrizedNum",
@@ -514,6 +548,10 @@
           "$ref": "#/definitions/ChannelName",
           "description": "The name of the channel to put in EOM mode."
         },
+        "correct_phase_drift": {
+          "description": "Performs a phase shift to correct for the phase drift incurred while turning on the EOM mode.",
+          "type": "boolean"
+        },
         "detuning_on": {
           "$ref": "#/definitions/ParametrizedNum",
           "description": "The detuning of the EOM pulses (in rad/µs)."
@@ -533,6 +571,39 @@
         "amp_on",
         "detuning_on",
         "optimal_detuning_off"
+      ],
+      "type": "object"
+    },
+    "OpModDetMap": {
+      "additionalProperties": false,
+      "properties": {
+        "dmm_name": {
+          "$ref": "#/definitions/ChannelName",
+          "description": "The name of the DMM."
+        },
+        "op": {
+          "const": "modulate_det_map",
+          "type": "string"
+        },
+        "protocol": {
+          "description": "Stipulates how to deal with eventual conflicts with other channels, specifically in terms of having multiple channels act on the same target simultaneously.\n\n- ``'min-delay'``: Before adding the pulse, introduces the   smallest possible delay that avoids all exisiting conflicts.\n\n- ``'no-delay'``: Adds the pulse to the channel, regardless of   existing conflicts.\n\n- ``'wait-for-all'``: Before adding the pulse, adds a delay   that idles the channel until the end of the other channels'   latest pulse.",
+          "enum": [
+            "min-delay",
+            "no-delay",
+            "wait-for-all"
+          ],
+          "type": "string"
+        },
+        "waveform": {
+          "$ref": "#/definitions/Waveform",
+          "description": "The waveform to add to the detuning of the DMM."
+        }
+      },
+      "required": [
+        "op",
+        "waveform",
+        "dmm_name",
+        "protocol"
       ],
       "type": "object"
     },
@@ -666,6 +737,12 @@
         },
         {
           "$ref": "#/definitions/OpEOMPulse"
+        },
+        {
+          "$ref": "#/definitions/OpConfigSLM"
+        },
+        {
+          "$ref": "#/definitions/OpModDetMap"
         }
       ],
       "description": "Sequence operation. All operations are performed in specified order."
@@ -723,6 +800,23 @@
                 }
               ],
               "description": "A valid device in which to execute the Sequence"
+            },
+            "dmm_channels": {
+              "description": "DMM channels declared in this Sequence.",
+              "items": {
+                "items": [
+                  {
+                    "$ref": "#/definitions/ChannelId"
+                  },
+                  {
+                    "$ref": "#/definitions/WeightMap"
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2,
+                "type": "array"
+              },
+              "type": "array"
             },
             "layout": {
               "$ref": "#/definitions/Layout",
@@ -820,6 +914,23 @@
                 }
               ],
               "description": "A valid device in which to execute the Sequence"
+            },
+            "dmm_channels": {
+              "description": "DMM channels declared in this Sequence.",
+              "items": {
+                "items": [
+                  {
+                    "$ref": "#/definitions/ChannelId"
+                  },
+                  {
+                    "$ref": "#/definitions/WeightMap"
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2,
+                "type": "array"
+              },
+              "type": "array"
             },
             "layout": {
               "$ref": "#/definitions/Layout",
@@ -1005,6 +1116,48 @@
         }
       ],
       "description": "Modulation waveform of any kind"
+    },
+    "WeightMap": {
+      "additionalProperties": false,
+      "description": "Associates weights to trap coordinates. The sum of the provided weights must be equal to 1.",
+      "properties": {
+        "slug": {
+          "type": "string"
+        },
+        "traps": {
+          "items": {
+            "$ref": "#/definitions/WeightedTrap"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "traps"
+      ],
+      "type": "object"
+    },
+    "WeightedTrap": {
+      "additionalProperties": false,
+      "properties": {
+        "weight": {
+          "description": "The weight on the site.",
+          "type": "number"
+        },
+        "x": {
+          "description": "x-position in µm",
+          "type": "number"
+        },
+        "y": {
+          "description": "y-position in µm",
+          "type": "number"
+        }
+      },
+      "required": [
+        "weight",
+        "x",
+        "y"
+      ],
+      "type": "object"
     }
   }
 }

--- a/pulser-core/pulser/json/abstract_repr/serializer.py
+++ b/pulser-core/pulser/json/abstract_repr/serializer.py
@@ -211,13 +211,13 @@ def serialize_abstract_sequence(
                     }
                 )
         elif call.name == "config_detuning_map":
-            data = get_all_args(("dmm_name", "dmm_id", "detuning_map"), call)
-            if "dmm_channels" not in res:
-                # Adding this field will break backwards compatibility, so
-                # we only add it if necessary
-                res["dmm_channels"] = []
-            res["dmm_channels"].append(
-                [data["dmm_name"], data["detuning_map"]]
+            data = get_all_args(("detuning_map", "dmm_id"), call)
+            operations.append(
+                {
+                    "op": "config_detuning_map",
+                    "detuning_map": data["detuning_map"],
+                    "dmm_id": data["dmm_id"],
+                }
             )
         elif "target" in call.name:
             data = get_all_args(("qubits", "channel"), call)

--- a/pulser-core/pulser/json/abstract_repr/serializer.py
+++ b/pulser-core/pulser/json/abstract_repr/serializer.py
@@ -211,12 +211,14 @@ def serialize_abstract_sequence(
                     }
                 )
         elif call.name == "config_detuning_map":
-            data = get_all_args(("detuning_map", "dmm_id"), call)
+            data = get_all_args(("dmm_name", "dmm_id", "detuning_map"), call)
             if "dmm_channels" not in res:
                 # Adding this field will break backwards compatibility, so
                 # we only add it if necessary
                 res["dmm_channels"] = []
-            res["dmm_channels"].append([data["dmm_id"], data["detuning_map"]])
+            res["dmm_channels"].append(
+                [data["dmm_name"], data["detuning_map"]]
+            )
         elif "target" in call.name:
             data = get_all_args(("qubits", "channel"), call)
             if call.name == "target":

--- a/pulser-core/pulser/json/abstract_repr/serializer.py
+++ b/pulser-core/pulser/json/abstract_repr/serializer.py
@@ -26,6 +26,7 @@ import numpy as np
 from pulser.json.abstract_repr.signatures import SIGNATURES
 from pulser.json.abstract_repr.validation import validate_abstract_repr
 from pulser.json.exceptions import AbstractReprError
+from pulser.json.utils import stringify_qubit_ids
 
 if TYPE_CHECKING:
     from pulser.register.base_register import QubitId
@@ -209,6 +210,13 @@ def serialize_abstract_sequence(
                         "target": convert_targets(data["initial_target"]),
                     }
                 )
+        elif call.name == "config_detuning_map":
+            data = get_all_args(("detuning_map", "dmm_id"), call)
+            if "dmm_channels" not in res:
+                # Adding this field will break backwards compatibility, so
+                # we only add it if necessary
+                res["dmm_channels"] = []
+            res["dmm_channels"].append([data["dmm_id"], data["detuning_map"]])
         elif "target" in call.name:
             data = get_all_args(("qubits", "channel"), call)
             if call.name == "target":
@@ -266,7 +274,21 @@ def serialize_abstract_sequence(
         elif call.name == "set_magnetic_field":
             res["magnetic_field"] = seq.magnetic_field.tolist()
         elif call.name == "config_slm_mask":
-            res["slm_mask_targets"] = tuple(seq._slm_mask_targets)
+            data = get_all_args(("qubits", "dmm_id"), call)
+            qubit_ids = stringify_qubit_ids(data["qubits"])
+            if seq._in_xy and data["dmm_id"] == get_kwarg_default(
+                call.name, "dmm_id"
+            ):
+                # Use the old way in XY mode to preserve compatibility
+                res["slm_mask_targets"] = tuple(qubit_ids)
+            else:
+                operations.append(
+                    {
+                        "op": "config_slm_mask",
+                        "qubits": qubit_ids,
+                        "dmm_id": data["dmm_id"],
+                    }
+                )
         elif call.name == "enable_eom_mode":
             data = get_all_args(
                 ("channel", "amp_on", "detuning_on", "optimal_detuning_off"),
@@ -290,6 +312,9 @@ def serialize_abstract_sequence(
             operations.append(
                 {"op": "disable_eom_mode", "channel": data["channel"]}
             )
+        elif call.name == "modulate_det_map":
+            data = get_all_args(("waveform", "dmm_name", "protocol"), call)
+            operations.append({"op": "modulate_det_map", **data})
         else:
             raise AbstractReprError(f"Unknown call '{call.name}'.")
 

--- a/pulser-core/pulser/json/abstract_repr/validation.py
+++ b/pulser-core/pulser/json/abstract_repr/validation.py
@@ -16,12 +16,12 @@ import json
 from typing import Literal
 
 import jsonschema
+from referencing import Registry, Resource
 
-from pulser.json.abstract_repr import SCHEMAS, SCHEMAS_PATH
+from pulser.json.abstract_repr import SCHEMAS
 
-RESOLVER = jsonschema.validators.RefResolver(
-    base_uri=f"{SCHEMAS_PATH.resolve().as_uri()}/",
-    referrer=SCHEMAS["sequence"],
+REGISTRY: Registry = Registry().with_resources(
+    [("device-schema.json", Resource.from_contents(SCHEMAS["device"]))]
 )
 
 
@@ -37,5 +37,5 @@ def validate_abstract_repr(
     obj = json.loads(obj_str)
     validate_args = dict(instance=obj, schema=SCHEMAS[name])
     if name == "sequence":
-        validate_args["resolver"] = RESOLVER
+        validate_args["registry"] = REGISTRY
     jsonschema.validate(**validate_args)

--- a/pulser-core/pulser/json/coders.py
+++ b/pulser-core/pulser/json/coders.py
@@ -34,7 +34,7 @@ class PulserEncoder(JSONEncoder):
         """Handles JSON encoding of objects not supported by default."""
         if hasattr(o, "_to_dict"):
             return cast(dict, o._to_dict())
-        elif type(o) == type:
+        elif type(o) is type:
             return obj_to_dict(o, _build=False, _name=o.__name__)
         elif isinstance(o, np.ndarray):
             return obj_to_dict(o, o.tolist(), _name="array")

--- a/pulser-core/pulser/register/base_register.py
+++ b/pulser-core/pulser/register/base_register.py
@@ -216,6 +216,7 @@ class BaseRegister(ABC):
             detuning_weights: A mapping between the IDs of the targeted qubits
                 and detuning weights (between 0 and 1, their sum must be equal
                 to 1).
+            slug: An optional identifier for the detuning map.
 
         Returns:
             A DetuningMap associating detuning weights to the trap coordinates

--- a/pulser-core/pulser/register/base_register.py
+++ b/pulser-core/pulser/register/base_register.py
@@ -206,7 +206,9 @@ class BaseRegister(ABC):
                 )
 
     def define_detuning_map(
-        self, detuning_weights: Mapping[QubitId, float]
+        self,
+        detuning_weights: Mapping[QubitId, float],
+        slug: str | None = None,
     ) -> DetuningMap:
         """Defines a DetuningMap for some qubits of the register.
 
@@ -227,6 +229,7 @@ class BaseRegister(ABC):
         return DetuningMap(
             [self.qubits[qubit_id] for qubit_id in detuning_weights],
             list(detuning_weights.values()),
+            slug,
         )
 
     @abstractmethod

--- a/pulser-core/pulser/register/mappable_reg.py
+++ b/pulser-core/pulser/register/mappable_reg.py
@@ -124,7 +124,9 @@ class MappableRegister:
         return [self.qubit_ids.index(id) for id in id_list]
 
     def define_detuning_map(
-        self, detuning_weights: Mapping[int, float]
+        self,
+        detuning_weights: Mapping[int, float],
+        slug: str | None = None,
     ) -> DetuningMap:
         """Defines a DetuningMap for some trap ids of the register layout.
 
@@ -137,7 +139,7 @@ class MappableRegister:
             A DetuningMap associating detuning weights to the trap coordinates
                 of the targeted traps.
         """
-        return self._layout.define_detuning_map(detuning_weights)
+        return self._layout.define_detuning_map(detuning_weights, slug)
 
     def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(self, self._layout, *self._qubit_ids)

--- a/pulser-core/pulser/register/mappable_reg.py
+++ b/pulser-core/pulser/register/mappable_reg.py
@@ -134,6 +134,7 @@ class MappableRegister:
             detuning_weights: A mapping between the IDs of the targeted traps
                 and detuning weights (between 0 and 1, their sum must be equal
                 to 1).
+            slug: An optional identifier for the detuning map.
 
         Returns:
             A DetuningMap associating detuning weights to the trap coordinates

--- a/pulser-core/pulser/register/register_layout.py
+++ b/pulser-core/pulser/register/register_layout.py
@@ -110,6 +110,7 @@ class RegisterLayout(Traps, RegDrawer):
             detuning_weights: A mapping between the IDs of the targeted traps
                 and detuning weights (between 0 and 1, their sum must be equal
                 to 1).
+            slug: An optional identifier for the detuning map.
 
         Returns:
             A DetuningMap associating detuning weights to the trap coordinates

--- a/pulser-core/pulser/register/register_layout.py
+++ b/pulser-core/pulser/register/register_layout.py
@@ -100,7 +100,9 @@ class RegisterLayout(Traps, RegDrawer):
         return reg
 
     def define_detuning_map(
-        self, detuning_weights: Mapping[int, float]
+        self,
+        detuning_weights: Mapping[int, float],
+        slug: str | None = None,
     ) -> DetuningMap:
         """Defines a DetuningMap for some trap ids of the register layout.
 
@@ -121,6 +123,7 @@ class RegisterLayout(Traps, RegDrawer):
         return DetuningMap(
             itemgetter(*detuning_weights.keys())(self.traps_dict),
             list(detuning_weights.values()),
+            slug,
         )
 
     def draw(

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -568,7 +568,7 @@ class Sequence(Generic[DeviceType]):
                 detuning to modulate.
             dmm_id: How the channel is identified in the device.
                 See in ``Sequence.available_channels`` which DMM IDs are still
-                available (start by "dmm_" ) and the associated description.
+                available (start by "dmm" ) and the associated description.
         """
         self._config_detuning_map(detuning_map, dmm_id, to_store=True)
 

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -60,6 +60,7 @@ from pulser.sequence._call import _Call
 from pulser.sequence._schedule import (
     _ChannelSchedule,
     _DMMSchedule,
+    _PhaseDriftParams,
     _Schedule,
     _TimeSlot,
 )
@@ -997,6 +998,7 @@ class Sequence(Generic[DeviceType]):
         amp_on: Union[float, Parametrized],
         detuning_on: Union[float, Parametrized],
         optimal_detuning_off: Union[float, Parametrized] = 0.0,
+        correct_phase_drift: bool = False,
     ) -> None:
         """Puts a channel in EOM mode operation.
 
@@ -1029,6 +1031,8 @@ class Sequence(Generic[DeviceType]):
             optimal_detuning_off: The optimal value of detuning (in rad/µs)
                 when there is no pulse being played. It will choose the closest
                 value among the existing options.
+            correct_phase_drift: Performs a phase shift to correct for the
+                phase drift incurred while turning on the EOM mode.
         """
         if self.is_in_eom_mode(channel):
             raise RuntimeError(
@@ -1045,29 +1049,35 @@ class Sequence(Generic[DeviceType]):
             channel_obj.validate_pulse(on_pulse)
             amp_on = cast(float, amp_on)
             detuning_on = cast(float, detuning_on)
-
-            off_options = cast(
-                RydbergEOM, channel_obj.eom_config
-            ).detuning_off_options(amp_on, detuning_on)
-
+            eom_config = cast(RydbergEOM, channel_obj.eom_config)
             if not isinstance(optimal_detuning_off, Parametrized):
-                closest_option = np.abs(
-                    off_options - optimal_detuning_off
-                ).argmin()
-                detuning_off = off_options[closest_option]
+                detuning_off = eom_config.calculate_detuning_off(
+                    amp_on, detuning_on, optimal_detuning_off
+                )
                 off_pulse = Pulse.ConstantPulse(
                     channel_obj.min_duration, 0.0, detuning_off, 0.0
                 )
                 channel_obj.validate_pulse(off_pulse)
 
             if not self.is_parametrized():
+                phase_drift_params = _PhaseDriftParams(
+                    drift_rate=-detuning_off, ti=self.get_duration(channel)
+                )
                 self._schedule.enable_eom(
                     channel, amp_on, detuning_on, detuning_off
                 )
+                if correct_phase_drift:
+                    buffer_slot = self._last(channel)
+                    drift = phase_drift_params.calc_phase_drift(buffer_slot.tf)
+                    self._phase_shift(
+                        -drift, *buffer_slot.targets, basis=channel_obj.basis
+                    )
 
     @seq_decorators.store
     @seq_decorators.block_if_measured
-    def disable_eom_mode(self, channel: str) -> None:
+    def disable_eom_mode(
+        self, channel: str, correct_phase_drift: bool = False
+    ) -> None:
         """Takes a channel out of EOM mode operation.
 
         For channels with a finite modulation bandwidth and an EOM, operation
@@ -1090,11 +1100,24 @@ class Sequence(Generic[DeviceType]):
 
         Args:
             channel: The name of the channel to take out of EOM mode.
+            correct_phase_drift: Performs a phase shift to correct for the
+                phase drift that occured since the last pulse (or the start of
+                the EOM mode, if no pulse was added).
         """
         if not self.is_in_eom_mode(channel):
             raise RuntimeError(f"The '{channel}' channel is not in EOM mode.")
         if not self.is_parametrized():
             self._schedule.disable_eom(channel)
+            if correct_phase_drift:
+                ch_schedule = self._schedule[channel]
+                # EOM mode has just been disabled, so tf is defined
+                last_eom_block_tf = cast(int, ch_schedule.eom_blocks[-1].tf)
+                drift_params = self._get_last_eom_pulse_phase_drift(channel)
+                self._phase_shift(
+                    -drift_params.calc_phase_drift(last_eom_block_tf),
+                    *ch_schedule[-1].targets,
+                    basis=ch_schedule.channel_obj.basis,
+                )
 
     @seq_decorators.store
     @seq_decorators.mark_non_empty
@@ -1106,6 +1129,7 @@ class Sequence(Generic[DeviceType]):
         phase: Union[float, Parametrized],
         post_phase_shift: Union[float, Parametrized] = 0.0,
         protocol: PROTOCOLS = "min-delay",
+        correct_phase_drift: bool = False,
     ) -> None:
         """Adds a square pulse to a channel in EOM mode.
 
@@ -1136,6 +1160,11 @@ class Sequence(Generic[DeviceType]):
                 immediately after the end of the pulse.
             protocol: Stipulates how to deal with eventual conflicts with
                 other channels (see `Sequence.add()` for more details).
+            correct_phase_drift: Adjusts the phase to correct for the phase
+                drift that occured since the last pulse (or the start of the
+                EOM mode, if adding the first pulse). This effectively
+                changes the phase of the EOM pulse, so an extra delay might
+                be added to enforce the phase jump time.
         """
         if not self.is_in_eom_mode(channel):
             raise RuntimeError(f"Channel '{channel}' must be in EOM mode.")
@@ -1159,7 +1188,14 @@ class Sequence(Generic[DeviceType]):
             phase,
             post_phase_shift=post_phase_shift,
         )
-        self._add(eom_pulse, channel, protocol)
+        phase_drift_params = (
+            self._get_last_eom_pulse_phase_drift(channel)
+            if correct_phase_drift
+            else None
+        )
+        self._add(
+            eom_pulse, channel, protocol, phase_drift_params=phase_drift_params
+        )
 
     @seq_decorators.store
     @seq_decorators.mark_non_empty
@@ -1723,6 +1759,7 @@ class Sequence(Generic[DeviceType]):
         pulse: Union[Pulse, Parametrized],
         channel: str,
         protocol: PROTOCOLS,
+        phase_drift_params: _PhaseDriftParams | None = None,
     ) -> None:
         self._validate_add_protocol(protocol)
         if self.is_parametrized():
@@ -1752,7 +1789,13 @@ class Sequence(Generic[DeviceType]):
             self._basis_ref[basis][q].phase.last_time for q in last.targets
         ]
 
-        self._schedule.add_pulse(pulse, channel, phase_barriers, protocol)
+        self._schedule.add_pulse(
+            pulse,
+            channel,
+            phase_barriers,
+            protocol,
+            phase_drift_params=phase_drift_params,
+        )
 
         true_finish = self._last(channel).tf + pulse.fall_time(
             channel_obj, in_eom_mode=self.is_in_eom_mode(channel)
@@ -1880,6 +1923,24 @@ class Sequence(Generic[DeviceType]):
 
             for qubit in target_ids:
                 self._basis_ref[basis][qubit].increment_phase(phi)
+
+    def _get_last_eom_pulse_phase_drift(
+        self, channel: str
+    ) -> _PhaseDriftParams:
+        eom_settings = self._schedule[channel].eom_blocks[-1]
+        try:
+            last_pulse_tf = (
+                self._schedule[channel]
+                .last_pulse_slot(ignore_detuned_delay=True)
+                .tf
+            )
+        except RuntimeError:
+            # There is no previous pulse
+            last_pulse_tf = 0
+        return _PhaseDriftParams(
+            drift_rate=-eom_settings.detuning_off,
+            ti=max(eom_settings.ti, last_pulse_tf),
+        )
 
     def _to_dict(self, _module: str = "pulser.sequence") -> dict[str, Any]:
         d = obj_to_dict(

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -510,7 +510,7 @@ class Sequence(Generic[DeviceType]):
         configured using this Detuning Map, and modulated by a pulse having
         a large negative detuning and either a duration defined from pulses
         already present in the sequence (same as in XY mode) or by the first
-        pulse added after this operation.  
+        pulse added after this operation.
 
         Args:
             qubits: Iterable of qubit ID's to mask during the first global

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -471,10 +471,10 @@ class Sequence(Generic[DeviceType]):
                 for qubit in self.register.qubit_ids
             }
         )
-        self.config_detuning_map(detuning_map, dmm_id)
+        self._config_detuning_map(detuning_map, dmm_id, to_store=False)
         # Find the name of the dmm in the declared channels.
         for key in reversed(self.declared_channels.keys()):
-            if dmm_id in key:
+            if dmm_id == "_".join(key.split("_")[0:2]):
                 self._slm_mask_dmm = key
                 break
         # Modulate the dmm if pulses have already been added to Global Channels
@@ -570,12 +570,13 @@ class Sequence(Generic[DeviceType]):
                 See in ``Sequence.available_channels`` which DMM IDs are still
                 available (start by "dmm_" ) and the associated description.
         """
-        self._config_detuning_map(detuning_map, dmm_id)
+        self._config_detuning_map(detuning_map, dmm_id, to_store=True)
 
     def _config_detuning_map(
         self,
         detuning_map: DetuningMap,
         dmm_id: str,
+        to_store: bool = True,
     ) -> None:
         if dmm_id not in self._device.dmm_channels:
             raise ValueError(f"No DMM {dmm_id} in the device.")
@@ -611,9 +612,12 @@ class Sequence(Generic[DeviceType]):
         # DMM has Global addressing
         self._add_to_schedule(dmm_name, _TimeSlot("target", -1, 0, self._qids))
         # Manually store the channel declaration as a regular call
-        self._calls.append(
-            _Call("config_detuning_map", (dmm_name, dmm_id, detuning_map), {})
-        )
+        if to_store:
+            self._calls.append(
+                _Call(
+                    "config_detuning_map", (dmm_name, dmm_id, detuning_map), {}
+                )
+            )
 
     def switch_device(
         self, new_device: DeviceType, strict: bool = False

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -674,7 +674,7 @@ class Sequence(Generic[DeviceType]):
 
                 # We verify the channel class then
                 # check whether the addressing is Global or Local
-                type_match = type(old_ch_obj) == type(new_ch_obj)
+                type_match = type(old_ch_obj) is type(new_ch_obj)
                 basis_match = old_ch_obj.basis == new_ch_obj.basis
                 addressing_match = (
                     old_ch_obj.addressing == new_ch_obj.addressing

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -501,8 +501,16 @@ class Sequence(Generic[DeviceType]):
     ) -> None:
         """Setup an SLM mask by specifying the qubits it targets.
 
-        A SLM mask is a DetuningMap where the detuning of each masked qubit
-        is the same.
+        If the sequence is in XY mode, masked qubits don't interact with
+        the incoming pulses until the end of the first pulse of the global
+        channel starting the earliest in the schedule.
+
+        If the sequence is in Ising, the SLM Mask is a DetuningMap where
+        the detuning of each masked qubit is the same. DMM "dmm_id" is
+        configured using this Detuning Map, and modulated by a pulse having
+        a large negative detuning and either a duration defined from pulses
+        already present in the sequence (same as in XY mode) or by the first
+        pulse added after this operation.  
 
         Args:
             qubits: Iterable of qubit ID's to mask during the first global
@@ -562,6 +570,13 @@ class Sequence(Generic[DeviceType]):
                 See in ``Sequence.available_channels`` which DMM IDs are still
                 available (start by "dmm_" ) and the associated description.
         """
+        self._config_detuning_map(detuning_map, dmm_id)
+
+    def _config_detuning_map(
+        self,
+        detuning_map: DetuningMap,
+        dmm_id: str,
+    ) -> None:
         if dmm_id not in self._device.dmm_channels:
             raise ValueError(f"No DMM {dmm_id} in the device.")
 

--- a/pulser-core/requirements.txt
+++ b/pulser-core/requirements.txt
@@ -1,4 +1,4 @@
-jsonschema < 4.18
+jsonschema >= 4.18
 matplotlib
 # Numpy 1.20 introduces type hints, 1.24.0 breaks matplotlib < 3.6.1
 numpy >= 1.20, != 1.24.0

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -37,7 +37,7 @@ from pulser.json.abstract_repr.serializer import (
     AbstractReprEncoder,
     abstract_repr,
 )
-from pulser.json.abstract_repr.validation import RESOLVER
+from pulser.json.abstract_repr.validation import REGISTRY
 from pulser.json.exceptions import AbstractReprError, DeserializeDeviceError
 from pulser.parametrized.decorators import parametrize
 from pulser.parametrized.paramobj import ParamObj
@@ -241,7 +241,7 @@ def validate_schema(instance):
         "pulser-core/pulser/json/abstract_repr/schemas/" "sequence-schema.json"
     ) as f:
         schema = json.load(f)
-    jsonschema.validate(instance=instance, schema=schema, resolver=RESOLVER)
+    jsonschema.validate(instance=instance, schema=schema, registry=REGISTRY)
 
 
 class TestSerialization:
@@ -693,32 +693,48 @@ class TestSerialization:
         ]
         assert abstract["variables"]["var"] == dict(type="int", value=[0])
 
-    def test_eom_mode(self, triangular_lattice):
+    @pytest.mark.parametrize("correct_phase_drift", (False, True))
+    def test_eom_mode(self, triangular_lattice, correct_phase_drift):
         reg = triangular_lattice.hexagonal_register(7)
         seq = Sequence(reg, IroiseMVP)
         seq.declare_channel("ryd", "rydberg_global")
         det_off = seq.declare_variable("det_off", dtype=float)
         duration = seq.declare_variable("duration", dtype=int)
         seq.enable_eom_mode(
-            "ryd", amp_on=3.0, detuning_on=0.0, optimal_detuning_off=det_off
+            "ryd",
+            amp_on=3.0,
+            detuning_on=0.0,
+            optimal_detuning_off=det_off,
+            correct_phase_drift=correct_phase_drift,
         )
-        seq.add_eom_pulse("ryd", duration, 0.0)
+        seq.add_eom_pulse(
+            "ryd", duration, 0.0, correct_phase_drift=correct_phase_drift
+        )
         seq.delay(duration, "ryd")
-        seq.disable_eom_mode("ryd")
+        seq.disable_eom_mode("ryd", correct_phase_drift)
 
         abstract = json.loads(seq.to_abstract_repr())
         validate_schema(abstract)
 
+        extra_kwargs = (
+            dict(correct_phase_drift=correct_phase_drift)
+            if correct_phase_drift
+            else {}
+        )
+
         assert abstract["operations"][0] == {
-            "op": "enable_eom_mode",
-            "channel": "ryd",
-            "amp_on": 3.0,
-            "detuning_on": 0.0,
-            "optimal_detuning_off": {
-                "expression": "index",
-                "lhs": {"variable": "det_off"},
-                "rhs": 0,
+            **{
+                "op": "enable_eom_mode",
+                "channel": "ryd",
+                "amp_on": 3.0,
+                "detuning_on": 0.0,
+                "optimal_detuning_off": {
+                    "expression": "index",
+                    "lhs": {"variable": "det_off"},
+                    "rhs": 0,
+                },
             },
+            **extra_kwargs,
         }
 
         ser_duration = {
@@ -727,17 +743,23 @@ class TestSerialization:
             "rhs": 0,
         }
         assert abstract["operations"][1] == {
-            "op": "add_eom_pulse",
-            "channel": "ryd",
-            "duration": ser_duration,
-            "phase": 0.0,
-            "post_phase_shift": 0.0,
-            "protocol": "min-delay",
+            **{
+                "op": "add_eom_pulse",
+                "channel": "ryd",
+                "duration": ser_duration,
+                "phase": 0.0,
+                "post_phase_shift": 0.0,
+                "protocol": "min-delay",
+            },
+            **extra_kwargs,
         }
 
         assert abstract["operations"][3] == {
-            "op": "disable_eom_mode",
-            "channel": "ryd",
+            **{
+                "op": "disable_eom_mode",
+                "channel": "ryd",
+            },
+            **extra_kwargs,
         }
 
     @pytest.mark.parametrize("use_default", [True, False])
@@ -894,6 +916,10 @@ def _check_roundtrip(serialized_seq: dict[str, Any]):
                             *(op[wf][qty] for qty in wf_args)
                         )
                         op[wf] = reconstructed_wf._to_abstract_repr()
+        elif "eom" in op["op"] and not op.get("correct_phase_drift"):
+            # Remove correct_phase_drift when at default, since the
+            # roundtrip will delete it
+            op.pop("correct_phase_drift", None)
 
     seq = Sequence.from_abstract_repr(json.dumps(s))
     defaults = {
@@ -1528,7 +1554,8 @@ class TestDeserialization:
         else:
             assert pulse.kwargs["detuning"] == 1
 
-    def test_deserialize_eom_ops(self):
+    @pytest.mark.parametrize("correct_phase_drift", (False, True, None))
+    def test_deserialize_eom_ops(self, correct_phase_drift):
         s = _get_serialized_seq(
             operations=[
                 {
@@ -1537,6 +1564,7 @@ class TestDeserialization:
                     "amp_on": 3.0,
                     "detuning_on": 0.0,
                     "optimal_detuning_off": -1.0,
+                    "correct_phase_drift": correct_phase_drift,
                 },
                 {
                     "op": "add_eom_pulse",
@@ -1549,16 +1577,21 @@ class TestDeserialization:
                     "phase": 0.0,
                     "post_phase_shift": 0.0,
                     "protocol": "no-delay",
+                    "correct_phase_drift": correct_phase_drift,
                 },
                 {
                     "op": "disable_eom_mode",
                     "channel": "global",
+                    "correct_phase_drift": correct_phase_drift,
                 },
             ],
             variables={"duration": {"type": "int", "value": [100]}},
             device=json.loads(IroiseMVP.to_abstract_repr()),
             channels={"global": "rydberg_global"},
         )
+        if correct_phase_drift is None:
+            for op in s["operations"]:
+                del op["correct_phase_drift"]
         _check_roundtrip(s)
         seq = Sequence.from_abstract_repr(json.dumps(s))
         # init + declare_channel + enable_eom_mode
@@ -1573,11 +1606,15 @@ class TestDeserialization:
             "amp_on": 3.0,
             "detuning_on": 0.0,
             "optimal_detuning_off": -1.0,
+            "correct_phase_drift": bool(correct_phase_drift),
         }
 
         disable_eom_call = seq._to_build_calls[-1]
         assert disable_eom_call.name == "disable_eom_mode"
-        assert disable_eom_call.kwargs == {"channel": "global"}
+        assert disable_eom_call.kwargs == {
+            "channel": "global",
+            "correct_phase_drift": bool(correct_phase_drift),
+        }
 
         eom_pulse_call = seq._to_build_calls[0]
         assert eom_pulse_call.name == "add_eom_pulse"
@@ -1586,6 +1623,9 @@ class TestDeserialization:
         assert eom_pulse_call.kwargs["phase"] == 0.0
         assert eom_pulse_call.kwargs["post_phase_shift"] == 0.0
         assert eom_pulse_call.kwargs["protocol"] == "no-delay"
+        assert eom_pulse_call.kwargs["correct_phase_drift"] == bool(
+            correct_phase_drift
+        )
 
     @pytest.mark.parametrize(
         "wf_obj",

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -824,7 +824,7 @@ class TestSerialization:
         }
 
         assert "slm_mask_targets" not in abstract  # only in xy
-        assert len(abstract["operations"]) == 1 if is_empty else 3
+        assert len(abstract["operations"]) == 1 if is_empty else 4
 
         assert abstract["operations"][0]["op"] == "config_slm_mask"
         assert abstract["operations"][0]["qubits"] == list(mask)
@@ -833,8 +833,9 @@ class TestSerialization:
         if not is_empty:
             assert abstract["channels"] == {"rydberg_global": "rydberg_global"}
 
-            assert abstract["dmm_channels"][0][0] == "dmm_0_1"
-            assert abstract["dmm_channels"][0][1]["traps"] == [
+            assert abstract["operations"][1]["op"] == "config_detuning_map"
+            assert abstract["operations"][1]["dmm_id"] == "dmm_0"
+            assert abstract["operations"][1]["detuning_map"]["traps"] == [
                 {
                     "weight": weight,
                     "x": reg._coords[i][0],
@@ -842,13 +843,15 @@ class TestSerialization:
                 }
                 for i, weight in enumerate(list(dmm.values()))
             ]
-            assert abstract["dmm_channels"][0][1]["slug"] == "det_map"
+            assert (
+                abstract["operations"][1]["detuning_map"]["slug"] == "det_map"
+            )
 
-            assert abstract["operations"][1]["op"] == "modulate_det_map"
-            assert abstract["operations"][1]["dmm_name"] == "dmm_0_1"
+            assert abstract["operations"][2]["op"] == "modulate_det_map"
+            assert abstract["operations"][2]["dmm_name"] == "dmm_0_1"
 
-            assert abstract["operations"][2]["op"] == "pulse"
-            assert abstract["operations"][2]["channel"] == "rydberg_global"
+            assert abstract["operations"][3]["op"] == "pulse"
+            assert abstract["operations"][3]["channel"] == "rydberg_global"
 
 
 def _get_serialized_seq(
@@ -1027,12 +1030,27 @@ class TestDeserialization:
         assert seq._in_xy
 
     def test_deserialize_seq_with_slm_dmm(self):
+        traps = [
+            {"weight": 0.5, "x": -2.0, "y": 9.0},
+            {"weight": 0.5, "x": 0.0, "y": 2.0},
+            {"weight": 0, "x": 12.0, "y": 0.0},
+        ]
         op = [
+            {
+                "op": "config_detuning_map",
+                "detuning_map": {"traps": traps},
+                "dmm_id": "dmm_0",
+            },
             {
                 "op": "config_slm_mask",
                 "qubits": [
                     "q0",
                 ],
+                "dmm_id": "dmm_0",
+            },
+            {
+                "op": "config_detuning_map",
+                "detuning_map": {"traps": traps, "slug": "det_map"},
                 "dmm_id": "dmm_0",
             },
             {
@@ -1063,22 +1081,18 @@ class TestDeserialization:
                 "post_phase_shift": 0.0,
             },
         ]
-        traps = [
-            {"weight": 0.5, "x": -2.0, "y": 9.0},
-            {"weight": 0.5, "x": 0.0, "y": 2.0},
-            {"weight": 0, "x": 12.0, "y": 0.0},
-        ]
-        kwargs = {
-            "device": json.loads(MockDevice.to_abstract_repr()),
-            "dmm_channels": [
-                ["dmm_0", {"traps": traps}],
-                ["dmm_0_2", {"traps": traps, "slug": "det_map"}],
-            ],
-        }
+        kwargs = {"device": json.loads(MockDevice.to_abstract_repr())}
         s = _get_serialized_seq(op, **kwargs)
         _check_roundtrip(s)
         seq = Sequence.from_abstract_repr(json.dumps(s))
         assert seq._slm_mask_targets == {"q0"}
+        assert seq.declared_channels.keys() == {
+            "digital",
+            "global",
+            "dmm_0",
+            "dmm_0_1",
+            "dmm_0_2",
+        }
         assert not seq._in_xy and seq._in_ising
 
     def test_deserialize_seq_with_mag_field(self):

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -236,46 +236,6 @@ class TestDevice:
         dev_str = device.to_abstract_repr()
         assert device == deserialize_device(dev_str)
 
-    @pytest.fixture
-    def chadoq2_with_dmm(self):
-        # TODO: Delete once Chadoq2 actually has a DMM
-        dmm = DMM(
-            bottom_detuning=-1,
-            clock_period=1,
-            min_duration=1,
-            max_duration=1e6,
-            mod_bandwidth=20,
-        )
-        return replace(Chadoq2, dmm_objects=(dmm,))
-
-    @pytest.mark.xfail(
-        raises=jsonschema.exceptions.ValidationError, strict=True
-    )
-    def test_abstract_repr_dmm_serialize(self, chadoq2_with_dmm):
-        chadoq2_with_dmm.to_abstract_repr()
-
-    @pytest.mark.xfail(raises=DeserializeDeviceError, strict=True)
-    @pytest.mark.parametrize(
-        "skip_validation",
-        [
-            False,  # Fails validation
-            True,  # Fails because the DMM channel is deserialized as Rydberg
-        ],
-    )
-    def test_abstract_repr_dmm_deserialize(
-        self, chadoq2_with_dmm, monkeypatch, skip_validation
-    ):
-        ser_device = json.dumps(chadoq2_with_dmm, cls=AbstractReprEncoder)
-        if skip_validation:
-
-            def dummy(*args, **kwargs):
-                return True
-
-            # Patches jsonschema.validate with a function that returns True
-            monkeypatch.setattr(jsonschema, "validate", dummy)
-        device = deserialize_device(ser_device)
-        assert device == chadoq2_with_dmm
-
 
 def validate_schema(instance):
     with open(
@@ -669,7 +629,6 @@ class TestSerialization:
 
             ParamObj(Foo, "bar")._to_abstract_repr()
 
-    @pytest.mark.xfail
     def test_mw_sequence(self, triangular_lattice):
         mag_field = [-10, 40, 0]
         mask = {"q0", "q2", "q4"}

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -27,7 +27,6 @@ import pytest
 
 from pulser import Pulse, Register, Register3D, Sequence, devices
 from pulser.channels import Rydberg
-from pulser.channels.dmm import DMM
 from pulser.channels.eom import RydbergBeam, RydbergEOM
 from pulser.devices import AnalogDevice, Chadoq2, Device, IroiseMVP, MockDevice
 from pulser.json.abstract_repr.deserializer import (
@@ -633,7 +632,7 @@ class TestSerialization:
         mag_field = [-10, 40, 0]
         mask = {"q0", "q2", "q4"}
         reg = triangular_lattice.hexagonal_register(5)
-        seq = Sequence(reg, replace(MockDevice, dmm_objects=(DMM(),)))
+        seq = Sequence(reg, MockDevice)
         seq.declare_channel("mw_ch", "mw_global")
         seq.set_magnetic_field(*mag_field)
         seq.config_slm_mask(mask)
@@ -653,6 +652,8 @@ class TestSerialization:
         assert abstract["magnetic_field"] == mag_field
         assert abstract["slm_mask_targets"] == list(mask)
         assert abstract["measurement"] == "XY"
+        assert "dmm_channels" not in abstract
+        assert "config_slm_mask" not in abstract["operations"]
 
     def test_mappable_register(self, triangular_lattice):
         reg = triangular_lattice.make_mappable_register(2)
@@ -795,6 +796,59 @@ class TestSerialization:
         seq.declare_channel("raman_local", "raman_local")
         getattr(seq, op)(*args)
         seq.to_abstract_repr()
+
+    @pytest.mark.parametrize("is_empty", [True, False])
+    def test_dmm_slm_mask(self, triangular_lattice, is_empty):
+        mask = {"q0", "q2", "q4", "q5"}
+        dmm = {"q0": 0.2, "q1": 0.3, "q2": 0.4, "q3": 0.1}
+        reg = triangular_lattice.rectangular_register(3, 4)
+        seq = Sequence(reg, MockDevice)
+        seq.config_slm_mask(mask, "dmm_0")
+        if not is_empty:
+            seq.config_detuning_map(
+                reg.define_detuning_map(dmm, "det_map"), "dmm_0"
+            )
+            seq.modulate_det_map(ConstantWaveform(100, -10), "dmm_0_1")
+            seq.declare_channel("rydberg_global", "rydberg_global")
+            seq.add(Pulse.ConstantPulse(100, 10, 0, 0), "rydberg_global")
+
+        abstract = json.loads(seq.to_abstract_repr())
+        validate_schema(abstract)
+        assert abstract["register"] == [
+            {"name": str(qid), "x": c[0], "y": c[1]}
+            for qid, c in reg.qubits.items()
+        ]
+        assert abstract["layout"] == {
+            "coordinates": triangular_lattice.coords.tolist(),
+            "slug": triangular_lattice.slug,
+        }
+
+        assert "slm_mask_targets" not in abstract  # only in xy
+        assert len(abstract["operations"]) == 1 if is_empty else 3
+
+        assert abstract["operations"][0]["op"] == "config_slm_mask"
+        assert abstract["operations"][0]["qubits"] == list(mask)
+        assert abstract["operations"][0]["dmm_id"] == "dmm_0"
+
+        if not is_empty:
+            assert abstract["channels"] == {"rydberg_global": "rydberg_global"}
+
+            assert abstract["dmm_channels"][0][0] == "dmm_0_1"
+            assert abstract["dmm_channels"][0][1]["traps"] == [
+                {
+                    "weight": weight,
+                    "x": reg._coords[i][0],
+                    "y": reg._coords[i][1],
+                }
+                for i, weight in enumerate(list(dmm.values()))
+            ]
+            assert abstract["dmm_channels"][0][1]["slug"] == "det_map"
+
+            assert abstract["operations"][1]["op"] == "modulate_det_map"
+            assert abstract["operations"][1]["dmm_name"] == "dmm_0_1"
+
+            assert abstract["operations"][2]["op"] == "pulse"
+            assert abstract["operations"][2]["channel"] == "rydberg_global"
 
 
 def _get_serialized_seq(
@@ -946,23 +1000,86 @@ class TestDeserialization:
         assert seq._register.qubit_ids == tuple(qids)
         assert seq._register.layout == RegisterLayout(layout_coords)
 
-    @pytest.mark.xfail
     def test_deserialize_seq_with_slm_mask(self):
         s = _get_serialized_seq(
-            slm_mask_targets=["q0"],
-            variables={},
+            [{"op": "config_slm_mask", "qubits": ["q0"], "dmm_id": "dmm_0"}],
             **{
-                "dmm_channels": {"dmm_0": "dmm_0"},
-                "device": json.loads(
-                    replace(
-                        Chadoq2, dmm_objects=(DMM(bottom_detuning=-100),)
-                    ).to_abstract_repr()
-                ),
+                "device": json.loads(MockDevice.to_abstract_repr()),
+                "channels": {},
             },
         )
         _check_roundtrip(s)
         seq = Sequence.from_abstract_repr(json.dumps(s))
         assert seq._slm_mask_targets == {"q0"}
+        assert not seq._in_xy and not seq._in_ising
+
+    def test_deserialize_seq_with_slm_mask_xy(self):
+        mag_field = [0.0, -10.0, 30.0]
+        s = _get_serialized_seq(
+            channels={},
+            magnetic_field=mag_field,
+            slm_mask_targets=["q0"],
+            device=json.loads(MockDevice.to_abstract_repr()),
+        )
+        _check_roundtrip(s)
+        seq = Sequence.from_abstract_repr(json.dumps(s))
+        assert seq._slm_mask_targets == {"q0"}
+        assert seq._in_xy
+
+    def test_deserialize_seq_with_slm_dmm(self):
+        op = [
+            {
+                "op": "config_slm_mask",
+                "qubits": [
+                    "q0",
+                ],
+                "dmm_id": "dmm_0",
+            },
+            {
+                "op": "modulate_det_map",
+                "protocol": "no-delay",
+                "waveform": {
+                    "kind": "constant",
+                    "duration": 100,
+                    "value": -10.0,
+                },
+                "dmm_name": "dmm_0_2",
+            },
+            {
+                "op": "pulse",
+                "channel": "global",
+                "protocol": "min-delay",
+                "amplitude": {
+                    "kind": "constant",
+                    "duration": 100,
+                    "value": 10.0,
+                },
+                "detuning": {
+                    "kind": "constant",
+                    "duration": 100,
+                    "value": 0.0,
+                },
+                "phase": 0.0,
+                "post_phase_shift": 0.0,
+            },
+        ]
+        traps = [
+            {"weight": 0.5, "x": -2.0, "y": 9.0},
+            {"weight": 0.5, "x": 0.0, "y": 2.0},
+            {"weight": 0, "x": 12.0, "y": 0.0},
+        ]
+        kwargs = {
+            "device": json.loads(MockDevice.to_abstract_repr()),
+            "dmm_channels": [
+                ["dmm_0", {"traps": traps}],
+                ["dmm_0_2", {"traps": traps, "slug": "det_map"}],
+            ],
+        }
+        s = _get_serialized_seq(op, **kwargs)
+        _check_roundtrip(s)
+        seq = Sequence.from_abstract_repr(json.dumps(s))
+        assert seq._slm_mask_targets == {"q0"}
+        assert not seq._in_xy and seq._in_ising
 
     def test_deserialize_seq_with_mag_field(self):
         mag_field = [10.0, -43.2, 0.0]

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -136,14 +136,14 @@ def test_post_init_value_errors(test_params, param, value, msg):
         VirtualDevice(**test_params)
 
 
-# TODO: Add test of comptability SLM-DMM once DMM is added for serialization
-# def test_post_init_slm_dmm_compatibility(test_params):
-#     test_params["supports_slm_mask"] = True
-#     test_params["dmm_objects"] = ()
-#     with pytest.raises(ValueError,
-#       match="One DMM object should be defined to support SLM mask."
-#     ):
-#         VirtualDevice(**test_params)
+def test_post_init_slm_dmm_compatibility(test_params):
+    test_params["supports_slm_mask"] = True
+    test_params["dmm_objects"] = ()
+    with pytest.raises(
+        ValueError,
+        match="One DMM object should be defined to support SLM mask.",
+    ):
+        VirtualDevice(**test_params)
 
 
 potential_params = ["max_atom_num", "max_radial_distance"]
@@ -384,7 +384,10 @@ def test_convert_to_virtual():
     assert Device(
         pre_calibrated_layouts=(TriangularLatticeLayout(40, 2),), **params
     ).to_virtual() == VirtualDevice(
-        supports_slm_mask=False, reusable_channels=False, **params
+        supports_slm_mask=False,
+        reusable_channels=False,
+        dmm_objects=(),
+        **params,
     )
 
 

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -125,7 +125,7 @@ class TestDetuningMap:
         )
 
         # And they have the same type, so they should be equal
-        assert type(det_map) == type(det_map2)
+        assert type(det_map) is type(det_map2)
         assert det_map == det_map2
 
         # This means their static hashes and reprs match

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -122,7 +122,7 @@ def test_register_numbered_keys(reg):
     j = json.dumps(reg, cls=PulserEncoder)
     decoded_reg = json.loads(j, cls=PulserDecoder)
     assert reg == decoded_reg
-    assert all([type(i) == int for i in decoded_reg.qubit_ids])
+    assert all([type(i) is int for i in decoded_reg.qubit_ids])
 
 
 def test_mappable_register():

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -813,13 +813,16 @@ def test_switch_device_up(
                 # modulates detuning map on trap ids 0, 1, 3, 4
                 mod_trap_ids = [20, 32, 54, 66]
                 assert np.all(
-                    nested_s1_loc[key][:100] == (-2.5 if trap_id in mod_trap_ids else 0)
+                    nested_s1_loc[key][:100]
+                    == (-2.5 if trap_id in mod_trap_ids else 0)
                 )
                 assert np.all(
-                    nested_s2_loc[key][:100] == (-2.5 if trap_id in mod_trap_ids else 0)
+                    nested_s2_loc[key][:100]
+                    == (-2.5 if trap_id in mod_trap_ids else 0)
                 )
                 assert np.all(
-                    nested_s3_loc[key][:100] == (-2.5 if trap_id in mod_trap_ids else 0)
+                    nested_s3_loc[key][:100]
+                    == (-2.5 if trap_id in mod_trap_ids else 0)
                 )
             else:
                 # first pulse is covered by SLM Mask

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1770,8 +1770,11 @@ def test_multiple_index_targets(reg):
     assert built_seq._last("ch0").targets == {"q2", "q3"}
 
 
+@pytest.mark.parametrize("correct_phase_drift", (True, False))
 @pytest.mark.parametrize("custom_buffer_time", (None, 400))
-def test_eom_mode(reg, mod_device, custom_buffer_time, patch_plt_show):
+def test_eom_mode(
+    reg, mod_device, custom_buffer_time, correct_phase_drift, patch_plt_show
+):
     # Setting custom_buffer_time
     channels = mod_device.channels
     eom_config = dataclasses.replace(
@@ -1817,22 +1820,39 @@ def test_eom_mode(reg, mod_device, custom_buffer_time, patch_plt_show):
     ]
 
     pulse_duration = 100
-    seq.add_eom_pulse("ch0", pulse_duration, phase=0.0)
+    seq.add_eom_pulse(
+        "ch0",
+        pulse_duration,
+        phase=0.0,
+        correct_phase_drift=correct_phase_drift,
+    )
     first_pulse_slot = seq._schedule["ch0"].last_pulse_slot()
     assert first_pulse_slot.ti == delay_slot.tf
     assert first_pulse_slot.tf == first_pulse_slot.ti + pulse_duration
-    eom_pulse = Pulse.ConstantPulse(pulse_duration, amp_on, detuning_on, 0.0)
+    phase = detuning_off * first_pulse_slot.ti * 1e-3 * correct_phase_drift
+    eom_pulse = Pulse.ConstantPulse(pulse_duration, amp_on, detuning_on, phase)
     assert first_pulse_slot.type == eom_pulse
     assert not seq._schedule["ch0"].is_detuned_delay(eom_pulse)
 
     # Check phase jump buffer
-    seq.add_eom_pulse("ch0", pulse_duration, phase=np.pi)
+    phase_ = np.pi
+    seq.add_eom_pulse(
+        "ch0",
+        pulse_duration,
+        phase=phase_,
+        correct_phase_drift=correct_phase_drift,
+    )
     second_pulse_slot = seq._schedule["ch0"].last_pulse_slot()
     phase_buffer = (
         eom_pulse.fall_time(ch0_obj, in_eom_mode=True)
         + seq.declared_channels["ch0"].phase_jump_time
     )
     assert second_pulse_slot.ti == first_pulse_slot.tf + phase_buffer
+    # Corrects the phase acquired during the phase buffer
+    phase_ += detuning_off * phase_buffer * 1e-3 * correct_phase_drift
+    assert second_pulse_slot.type == Pulse.ConstantPulse(
+        pulse_duration, amp_on, detuning_on, phase_
+    )
 
     # Check phase jump buffer is not enforced with "no-delay"
     seq.add_eom_pulse("ch0", pulse_duration, phase=0.0, protocol="no-delay")
@@ -1863,8 +1883,15 @@ def test_eom_mode(reg, mod_device, custom_buffer_time, patch_plt_show):
     )
     assert buffer_delay.type == "delay"
 
+    assert seq.current_phase_ref("q0", basis="ground-rydberg") == 0
     # Check buffer when EOM is not enabled at the start of the sequence
-    seq.enable_eom_mode("ch0", amp_on, detuning_on, optimal_detuning_off=-100)
+    seq.enable_eom_mode(
+        "ch0",
+        amp_on,
+        detuning_on,
+        optimal_detuning_off=-100,
+        correct_phase_drift=correct_phase_drift,
+    )
     last_slot = seq._schedule["ch0"][-1]
     assert len(seq._schedule["ch0"].eom_blocks) == 2
     new_eom_block = seq._schedule["ch0"].eom_blocks[1]
@@ -1878,6 +1905,23 @@ def test_eom_mode(reg, mod_device, custom_buffer_time, patch_plt_show):
     # The buffer is a Pulse at 'detuning_off' and zero amplitude
     assert last_slot.type == Pulse.ConstantPulse(
         duration, 0.0, new_eom_block.detuning_off, last_pulse_slot.type.phase
+    )
+    # Check the phase shift that corrects for the drift
+    phase_ref = (
+        (new_eom_block.detuning_off * duration * 1e-3)
+        % (2 * np.pi)
+        * correct_phase_drift
+    )
+    assert seq.current_phase_ref("q0", basis="ground-rydberg") == phase_ref
+
+    # Add delay to test the phase drift correction in disable_eom_mode
+    last_delay_time = 400
+    seq.delay(last_delay_time, "ch0")
+
+    seq.disable_eom_mode("ch0", correct_phase_drift=True)
+    phase_ref += new_eom_block.detuning_off * last_delay_time * 1e-3
+    assert seq.current_phase_ref("q0", basis="ground-rydberg") == phase_ref % (
+        2 * np.pi
     )
 
     # Test drawing in eom mode

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -126,7 +126,7 @@ def test_channel_declaration(reg, device):
 
     seq2 = Sequence(reg, MockDevice)
     seq2.declare_channel("ch0", "mw_global")
-    assert set(seq2.available_channels) == {"mw_global"}
+    assert set(seq2.available_channels) == {"mw_global", "dmm_0"}
     with pytest.raises(
         ValueError,
         match="cannot work simultaneously with the declared 'Microwave'",
@@ -292,6 +292,8 @@ def test_magnetic_field(reg, mock_dev_dmm):
     seq3 = Sequence(reg, mock_dev_dmm)
     seq3.config_slm_mask(["q0", "q1"], "dmm_0")
     seq3.set_magnetic_field(1.0, 0.0, 0.0)  # sets seq to XY mode
+    # dmm_0 doesn't appear because there can only be one in XY mode
+    # and the SLM is already configured
     assert set(seq3.available_channels) == {"mw_global"}
     assert list(seq3.declared_channels.keys()) == []
     seq3.declare_channel("ch0", "mw_global")
@@ -299,7 +301,7 @@ def test_magnetic_field(reg, mock_dev_dmm):
 
     seq3 = Sequence(reg, MockDevice)
     seq3.set_magnetic_field(1.0, 0.0, 0.0)  # sets seq to XY mode
-    assert set(seq3.available_channels) == {"mw_global"}
+    assert set(seq3.available_channels) == {"mw_global", "dmm_0"}
     seq3.declare_channel("ch0", "mw_global")
     # Does not change to default
     assert np.all(seq3.magnetic_field == np.array((1.0, 0.0, 0.0)))

--- a/tests/test_sequence_sampler.py
+++ b/tests/test_sequence_sampler.py
@@ -25,12 +25,11 @@ import pulser_simulation
 from pulser.channels.dmm import DMM
 from pulser.devices import Device, MockDevice
 from pulser.pulse import Pulse
+from pulser.register.mappable_reg import MappableRegister
+from pulser.register.register_layout import RegisterLayout
 from pulser.sampler import sample
 from pulser.sequence._seq_drawer import draw_samples
 from pulser.waveforms import BlackmanWaveform, RampWaveform
-from pulser.register.mappable_reg import MappableRegister
-from pulser.register.register_layout import RegisterLayout
-
 
 # Helpers
 

--- a/tests/test_sequence_sampler.py
+++ b/tests/test_sequence_sampler.py
@@ -286,7 +286,7 @@ def test_seq_with_DMM_and_map_reg():
     reg = MappableRegister(
         RegisterLayout([[-4, 0], [4, 0], [0, -4], [0, 4]]), *["q0", "q1"]
     )
-    seq = pulser.Sequence(reg, replace(MockDevice, dmm_objects=(DMM(),)))
+    seq = pulser.Sequence(reg, MockDevice)
     seq.config_detuning_map(
         reg.define_detuning_map({i: 0.25 for i in range(4)}), "dmm_0"
     )
@@ -365,7 +365,6 @@ def test_SLM_samples():
     )
 
     got = sample(seq).to_nested_dict()
-    print(got)
     assert_nested_dict_equality(got, want)
 
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from collections import Counter
-from dataclasses import replace
 from unittest.mock import patch
 
 import numpy as np
@@ -21,15 +20,11 @@ import pytest
 import qutip
 
 from pulser import Pulse, Register, Sequence
-from pulser.channels.dmm import DMM
 from pulser.devices import Chadoq2, IroiseMVP, MockDevice
 from pulser.register.register_layout import RegisterLayout
 from pulser.sampler import sampler
 from pulser.waveforms import BlackmanWaveform, ConstantWaveform, RampWaveform
 from pulser_simulation import QutipEmulator, SimConfig, Simulation
-
-assert not MockDevice.dmm_objects, "Delete the next line"
-MockDevice = replace(MockDevice, dmm_objects=(DMM(),))
 
 
 @pytest.fixture

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1088,7 +1088,7 @@ def test_mask_two_pulses_xy():
 def test_mask_local_channel():
     seq_ = Sequence(
         Register.square(2, prefix="q"),
-        replace(MockDevice, dmm_objects=(DMM(),)),
+        MockDevice,
     )
     seq_.declare_channel("rydberg_global", "rydberg_global")
     pulse = Pulse.ConstantPulse(1000, 10, 0, 0)

--- a/tutorials/advanced_features/Output Modulation and EOM Mode.ipynb
+++ b/tutorials/advanced_features/Output Modulation and EOM Mode.ipynb
@@ -250,11 +250,11 @@
    "source": [
     "The modulation bandwidth of a channel can impose significant limitations on how a pulse sequence is programmed. Perhaps most importantly, it can force the user to program longer pulses than would otherwise be required, resulting in longer sequences and consequently noisier results.\n",
     "\n",
-    "To overcome these limitations, a channel can be equipped with an EOM that allows the execution of pulses with a higher modulation bandwidth. For now, EOM mode operation is reserved for `Rydberg` channels and works under very specific conditions:\n",
+    "To overcome these limitations, a channel can be equipped with an EOM that allows the execution of square pulses with a higher modulation bandwidth. For now, EOM mode operation is reserved for `Rydberg` channels and works under very specific conditions:\n",
     "\n",
     "   1. EOM mode must be explicitly enabled (`Sequence.enable_eom_mode()`) and disabled (`Sequence.disable_eom_mode()`).\n",
     "   2. A buffering time is automatically added before the EOM mode is enabled and after it is disabled, as it needs to be isolated from regular channel operation. During the starting buffer, the detuning goes to the value it will assume between EOM pulses (_i.e._ during delays).\n",
-    "   3. When enabling the EOM mode, one must choose the amplitude and detuning value that all square pulses will have. These values will also determine a set of options for the detuning during delays, out of which one chosen.\n",
+    "   3. When enabling the EOM mode, one must choose the amplitude and detuning value that all square pulses will have. These values will also determine a set of options for the detuning during delays, out of which the best one is chosen. When this detuning value is not zero, the phase of each qubit's state will drift during delays. If desired, this phase drift can be corrected through the `correct_phase_drift` option, which will adjust the phase of subsequent pulses accordingly. \n",
     "   4. While in EOM mode, one can only add delays or pulses of variable duration (through `Sequence.add_eom_pulse()`) – changing the phase between pulses is also allowed, but the necessary buffer time for a phase jump will still be enforced."
    ]
   },
@@ -280,12 +280,12 @@
     "seq.add(Pulse.ConstantPulse(100, 1, 0, 0), \"rydberg\")\n",
     "seq.enable_eom_mode(\"rydberg\", amp_on=1.0, detuning_on=0.0)\n",
     "seq.add_eom_pulse(\"rydberg\", duration=100, phase=0.0)\n",
-    "seq.delay(200, \"rydberg\")\n",
-    "seq.add_eom_pulse(\"rydberg\", duration=60, phase=0.0)\n",
+    "seq.delay(300, \"rydberg\")\n",
+    "seq.add_eom_pulse(\"rydberg\", duration=60, phase=0.0, correct_phase_drift=True)\n",
     "seq.disable_eom_mode(\"rydberg\")\n",
     "seq.add(Pulse.ConstantPulse(100, 1, 0, 0), \"rydberg\")\n",
     "\n",
-    "seq.draw()"
+    "seq.draw(draw_phase_curve=True)"
    ]
   },
   {
@@ -302,7 +302,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As expected, inside the isolated EOM mode block in the middle we see that the pulses are much sharper, but we can only do square pulses with a fixed amplitude and there is some non-zero detuning in between them."
+    "As expected, inside the isolated EOM mode block in the middle we see that the pulses are much sharper, but we can only do square pulses with a fixed amplitude and there is some non-zero detuning in between them. \n",
+    "\n",
+    "We also observe how the phase of the second EOM pulse changes to correct for the phase drift during the detuned delay (because we set `correct_phase_drift=True`)."
    ]
   }
  ],


### PR DESCRIPTION
The last three commits take into account last review from #568:
- [x] Adds slug description
- [x] The dmm ids are switched when using 'switch_device' (useful when going from a virtual device to a real one). This is also performed for the dmm id used in `config_slm_mask`.
- [x] Parametrized sequences are now taken into account. This was particularly annoying with the slm mask, that does not config the detuning map right away but configures it at the build.
- [x] Config_det_map is now stored as an operation in the schema, this makes deserialization easier.