### PR TITLE
Change EmuTN default sampling rate

### DIFF
--- a/pulser-pasqal/pulser_pasqal/backends.py
+++ b/pulser-pasqal/pulser_pasqal/backends.py
@@ -24,7 +24,9 @@ from pulser.backend.config import EmulatorConfig
 from pulser.backend.remote import JobParams, RemoteBackend, RemoteResults
 from pulser_pasqal.pasqal_cloud import PasqalCloud
 
-DEFAULT_CONFIG_EMU_TN = EmulatorConfig(evaluation_times="Final")
+DEFAULT_CONFIG_EMU_TN = EmulatorConfig(
+    evaluation_times="Final", sampling_rate=0.1
+)
 DEFAULT_CONFIG_EMU_FREE = EmulatorConfig(
     evaluation_times="Final", sampling_rate=0.25
 )

--- a/pulser-pasqal/pulser_pasqal/backends.py
+++ b/pulser-pasqal/pulser_pasqal/backends.py
@@ -111,7 +111,8 @@ class EmuTNBackend(PasqalEmulator):
     """An emulator backend using tensor network simulation.
 
     Configurable fields in EmulatorConfig:
-        - sampling_rate
+        - sampling_rate: Defaults to 0.1. This value must remain low to use
+          this backend efficiently.
         - backend_options:
             - precision (str): The precision of the simulation. Can be "low",
               "normal" or "high". Defaults to "normal".

--- a/tests/test_pasqal.py
+++ b/tests/test_pasqal.py
@@ -321,7 +321,7 @@ def test_emulators_run(fixt, seq, emu_cls, parametrized: bool):
     sdk_config: EmuTNConfig | EmuFreeConfig
     if isinstance(emu, EmuTNBackend):
         emulator_type = EmulatorType.EMU_TN
-        sdk_config = EmuTNConfig(dt=1.0)
+        sdk_config = EmuTNConfig(dt=10)
     else:
         emulator_type = EmulatorType.EMU_FREE
         sdk_config = EmuFreeConfig()


### PR DESCRIPTION
The default sampling rate, inherited from `EmulatorConfig`  defaults, is 1.

If I am not mistaken, this translates to `dt=1` for the EmuTN job runned by cloud services, which is not a viable value.

I open this MR not for a blind merge, but rather to make sure the above interpretation of `sampling_rate` for EmuTnBackend is right, and reflect on a good default value.