### PR TITLE
Fix switch device err message

### DIFF
--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -553,6 +553,7 @@ class Sequence(Generic[DeviceType]):
                         continue
                 if not strict:
                     channel_match[old_ch_name] = new_ch_id
+                    # Found a match, clear match error msg for this channel
                     if ch_match_err.startswith(base_msg):
                         ch_match_err = ""
                     break
@@ -576,6 +577,7 @@ class Sequence(Generic[DeviceType]):
                 else:
                     # Only reached if all checks passed
                     channel_match[old_ch_name] = new_ch_id
+                    # Found a match, clear match error msgs for this channel
                     if ch_match_err.startswith(base_msg):
                         ch_match_err = ""
                     if strict_error_message.startswith(base_msg):

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -553,6 +553,8 @@ class Sequence(Generic[DeviceType]):
                         continue
                 if not strict:
                     channel_match[old_ch_name] = new_ch_id
+                    if ch_match_err.startswith(base_msg):
+                        ch_match_err = ""
                     break
 
                 params_to_check = [
@@ -574,6 +576,10 @@ class Sequence(Generic[DeviceType]):
                 else:
                     # Only reached if all checks passed
                     channel_match[old_ch_name] = new_ch_id
+                    if ch_match_err.startswith(base_msg):
+                        ch_match_err = ""
+                    if strict_error_message.startswith(base_msg):
+                        strict_error_message = ""
                     break
 
         if None in channel_match.values():

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -359,7 +359,7 @@ def test_switch_device_down(reg, devices, pulses, mappable_reg, parametrized):
         " right type, basis and addressing.",
     ):
         # Can't find a match for the 2nd raman_local
-        seq.switch_device(Chadoq2)
+        seq.switch_device(Chadoq2, strict=True)
 
     with pytest.raises(
         ValueError,

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -350,7 +350,7 @@ def test_switch_device_down(reg, devices, pulses, mappable_reg, parametrized):
         match="No match for channel raman_1 with the"
         " right type, basis and addressing.",
     ):
-        # Can't find a match for the 2nd rydberg_local
+        # Can't find a match for the 2nd raman_local
         seq.switch_device(Chadoq2)
 
     with pytest.raises(
@@ -358,7 +358,7 @@ def test_switch_device_down(reg, devices, pulses, mappable_reg, parametrized):
         match="No match for channel raman_1 with the"
         " right type, basis and addressing.",
     ):
-        # Can't find a match for the 2nd rydberg_local
+        # Can't find a match for the 2nd raman_local
         seq.switch_device(Chadoq2)
 
     with pytest.raises(


### PR DESCRIPTION
Finalizing resolution from #579, in the last MR #580 two tests were the same, whereas one was intended to be for strict=False and the other for strict=True.