### PR TITLE
Fix use of spacing with a device of min_atom_distance=0 in Register.max_connectivity

### DIFF
--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -253,11 +253,6 @@ class Register(BaseRegister, RegDrawer):
                 f" ({device.max_atom_num})."
             )
 
-        if not device.min_atom_distance > 0.0:
-            raise NotImplementedError(
-                "Maximum connectivity layouts are not well defined for a "
-                f"device with 'min_atom_distance={device.min_atom_distance}'."
-            )
         # Default spacing or check minimal distance
         if spacing is None:
             spacing = device.min_atom_distance
@@ -267,6 +262,12 @@ class Register(BaseRegister, RegDrawer):
                 " must be greater than or equal to the minimal"
                 " distance supported by this device"
                 f" ({device.min_atom_distance})."
+            )
+        if spacing <= 0.0:
+            # spacing is None or 0.0, device.min_atom_distance is 0.0
+            raise NotImplementedError(
+                "Maximum connectivity layouts are not well defined for a "
+                "device with 'min_atom_distance=0.0'."
             )
 
         coords = patterns.triangular_hex(n_qubits) * spacing

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -181,10 +181,8 @@ def test_max_connectivity():
     # Check spacing
     reg = Register.max_connectivity(max_atom_num, device, spacing=spacing)
     with pytest.raises(ValueError, match="Spacing "):
-        reg = Register.max_connectivity(
-            max_atom_num, device, spacing=spacing - 1.0
-        )
-
+        Register.max_connectivity(max_atom_num, device, spacing=spacing - 1.0)
+    reg = Register.max_connectivity(max_atom_num, MockDevice, spacing=spacing)
     with pytest.raises(
         NotImplementedError,
         match="Maximum connectivity layouts are not well defined for a "


### PR DESCRIPTION
Checks that spacing is greater than zero after the definition of spacing.
Fixes #603 