### PR TITLE
Adding register_is_from_calibrated_layout and is_calibrated_layout to Device

### DIFF
--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -538,6 +538,47 @@ class Device(BaseDevice):
         """Register layouts already calibrated on this device."""
         return {str(layout): layout for layout in self.pre_calibrated_layouts}
 
+    def is_calibrated_layout(self, register_layout: RegisterLayout) -> bool:
+        """Checks whether a layout is within the calibrated layouts.
+
+        Args:
+            register_layout: the RegisterLayout to check.
+
+        Returns:
+            True if register_layout is found among calibrated_register_layouts,
+            False otherwise.
+        """
+        for (
+            name,
+            calibrated_layout,
+        ) in self.calibrated_register_layouts.items():
+            if register_layout == calibrated_layout:
+                return True
+        return False
+
+    def register_is_from_calibrated_layout(
+        self, register: BaseRegister | MappableRegister
+    ) -> bool:
+        """Checks whether a register was constructed from a calibrated layout.
+
+        If the register is a BaseRegister, checks that it has a layout. If so,
+        or if it is a MappableRegister, check that its layout is within the
+        calibrated layouts.
+
+        Args:
+            register_layout: the Register or MappableRegister to check.
+
+        Returns:
+            True if register has a layout and it is found among
+            calibrated_register_layouts, False otherwise.
+        """
+        if (
+            isinstance(register, BaseRegister)
+            and register._layout_info is None
+        ):
+            return False
+        return self.is_calibrated_layout(cast(RegisterLayout, register.layout))
+
     def to_virtual(self) -> VirtualDevice:
         """Converts the Device into a VirtualDevice."""
         params = self._params()

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -542,16 +542,13 @@ class Device(BaseDevice):
         """Checks whether a layout is within the calibrated layouts.
 
         Args:
-            register_layout: the RegisterLayout to check.
+            register_layout: The RegisterLayout to check.
 
         Returns:
             True if register_layout is found among calibrated_register_layouts,
             False otherwise.
         """
-        for (
-            name,
-            calibrated_layout,
-        ) in self.calibrated_register_layouts.items():
+        for _, calibrated_layout in self.calibrated_register_layouts.items():
             if register_layout == calibrated_layout:
                 return True
         return False
@@ -572,12 +569,16 @@ class Device(BaseDevice):
             True if register has a layout and it is found among
             calibrated_register_layouts, False otherwise.
         """
-        if (
-            isinstance(register, BaseRegister)
-            and register._layout_info is None
+        if not isinstance(register, BaseRegister) or isinstance(
+            register, MappableRegister
         ):
+            raise TypeError(
+                "The register to check must be of type "
+                "BaseRegister or MappableRegister."
+            )
+        if isinstance(register, BaseRegister) and register.layout is None:
             return False
-        return self.is_calibrated_layout(cast(RegisterLayout, register.layout))
+        return self.is_calibrated_layout(register.layout)
 
     def to_virtual(self) -> VirtualDevice:
         """Converts the Device into a VirtualDevice."""

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -548,10 +548,12 @@ class Device(BaseDevice):
             True if register_layout is found among calibrated_register_layouts,
             False otherwise.
         """
-        for _, calibrated_layout in self.calibrated_register_layouts.items():
-            if register_layout == calibrated_layout:
-                return True
-        return False
+        return any(
+            [
+                register_layout == layout
+                for layout in list(self.calibrated_register_layouts.values())
+            ]
+        )
 
     def register_is_from_calibrated_layout(
         self, register: BaseRegister | MappableRegister
@@ -569,16 +571,14 @@ class Device(BaseDevice):
             True if register has a layout and it is found among
             calibrated_register_layouts, False otherwise.
         """
-        if not isinstance(register, BaseRegister) or isinstance(
-            register, MappableRegister
-        ):
+        if not isinstance(register, (BaseRegister, MappableRegister)):
             raise TypeError(
                 "The register to check must be of type "
                 "BaseRegister or MappableRegister."
             )
         if isinstance(register, BaseRegister) and register.layout is None:
             return False
-        return self.is_calibrated_layout(register.layout)
+        return self.is_calibrated_layout(cast(RegisterLayout, register.layout))
 
     def to_virtual(self) -> VirtualDevice:
         """Converts the Device into a VirtualDevice."""

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -355,6 +355,11 @@ def test_calibrated_layouts():
         "TriangularLatticeLayout(100, 6.8µm)",
         "TriangularLatticeLayout(200, 5.0µm)",
     }
+    with pytest.raises(
+        TypeError,
+        match="The register to check must be of type ",
+    ):
+        TestDevice.register_is_from_calibrated_layout(layout100)
     assert TestDevice.is_calibrated_layout(layout100)
     register = layout200.define_register(*range(10))
     assert TestDevice.register_is_from_calibrated_layout(register)

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -25,7 +25,10 @@ from pulser.channels.dmm import DMM
 from pulser.devices import Chadoq2, Device, VirtualDevice
 from pulser.register import Register, Register3D
 from pulser.register.register_layout import RegisterLayout
-from pulser.register.special_layouts import TriangularLatticeLayout
+from pulser.register.special_layouts import (
+    SquareLatticeLayout,
+    TriangularLatticeLayout,
+)
 
 
 @pytest.fixture
@@ -336,6 +339,8 @@ def test_calibrated_layouts():
             pre_calibrated_layouts=(TriangularLatticeLayout(201, 3),),
         )
 
+    layout100 = TriangularLatticeLayout(100, 6.8)
+    layout200 = TriangularLatticeLayout(200, 5)
     TestDevice = Device(
         name="TestDevice",
         dimensions=2,
@@ -344,15 +349,27 @@ def test_calibrated_layouts():
         max_radial_distance=50,
         min_atom_distance=4,
         channel_objects=(),
-        pre_calibrated_layouts=(
-            TriangularLatticeLayout(100, 6.8),
-            TriangularLatticeLayout(200, 5),
-        ),
+        pre_calibrated_layouts=(layout100, layout200),
     )
     assert TestDevice.calibrated_register_layouts.keys() == {
         "TriangularLatticeLayout(100, 6.8µm)",
         "TriangularLatticeLayout(200, 5.0µm)",
     }
+    assert TestDevice.is_calibrated_layout(layout100)
+    register = layout200.define_register(*range(10))
+    assert TestDevice.register_is_from_calibrated_layout(register)
+    # Checking a register not built from a layout returns False
+    assert not TestDevice.register_is_from_calibrated_layout(
+        Register.triangular_lattice(4, 25, 6.8)
+    )
+    # Checking Layouts that don't match calibrated layouts returns False
+    square_layout = SquareLatticeLayout(10, 10, 6.8)
+    layout125 = TriangularLatticeLayout(125, 6.8)
+    compact_layout = TriangularLatticeLayout(100, 3)
+    for bad_layout in (square_layout, layout125, compact_layout):
+        assert not TestDevice.is_calibrated_layout(bad_layout)
+        register = bad_layout.define_register(*range(10))
+        assert not TestDevice.register_is_from_calibrated_layout(register)
 
 
 def test_device_with_virtual_channel():


### PR DESCRIPTION
As suggested by @HGSilveri:
Add two new methods to `Device`:
- [ ] `Device.is_calibrated_layout(layout: RegisterLayout)`: Checks whether a layout is within the calibrated layouts.
- [ ] `Device.register_is_from_calibrated_layout(register: BaseRegister|MappableRegister)`: Checks whether the register was constructed from a pre-calibrated layout (ie checks if it has a layout AND `is_calibrated_layout(layout)`)
As discussed, returns a boolean and not an error.
register_is_from_calibrated_layout works with BaseRegister (hence Register and Register3D) and MappableRegister (always has a layout in this case) because the type of the register in a sequence can be of type one of these two types. 

Closes #577 