### PR TITLE
Rectangular lattice register and layout

### DIFF
--- a/pulser-core/pulser/json/supported.py
+++ b/pulser-core/pulser/json/supported.py
@@ -66,6 +66,7 @@ SUPPORTED_MODULES = {
     "pulser.register.register3d": ("Register3D",),
     "pulser.register.register_layout": ("RegisterLayout",),
     "pulser.register.special_layouts": (
+        "RectangularLatticeLayout",
         "SquareLatticeLayout",
         "TriangularLatticeLayout",
     ),

--- a/pulser-core/pulser/json/supported.py
+++ b/pulser-core/pulser/json/supported.py
@@ -69,6 +69,7 @@ SUPPORTED_MODULES = {
         "RectangularLatticeLayout",
         "SquareLatticeLayout",
         "TriangularLatticeLayout",
+        # "RectangularLatticeLayout",
     ),
     "pulser.register.mappable_reg": ("MappableRegister",),
     "pulser.register.weight_maps": ("DetuningMap",),

--- a/pulser-core/pulser/json/supported.py
+++ b/pulser-core/pulser/json/supported.py
@@ -69,7 +69,6 @@ SUPPORTED_MODULES = {
         "RectangularLatticeLayout",
         "SquareLatticeLayout",
         "TriangularLatticeLayout",
-        # "RectangularLatticeLayout",
     ),
     "pulser.register.mappable_reg": ("MappableRegister",),
     "pulser.register.weight_maps": ("DetuningMap",),

--- a/pulser-core/pulser/register/__init__.py
+++ b/pulser-core/pulser/register/__init__.py
@@ -18,8 +18,11 @@ from pulser.register.register import Register
 from pulser.register.register3d import Register3D
 from pulser.register.register_layout import RegisterLayout
 from pulser.register.special_layouts import (
+    RectangularLatticeLayout,
     SquareLatticeLayout,
     TriangularLatticeLayout,
+    TriangularLatticeLayoutRectShape,
+    RandomLayout,
 )
 
 __all__ = [
@@ -29,4 +32,6 @@ __all__ = [
     "RegisterLayout",
     "SquareLatticeLayout",
     "TriangularLatticeLayout",
+    "TriangularLatticeLayoutRectShape",
+    "RandomLayout",
 ]

--- a/pulser-core/pulser/register/__init__.py
+++ b/pulser-core/pulser/register/__init__.py
@@ -18,11 +18,9 @@ from pulser.register.register import Register
 from pulser.register.register3d import Register3D
 from pulser.register.register_layout import RegisterLayout
 from pulser.register.special_layouts import (
-    RectangularLatticeLayout,
     SquareLatticeLayout,
     TriangularLatticeLayout,
-    TriangularLatticeLayoutRectShape,
-    RandomLayout,
+    RectangularLatticeLayout,
 )
 
 __all__ = [
@@ -32,6 +30,5 @@ __all__ = [
     "RegisterLayout",
     "SquareLatticeLayout",
     "TriangularLatticeLayout",
-    "TriangularLatticeLayoutRectShape",
-    "RandomLayout",
+    "RectangularLatticeLayout",
 ]

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -89,7 +89,7 @@ class Register(BaseRegister, RegDrawer):
         spacing: float = 4.0,
         prefix: Optional[str] = None,
     ) -> Register:
-        """Initializes register, qubits in a rectangular array, square lattice.
+        """Creates a rectangular array of qubits on a square lattice.
 
         Args:
             rows: Number of rows.
@@ -102,33 +102,10 @@ class Register(BaseRegister, RegDrawer):
         Returns:
             A register with qubits placed in a rectangular array.
         """
-        # Check rows
-        if rows < 1:
-            raise ValueError(
-                f"The number of rows (`rows` = {rows})"
-                " must be greater than or equal to 1."
-            )
-
-        # Check columns
-        if columns < 1:
-            raise ValueError(
-                f"The number of columns (`columns` = {columns})"
-                " must be greater than or equal to 1."
-            )
-
-        # Check spacing
-        if spacing <= 0.0:
-            raise ValueError(
-                f"Spacing between atoms (`spacing` = {spacing})"
-                " must be greater than 0."
-            )
-
-        coords = patterns.square_rect(rows, columns) * spacing
-
-        return cls.from_coordinates(coords, center=True, prefix=prefix)
+        return cls.rectangular_lattice(rows, columns, spacing, spacing, prefix)
 
     @classmethod
-    def rectangle_rect_lattice(
+    def rectangular_lattice(
         cls,
         rows: int,
         columns: int,
@@ -136,7 +113,7 @@ class Register(BaseRegister, RegDrawer):
         col_spacing: float = 2.0,
         prefix: Optional[str] = None,
     ) -> Register:
-        """Initializes register, qubits in rectangle array, rectangle lattice.
+        """Creates a rectangular array of qubits on a rectangular lattice.
 
         Args:
             rows: Number of rows.
@@ -148,7 +125,8 @@ class Register(BaseRegister, RegDrawer):
                 (e.g. prefix='q' -> IDs: 'q0', 'q1', 'q2', ...)
 
         Returns:
-            Register, qubits placed in a rectangular array, rectangle lattice.
+            Register with qubits placed in a rectangular array on a
+            rectangular lattice.
         """
         # Check rows
         if rows < 1:
@@ -166,13 +144,11 @@ class Register(BaseRegister, RegDrawer):
 
         # Check spacing
         if row_spacing <= 0.0 or col_spacing <= 0.0:
-            raise ValueError(
-                "Spacing between atoms must be greater than 0."
-            )
+            raise ValueError("Spacing between atoms must be greater than 0.")
 
         coords = patterns.square_rect(rows, columns)
-        coords[:, 0] = coords[:, 0]*col_spacing
-        coords[:, 1] = coords[:, 1]*row_spacing
+        coords[:, 0] = coords[:, 0] * col_spacing
+        coords[:, 1] = coords[:, 1] * row_spacing
 
         return cls.from_coordinates(coords, center=True, prefix=prefix)
 

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -89,7 +89,7 @@ class Register(BaseRegister, RegDrawer):
         spacing: float = 4.0,
         prefix: Optional[str] = None,
     ) -> Register:
-        """Initializes the register with the qubits in a rectangular array with a square lattice.
+        """Initializes register, qubits in a rectangular array, square lattice.
 
         Args:
             rows: Number of rows.
@@ -124,6 +124,55 @@ class Register(BaseRegister, RegDrawer):
             )
 
         coords = patterns.square_rect(rows, columns) * spacing
+
+        return cls.from_coordinates(coords, center=True, prefix=prefix)
+
+    @classmethod
+    def rectangle_rect_lattice(
+        cls,
+        rows: int,
+        columns: int,
+        row_spacing: float = 4.0,
+        col_spacing: float = 2.0,
+        prefix: Optional[str] = None,
+    ) -> Register:
+        """Initializes register, qubits in rectangle array, rectangle lattice.
+
+        Args:
+            rows: Number of rows.
+            columns: Number of columns.
+            row_spacing: The distance between rows in μm.
+            col_spacing: The distance between columns in μm.
+            prefix: The prefix for the qubit ids. If defined, each qubit
+                id starts with the prefix, followed by an int from 0 to N-1
+                (e.g. prefix='q' -> IDs: 'q0', 'q1', 'q2', ...)
+
+        Returns:
+            Register, qubits placed in a rectangular array, rectangle lattice.
+        """
+        # Check rows
+        if rows < 1:
+            raise ValueError(
+                f"The number of rows (`rows` = {rows})"
+                " must be greater than or equal to 1."
+            )
+
+        # Check columns
+        if columns < 1:
+            raise ValueError(
+                f"The number of columns (`columns` = {columns})"
+                " must be greater than or equal to 1."
+            )
+
+        # Check spacing
+        if row_spacing <= 0.0 or col_spacing <= 0.0:
+            raise ValueError(
+                "Spacing between atoms must be greater than 0."
+            )
+
+        coords = patterns.square_rect(rows, columns)
+        coords[:, 0] = coords[:, 0]*col_spacing
+        coords[:, 1] = coords[:, 1]*row_spacing
 
         return cls.from_coordinates(coords, center=True, prefix=prefix)
 

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -89,7 +89,7 @@ class Register(BaseRegister, RegDrawer):
         spacing: float = 4.0,
         prefix: Optional[str] = None,
     ) -> Register:
-        """Initializes the register with the qubits in a rectangular array.
+        """Initializes the register with the qubits in a rectangular array with a square lattice.
 
         Args:
             rows: Number of rows.

--- a/pulser-core/pulser/register/special_layouts.py
+++ b/pulser-core/pulser/register/special_layouts.py
@@ -30,31 +30,30 @@ from scipy.spatial.distance import cdist
 
 
 class RectangularLatticeLayout(RegisterLayout):
-    """A RegisterLayout with a rectangular lattice pattern in a rectangular
-    shape.
+    """RegisterLayout with rectangular lattice pattern in a rectangular shape.
 
     Args:
         rows: The number of rows of traps.
         columns: The number of columns of traps.
-        x_spacing: Horizontal distance between neighbouring traps (in µm).
-        y_spacing: Vertical distance between neighbouring traps (in µm)
+        col_spacing: Horizontal distance between neighbouring traps (in µm).
+        row_spacing: Vertical distance between neighbouring traps (in µm)
     """
 
     def __init__(
-        self, rows: int, columns: int, x_spacing: float, y_spacing: float
+        self, rows: int, columns: int, col_spacing: float, row_spacing: float
     ):
         """Initializes a RectangularLatticeLayout."""
         self._rows = int(rows)
         self._columns = int(columns)
-        self._x_spacing = float(x_spacing)
-        self._y_spacing = float(y_spacing)
+        self._col_spacing = float(col_spacing)
+        self._row_spacing = float(row_spacing)
         slug = (
-            f"RectangularLatticeLayout(Shape : {self._rows}x{self._columns}, "
-            f"Lattice pattern : {self._x_spacing}x{self._y_spacing}µm)"
+            f"RectangularLatticeLayout({self._rows}x{self._columns}, "
+            f"{self._col_spacing}x{self._row_spacing}µm)"
         )
         self._traps = patterns.square_rect(self._rows, self._columns)
-        self._traps[:, 0] = self._traps[:, 0] * self._x_spacing
-        self._traps[:, 1] = self._traps[:, 1] * self._y_spacing
+        self._traps[:, 0] = self._traps[:, 0] * self._col_spacing
+        self._traps[:, 1] = self._traps[:, 1] * self._row_spacing
         super().__init__(
             trap_coordinates=self._traps,
             slug=slug,
@@ -98,8 +97,8 @@ class RectangularLatticeLayout(RegisterLayout):
                 f"{self._rows}x{self._columns} RectangularLatticeLayout."
             )
         points = patterns.square_rect(rows, columns)
-        points[:, 0] = points[:, 0] * self._x_spacing
-        points[:, 1] = points[:, 1] * self._y_spacing
+        points[:, 0] = points[:, 0] * self._col_spacing
+        points[:, 1] = points[:, 1] * self._row_spacing
         trap_ids = self.get_traps_from_coordinates(*points)
         qubit_ids = [f"{prefix}{i}" for i in range(len(trap_ids))]
         return cast(
@@ -109,7 +108,8 @@ class RectangularLatticeLayout(RegisterLayout):
 
     def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(
-            self, self._rows, self._columns, self._x_spacing, self._y_spacing
+            self, self._rows, self._columns, self._col_spacing,
+            self._row_spacing
         )
 
 
@@ -127,9 +127,16 @@ class SquareLatticeLayout(RectangularLatticeLayout):
         self._rows = int(rows)
         self._columns = int(columns)
         self._spacing = float(spacing)
+        self._col_spacing = self._spacing
+        self._row_spacing = self._spacing
         super().__init__(
             self._rows, self._columns, self._spacing, self._spacing
         )
+        slug = (
+            f"SquareLatticeLayout({self._rows}x{self._columns}, "
+            f"{self._spacing}µm)"
+        )
+        object.__setattr__(self, "slug", slug)
 
     def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(self, self._rows, self._columns, self._spacing)
@@ -211,8 +218,7 @@ class TriangularLatticeLayout(RegisterLayout):
 
 
 class TriangularLatticeLayoutRectShape(RegisterLayout):
-    """A RegisterLayout with a triangular lattice pattern in a rectangular
-    shape.
+    """RegisterLayout with a triangular lattice pattern in a rectangular shape.
 
     Args:
         n_traps: The number of traps in the layout.
@@ -252,8 +258,8 @@ class RandomLayout(RegisterLayout):
         min_spacing: float = 5,
         max_iter: int = 1000,
     ):
-        """Initializes a random layout"""
-        self._pts = []
+        """Initializes a random layout."""
+        self._pts : np.ndarray = []
         self._n_traps = int(n_traps)
         self._min_spacing = float(min_spacing)
         i = 0

--- a/pulser-core/pulser/register/special_layouts.py
+++ b/pulser-core/pulser/register/special_layouts.py
@@ -25,9 +25,6 @@ from pulser.register.register_layout import RegisterLayout
 if TYPE_CHECKING:
     from pulser.register import Register
 
-import numpy as np
-from scipy.spatial.distance import cdist
-
 
 class RectangularLatticeLayout(RegisterLayout):
     """RegisterLayout with rectangular lattice pattern in a rectangular shape.
@@ -108,8 +105,11 @@ class RectangularLatticeLayout(RegisterLayout):
 
     def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(
-            self, self._rows, self._columns, self._col_spacing,
-            self._row_spacing
+            self,
+            self._rows,
+            self._columns,
+            self._col_spacing,
+            self._row_spacing,
         )
 
 
@@ -215,75 +215,3 @@ class TriangularLatticeLayout(RegisterLayout):
 
     def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(self, self.number_of_traps, self._spacing)
-
-
-class TriangularLatticeLayoutRectShape(RegisterLayout):
-    """RegisterLayout with a triangular lattice pattern in a rectangular shape.
-
-    Args:
-        n_traps: The number of traps in the layout.
-        spacing: The distance between neighbouring traps (in µm).
-    """
-
-    def __init__(self, columns: int, rows: int, spacing: float = 5):
-        """Initializes a TriangularLatticeLayout."""
-        self._spacing = float(spacing)
-        self._columns = int(columns)
-        self._rows = int(rows)
-        slug = (
-            f"TriangularLatticeLayoutRectshape({self._rows}x{self._columns}, "
-            f"{self._spacing}µm)"
-        )
-        super().__init__(
-            patterns.triangular_rect(self._rows, self._columns)
-            * self._spacing,
-            slug=slug,
-        )
-
-
-class RandomLayout(RegisterLayout):
-    """A RegisterLayout generated randomly.
-
-    Args :
-        n_traps : the number of traps in the layout
-        radius : radius defining the working area
-        min_dist : minimum distance between traps
-        max_iter = maximum number of iterations to compute the random layout
-    """
-
-    def __init__(
-        self,
-        n_traps: int,
-        radius: float = 35,
-        min_spacing: float = 5,
-        max_iter: int = 1000,
-    ):
-        """Initializes a random layout."""
-        self._pts : np.ndarray = []
-        self._n_traps = int(n_traps)
-        self._min_spacing = float(min_spacing)
-        i = 0
-        while len(self._pts) < n_traps and i < max_iter:
-            pt_x = np.random.uniform(low=-radius, high=radius, size=1)
-            pt_y = np.random.uniform(low=-radius, high=radius, size=1)
-            pt = np.stack([pt_x, pt_y], axis=1)
-            if not self._pts and pt_x**2 + pt_y**2 <= radius**2:
-                self._pts.append(pt)
-                continue
-            if len(self._pts) == 0:
-                continue
-            dist = cdist(np.concatenate(self._pts), pt)
-            if pt_x**2 + pt_y**2 <= radius**2 and np.all(
-                dist > self._min_spacing
-            ):
-                self._pts.append(pt)
-            i += 1
-        if len(self._pts) < n_traps:
-            raise ValueError(
-                "Could not compute random traps in max iterations"
-            )
-        slug = (
-            f"RandomLayout({self._n_traps} traps, "
-            f"min spacing {self._min_spacing}µm)"
-        )
-        super().__init__(trap_coordinates=np.concatenate(self._pts), slug=slug)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -28,6 +28,7 @@ from pulser.register.register_layout import RegisterLayout
 from pulser.register.special_layouts import (
     SquareLatticeLayout,
     TriangularLatticeLayout,
+    RectangularLatticeLayout,
 )
 from pulser.register.weight_maps import DetuningMap
 from pulser.waveforms import BlackmanWaveform
@@ -91,6 +92,11 @@ def test_layout():
     new_square_layout = encode_decode(square_layout)
     assert new_square_layout == square_layout
     assert type(new_square_layout) is SquareLatticeLayout
+
+    rectangular_layout = RectangularLatticeLayout(8, 10, 6, 5)
+    new_rectangular_layout = encode_decode(rectangular_layout)
+    assert new_rectangular_layout == rectangular_layout
+    assert type(new_rectangular_layout) is RectangularLatticeLayout
 
 
 def test_register_from_layout():

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -26,9 +26,9 @@ from pulser.json.supported import validate_serialization
 from pulser.parametrized.decorators import parametrize
 from pulser.register.register_layout import RegisterLayout
 from pulser.register.special_layouts import (
+    RectangularLatticeLayout,
     SquareLatticeLayout,
     TriangularLatticeLayout,
-    RectangularLatticeLayout,
 )
 from pulser.register.weight_maps import DetuningMap
 from pulser.waveforms import BlackmanWaveform

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -84,6 +84,24 @@ def test_creation():
         Register(qubits, spacing=10, layout="square", trap_ids=(0, 1, 3))
 
 
+def test_rectangular_lattice():
+    # Check rows
+    with pytest.raises(ValueError, match="The number of rows"):
+        Register.rectangular_lattice(0, 2, 3, 4)
+
+    # Check columns
+    with pytest.raises(ValueError, match="The number of columns"):
+        Register.rectangular_lattice(2, 0, 3, 4)
+
+    # Check row spacing
+    with pytest.raises(ValueError, match="Spacing"):
+        Register.rectangular_lattice(2, 2, 0.0, 5)
+
+    # Check col spacing
+    with pytest.raises(ValueError, match="Spacing"):
+        Register.rectangular_lattice(2, 2, 3, 0.0)
+
+
 def test_rectangle():
     # Check rows
     with pytest.raises(ValueError, match="The number of rows"):

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -22,8 +22,11 @@ import pytest
 from pulser.register import Register, Register3D
 from pulser.register.register_layout import RegisterLayout
 from pulser.register.special_layouts import (
+    RandomLayout,
+    RectangularLatticeLayout,
     SquareLatticeLayout,
     TriangularLatticeLayout,
+    TriangularLatticeLayoutRectShape,
 )
 
 
@@ -190,6 +193,25 @@ def test_square_lattice_layout():
         square.rectangular_register(10, 3)
 
 
+def test_rectangular_lattice_layout():
+    rectangle = RectangularLatticeLayout(9, 7, 5, 5)
+    assert (
+        str(rectangle)
+        == "RectangularLatticeLayout(Shape : 9x7, Lattice pattern : 5.0x5.0µm)"
+    )
+    assert rectangle.square_register(3) == Register.square(
+        3, spacing=5, prefix="q"
+    )
+    # An even number of atoms on the side won't align the center with an atom
+    assert rectangle.square_register(4) != Register.square(
+        4, spacing=5, prefix="q"
+    )
+    with pytest.raises(ValueError, match="'8x8' array doesn't fit"):
+        rectangle.square_register(8)
+    with pytest.raises(ValueError, match="'10x3' array doesn't fit"):
+        rectangle.rectangular_register(10, 3)
+
+
 def test_triangular_lattice_layout():
     tri = TriangularLatticeLayout(50, 5)
     assert str(tri) == "TriangularLatticeLayout(50, 5.0µm)"
@@ -219,6 +241,16 @@ def test_triangular_lattice_layout():
     assert tri.rectangular_register(5, 5) != Register.triangular_lattice(
         5, 5, spacing=5, prefix="q"
     )
+
+
+def test_triangular_lattice_layout_rect_shape():
+    tri = TriangularLatticeLayoutRectShape(10, 4, 5)
+    assert str(tri) == "TriangularLatticeLayoutRectshape(4x10, 5.0µm)"
+
+
+def test_random_layout():
+    rand = RandomLayout(50, max_iter=10000, min_spacing=4)
+    assert str(rand) == "RandomLayout(50 traps, min spacing 4.0µm)"
 
 
 def test_mappable_register_creation():

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -194,17 +194,17 @@ def test_square_lattice_layout():
 
 
 def test_rectangular_lattice_layout():
-    rectangle = RectangularLatticeLayout(9, 7, 5, 5)
+    rectangle = RectangularLatticeLayout(9, 7, 2, 4)
     assert (
         str(rectangle)
-        == "RectangularLatticeLayout(Shape : 9x7, Lattice pattern : 5.0x5.0µm)"
+        == "RectangularLatticeLayout(9x7, 2.0x4.0µm)"
     )
-    assert rectangle.square_register(3) == Register.square(
-        3, spacing=5, prefix="q"
+    assert rectangle.square_register(3) == Register.rectangle_rect_lattice(
+        3, 3, col_spacing=2, row_spacing=4, prefix="q"
     )
     # An even number of atoms on the side won't align the center with an atom
-    assert rectangle.square_register(4) != Register.square(
-        4, spacing=5, prefix="q"
+    assert rectangle.square_register(4) != Register.rectangle_rect_lattice(
+        4, 4, col_spacing=2, row_spacing=4, prefix="q"
     )
     with pytest.raises(ValueError, match="'8x8' array doesn't fit"):
         rectangle.square_register(8)

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -22,11 +22,9 @@ import pytest
 from pulser.register import Register, Register3D
 from pulser.register.register_layout import RegisterLayout
 from pulser.register.special_layouts import (
-    RandomLayout,
     RectangularLatticeLayout,
     SquareLatticeLayout,
     TriangularLatticeLayout,
-    TriangularLatticeLayoutRectShape,
 )
 
 
@@ -195,15 +193,12 @@ def test_square_lattice_layout():
 
 def test_rectangular_lattice_layout():
     rectangle = RectangularLatticeLayout(9, 7, 2, 4)
-    assert (
-        str(rectangle)
-        == "RectangularLatticeLayout(9x7, 2.0x4.0µm)"
-    )
-    assert rectangle.square_register(3) == Register.rectangle_rect_lattice(
+    assert str(rectangle) == "RectangularLatticeLayout(9x7, 2.0x4.0µm)"
+    assert rectangle.square_register(3) == Register.rectangular_lattice(
         3, 3, col_spacing=2, row_spacing=4, prefix="q"
     )
     # An even number of atoms on the side won't align the center with an atom
-    assert rectangle.square_register(4) != Register.rectangle_rect_lattice(
+    assert rectangle.square_register(4) != Register.rectangular_lattice(
         4, 4, col_spacing=2, row_spacing=4, prefix="q"
     )
     with pytest.raises(ValueError, match="'8x8' array doesn't fit"):
@@ -241,16 +236,6 @@ def test_triangular_lattice_layout():
     assert tri.rectangular_register(5, 5) != Register.triangular_lattice(
         5, 5, spacing=5, prefix="q"
     )
-
-
-def test_triangular_lattice_layout_rect_shape():
-    tri = TriangularLatticeLayoutRectShape(10, 4, 5)
-    assert str(tri) == "TriangularLatticeLayoutRectshape(4x10, 5.0µm)"
-
-
-def test_random_layout():
-    rand = RandomLayout(50, max_iter=10000, min_spacing=4)
-    assert str(rand) == "RandomLayout(50 traps, min spacing 4.0µm)"
 
 
 def test_mappable_register_creation():


### PR DESCRIPTION
Addition of classes to the special layouts :
RectangularLatticeLayout to be able to play with x and y spacing. Now SquareLatticeLayout inherits from it. Don't know how to deal with the print change, we can keep rectangular for a square. (one test fails that compares the strings)
TriangularLatticeLayoutRectShape to have triangular lattice in a rectangular layout
RandomLayout that generates a random layout for a given number of traps (limited number of iterations)

mypy failed because of no type defintion of an empty list in RandomLayout.