### PR TITLE
Replace `Register.rotate()` with `Register.rotated()`

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -175,8 +175,11 @@ def test_rare_cases(patch_plt_show):
     var_._assign(10)
     assert wf_.build() == BlackmanWaveform(100, 10)
 
-    rotated_reg = parametrize(Register.rotate)(reg, var)
-    with pytest.raises(NotImplementedError):
+    rotated_reg = parametrize(Register.rotated)(reg, var)
+    with pytest.raises(
+        NotImplementedError,
+        match="Instance or static method serialization is not supported.",
+    ):
         encode(rotated_reg)
 
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -11,12 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import re
 from unittest.mock import patch
 
 import numpy as np
 import pytest
 
+import pulser
 from pulser import Register, Register3D
 from pulser.devices import DigitalAnalogDevice, MockDevice
 
@@ -273,9 +274,20 @@ def test_max_connectivity():
 
 def test_rotation():
     reg = Register.square(2, spacing=np.sqrt(2))
-    reg.rotate(45)
-    coords_ = np.array([(0, -1), (1, 0), (-1, 0), (0, 1)], dtype=float)
-    assert np.all(np.isclose(reg._coords, coords_))
+    rot_reg = reg.rotated(45)
+    new_coords_ = np.array([(0, -1), (1, 0), (-1, 0), (0, 1)], dtype=float)
+    np.testing.assert_allclose(rot_reg._coords, new_coords_, atol=1e-15)
+
+    assert rot_reg != reg
+
+    assert pulser.__version__ <= "0.18", "Remove 'Register.rotate()'."
+    with pytest.warns(
+        DeprecationWarning,
+        match=re.escape("'Register.rotate()' has been deprecated"),
+    ):
+        reg.rotate(45)
+    assert np.all(np.isclose(reg._coords, new_coords_))
+    assert reg == rot_reg
 
 
 draw_params = [

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -113,7 +113,17 @@ def test_register_definition(layout, layout3d):
         reg2d._validate_layout(layout, (0, 1))
 
     with pytest.raises(TypeError, match="cannot be rotated"):
-        reg2d.rotate(30)
+        with pytest.warns(
+            DeprecationWarning,
+            match=re.escape("'Register.rotate()' has been deprecated"),
+        ):
+            reg2d.rotate(30)
+
+    with pytest.warns(
+        UserWarning, match="won't have an associated 'RegisterLayout'"
+    ):
+        rot_reg2d = reg2d.rotated(90)
+    assert rot_reg2d.layout is None
 
 
 def test_draw(layout, layout3d, patch_plt_show):

--- a/tutorials/creating_sequences.ipynb
+++ b/tutorials/creating_sequences.ipynb
@@ -54,7 +54,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `Register` class provides some useful features, like the ability to visualise the array and to rotate it."
+    "The `Register` class provides some useful features, like the ability to visualise the array and to make a rotated copy."
    ]
   },
   {
@@ -63,10 +63,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "reg1 = Register(qubits)  # Copy of 'reg' to keep the original intact\n",
     "print(\"The original array:\")\n",
-    "reg1.draw()\n",
-    "reg1.rotate(45)  # Rotate by 45 degrees\n",
+    "reg.draw()\n",
+    "reg1 = reg.rotated(45)  # Rotate by 45 degrees\n",
     "print(\"The rotated array:\")\n",
     "reg1.draw()"
    ]


### PR DESCRIPTION
- Introduces `Register.rotated()`, which returns a new instance instead of rotating in place
- Deprecates `Register.rotate()` 

Closes #628 .