### PR TITLE
Remove `Register.rotate()`

### DIFF
--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -281,35 +281,6 @@ class Register(BaseRegister, RegDrawer):
 
         return cls.from_coordinates(coords, center=False, prefix=prefix)
 
-    def rotate(self, degrees: float) -> None:
-        """Rotates the array around the origin by the given angle.
-
-        Warning:
-            Deprecated in v0.17 in favour of `Register.rotated()`. To be
-            removed in v0.18.
-
-        Args:
-            degrees: The angle of rotation in degrees.
-        """
-        with warnings.catch_warnings():
-            warnings.simplefilter("always")
-            warnings.warn(
-                "'Register.rotate()' has been deprecated and will be "
-                "removed in v0.18. Consider using `Register.rotated()` "
-                "instead.",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-        if self.layout is not None:
-            raise TypeError(
-                "A register defined from a RegisterLayout cannot be rotated."
-            )
-        theta = np.deg2rad(degrees)
-        rot = np.array(
-            [[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]]
-        )
-        object.__setattr__(self, "_coords", [rot @ v for v in self._coords])
-
     def rotated(self, degrees: float) -> Register:
         """Makes a new rotated register.
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -11,13 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import re
 from unittest.mock import patch
 
 import numpy as np
 import pytest
 
-import pulser
 from pulser import Register, Register3D
 from pulser.devices import DigitalAnalogDevice, MockDevice
 
@@ -277,17 +275,7 @@ def test_rotation():
     rot_reg = reg.rotated(45)
     new_coords_ = np.array([(0, -1), (1, 0), (-1, 0), (0, 1)], dtype=float)
     np.testing.assert_allclose(rot_reg._coords, new_coords_, atol=1e-15)
-
     assert rot_reg != reg
-
-    assert pulser.__version__ <= "0.18", "Remove 'Register.rotate()'."
-    with pytest.warns(
-        DeprecationWarning,
-        match=re.escape("'Register.rotate()' has been deprecated"),
-    ):
-        reg.rotate(45)
-    assert np.all(np.isclose(reg._coords, new_coords_))
-    assert reg == rot_reg
 
 
 draw_params = [

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -112,13 +112,6 @@ def test_register_definition(layout, layout3d):
     ):
         reg2d._validate_layout(layout, (0, 1))
 
-    with pytest.raises(TypeError, match="cannot be rotated"):
-        with pytest.warns(
-            DeprecationWarning,
-            match=re.escape("'Register.rotate()' has been deprecated"),
-        ):
-            reg2d.rotate(30)
-
     with pytest.warns(
         UserWarning, match="won't have an associated 'RegisterLayout'"
     ):


### PR DESCRIPTION
Following deprecation in v0.17.0. 