### PR TITLE
[FIX] Allow parametrized phase in EOM mode

### DIFF
--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -1220,7 +1220,7 @@ class Sequence(Generic[DeviceType]):
                 channel_obj = self.declared_channels[channel]
                 channel_obj.validate_duration(duration)
             for arg in (phase, post_phase_shift):
-                if not isinstance(arg, (float, int)):
+                if not isinstance(arg, (Parametrized, float, int)):
                     raise TypeError("Phase values must be a numeric value.")
             return
 

--- a/tests/test_paramseq.py
+++ b/tests/test_paramseq.py
@@ -319,13 +319,16 @@ def test_parametrized_before_eom_mode(mod_device):
     with pytest.raises(ValueError, match="duration has to be at least"):
         seq.add_eom_pulse("ch0", 0, 0.0)
 
-    seq.add_eom_pulse("ch0", 100, 0.0)
+    var = seq.declare_variable("var", dtype=float, size=None)
+    seq.add_eom_pulse("ch0", 100, 0.0, post_phase_shift=var)
+    seq.add_eom_pulse("ch0", var * 1000, np.pi)
+    seq.add_eom_pulse("ch0", 200, var)
 
     seq.disable_eom_mode("ch0")
     assert not seq.is_in_eom_mode("ch0")
 
     # Just check that building works
-    seq.build(amp=3.0)
+    seq.build(amp=3.0, var=0.5)
 
 
 def test_iterable_variable_check():


### PR DESCRIPTION
I stumbled upon this bug when trying to make EOM pulses with a parametrized phase.