### PR TITLE
Add parameter to specify the numerical precision for matching coords to layout traps 

### DIFF
--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -32,7 +32,7 @@ from pulser.json.utils import get_dataclass_defaults, obj_to_dict
 from pulser.register.base_register import BaseRegister, QubitId
 from pulser.register.mappable_reg import MappableRegister
 from pulser.register.register_layout import RegisterLayout
-from pulser.register.traps import COORD_PRECISION
+from pulser.register.traps import COORD_DECIMAL_PRECISION
 
 DIMENSIONS = Literal[2, 3]
 
@@ -375,11 +375,11 @@ class BaseDevice(ABC):
     ) -> None:
         def invalid_dists(dists: np.ndarray) -> np.ndarray:
             cond1 = dists - self.min_atom_distance < -(
-                10 ** (-COORD_PRECISION)
+                10 ** (-COORD_DECIMAL_PRECISION)
             )
             # Ensures there are no identical traps when
             # min_atom_distance = 0
-            cond2 = dists < 10 ** (-COORD_PRECISION)
+            cond2 = dists < 10 ** (-COORD_DECIMAL_PRECISION)
             return cast(np.ndarray, np.logical_or(cond1, cond2))
 
         if len(coords) > 1:
@@ -394,7 +394,7 @@ class BaseDevice(ABC):
                 raise ValueError(
                     f"The minimal distance between {kind} in this device "
                     f"({self.min_atom_distance} µm) is not respected "
-                    f"(up to a precision of 1e{-COORD_PRECISION} µm) "
+                    f"(up to a precision of 1e{-COORD_DECIMAL_PRECISION} µm) "
                     f"for the pairs: {bad_qbt_pairs}"
                 )
 

--- a/pulser-core/pulser/register/_coordinates.py
+++ b/pulser-core/pulser/register/_coordinates.py
@@ -8,7 +8,7 @@ from typing import cast
 
 import numpy as np
 
-COORD_PRECISION = 6
+COORD_DECIMAL_PRECISION = 6
 
 
 @dataclass(eq=False, frozen=True)
@@ -39,7 +39,7 @@ class CoordsCollection:
     @cached_property  # Acts as an attribute in a frozen dataclass
     def _sorted_coords(self) -> np.ndarray:
         coords = np.array(self._coords, dtype=float)
-        rounded_coords = np.round(coords, decimals=COORD_PRECISION)
+        rounded_coords = np.round(coords, decimals=COORD_DECIMAL_PRECISION)
         sorting = self._calc_sorting_order()
         return cast(np.ndarray, rounded_coords[sorting])
 
@@ -47,7 +47,7 @@ class CoordsCollection:
         """Calculates the unique order that sorts the coordinates."""
         coords = np.array(self._coords, dtype=float)
         # Sorting the coordinates 1st left to right, 2nd bottom to top
-        rounded_coords = np.round(coords, decimals=COORD_PRECISION)
+        rounded_coords = np.round(coords, decimals=COORD_DECIMAL_PRECISION)
         dims = rounded_coords.shape[1]
         sorter = [rounded_coords[:, i] for i in range(dims - 1, -1, -1)]
         sorting = np.lexsort(tuple(sorter))

--- a/pulser-core/pulser/register/traps.py
+++ b/pulser-core/pulser/register/traps.py
@@ -24,7 +24,7 @@ from typing import Any
 import numpy as np
 from numpy.typing import ArrayLike
 
-from pulser.register._coordinates import COORD_PRECISION, CoordsCollection
+from pulser.register._coordinates import COORD_DECIMAL_PRECISION, CoordsCollection
 
 
 @dataclass(init=False, eq=False, frozen=True)
@@ -83,7 +83,7 @@ class Traps(ABC, CoordsCollection):
     def get_traps_from_coordinates(
         self,
         *coordinates: ArrayLike,
-        decimals: float = COORD_PRECISION,
+        decimals: float = COORD_DECIMAL_PRECISION,
     ) -> list[int]:
         """Finds the trap ID for a given set of trap coordinates.
 

--- a/pulser-core/pulser/register/traps.py
+++ b/pulser-core/pulser/register/traps.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Defines a set of traps from their coordinates."""
+
 from __future__ import annotations
 
 import hashlib
@@ -56,9 +57,7 @@ class Traps(ABC, CoordsCollection):
             raise array_type_error_msg
 
         if shape[1] not in (2, 3):
-            raise ValueError(
-                f"Each coordinate must be of size 2 or 3, not {shape[1]}."
-            )
+            raise ValueError(f"Each coordinate must be of size 2 or 3, not {shape[1]}.")
 
         if len(np.unique(trap_coordinates, axis=0)) != shape[0]:
             raise ValueError(

--- a/pulser-core/pulser/register/traps.py
+++ b/pulser-core/pulser/register/traps.py
@@ -81,19 +81,23 @@ class Traps(ABC, CoordsCollection):
         """The number of traps in the layout."""
         return len(self._sorted_coords)
 
-    def get_traps_from_coordinates(self, *coordinates: ArrayLike) -> list[int]:
+    def get_traps_from_coordinates(
+        self,
+        *coordinates: ArrayLike,
+        decimals: float = COORD_PRECISION,
+    ) -> list[int]:
         """Finds the trap ID for a given set of trap coordinates.
 
         Args:
             coordinates: The coordinates to return the trap IDs.
+            decimals: The numerical precision used to match coordinates
+                to traps.
 
         Returns:
             The list of trap IDs corresponding to the coordinates.
         """
         traps = []
-        rounded_coords = np.round(
-            np.array(coordinates), decimals=COORD_PRECISION
-        )
+        rounded_coords = np.round(np.array(coordinates), decimals=decimals)
         for coord, rounded in zip(coordinates, rounded_coords):
             key = tuple(rounded)
             if key not in self._coords_to_traps:

--- a/pulser-core/pulser/register/weight_maps.py
+++ b/pulser-core/pulser/register/weight_maps.py
@@ -27,7 +27,7 @@ from numpy.typing import ArrayLike
 
 from pulser.json.utils import obj_to_dict
 from pulser.register._reg_drawer import RegDrawer
-from pulser.register.traps import COORD_PRECISION, Traps
+from pulser.register.traps import COORD_DECIMAL_PRECISION, Traps
 
 if TYPE_CHECKING:
     from pulser.register.base_register import QubitId
@@ -81,7 +81,7 @@ class WeightMap(Traps, RegDrawer):
         for qid, pos in qubits.items():
             matches = np.argwhere(
                 np.all(
-                    np.isclose(coords_arr, pos, atol=10 ** (-COORD_PRECISION)),
+                    np.isclose(coords_arr, pos, atol=10 ** (-COORD_DECIMAL_PRECISION)),
                     axis=1,
                 )
             )


### PR DESCRIPTION
Adds the new keyword parameter `decimals` to `get_traps_from_coordinates`.
Also, renames the associated constant to make it clear it specifies a number of decimals.