### PR TITLE
Pin matplotlib < 3.8

### DIFF
--- a/pulser-core/requirements.txt
+++ b/pulser-core/requirements.txt
@@ -1,5 +1,5 @@
 jsonschema >= 4.18
-matplotlib
+matplotlib < 3.8
 # Numpy 1.20 introduces type hints, 1.24.0 breaks matplotlib < 3.6.1
 numpy >= 1.20, != 1.24.0
 scipy


### PR DESCRIPTION
It seems that `matplotlib 3.8` does two disruptive things to our CI workflow:
1. It introduces type-hints
2. It drops support for python 3.8

I briefly looked into the changes that it will take to make our current code pass the `mypy` checks and I think some warrant using`type:ignore` . However, these `type:ignore`s will then be seen as "unused" when using `matplotlib < 3.8`, which is a necessity if `python == 3.8`.

Also, I would prefer that all python versions have access to the same matplotlib version, so for now I'll just restrict `matplotlib` to be < 3.8. I don't expect us to miss out on any functionality, but we can always revaluate. Once we drop support for python 3.8, we can maybe lift this restriction too.