### PR TITLE
Remove deprecated noise arguments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.10.1
+    rev: 24.4.0
     hooks:
       - id: black-jupyter
 

--- a/pulser-core/pulser/backend/noise_model.py
+++ b/pulser-core/pulser/backend/noise_model.py
@@ -14,9 +14,8 @@
 """Defines a noise model class for emulator backends."""
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass, field, fields
-from typing import Any, Literal, get_args
+from typing import Literal, get_args
 
 import numpy as np
 
@@ -69,16 +68,10 @@ class NoiseModel:
         amp_sigma: Dictates the fluctuations in amplitude as a standard
             deviation of a normal distribution centered in 1.
         dephasing_rate: The rate of a dephasing error occuring (in rad/µs).
-        dephasing_prob: (Deprecated) The rate of a dephasing error occuring
-            (in rad/µs). Use `dephasing_rate` instead.
         depolarizing_rate: The rate (in rad/µs) at which a depolarizing
             error occurs.
-        depolarizing_prob: (Deprecated) The rate (in rad/µs) at which a
-            depolarizing error occurs. Use `depolarizing_rate` instead.
         eff_noise_rates: The rate associated to each effective noise operator
             (in rad/µs).
-        eff_noise_probs: (Deprecated) The rate associated to each effective
-            noise operator (in rad/µs). Use `eff_noise_rate` instead.
         eff_noise_opers: The operators for the effective noise model.
     """
 
@@ -95,44 +88,8 @@ class NoiseModel:
     depolarizing_rate: float = 0.05
     eff_noise_rates: list[float] = field(default_factory=list)
     eff_noise_opers: list[np.ndarray] = field(default_factory=list)
-    dephasing_prob: float | None = None
-    depolarizing_prob: float | None = None
-    eff_noise_probs: list[float] = field(default_factory=list)
 
     def __post_init__(self) -> None:
-        default_field_value = {
-            field.name: field.default for field in fields(self)
-        }
-        for noise in ["dephasing", "depolarizing", "eff_noise"]:
-            # Probability and rates should be the same
-            prob_name = f"{noise}_prob{'s' if noise=='eff_noise' else ''}"
-            rate_name = f"{noise}_rate{'s' if noise=='eff_noise' else ''}"
-            prob, rate = (getattr(self, prob_name), getattr(self, rate_name))
-            if len(prob) > 0 if noise == "eff_noise" else prob is not None:
-                warnings.warn(
-                    f"{prob_name} is deprecated. Use {rate_name} instead.",
-                    DeprecationWarning,
-                )
-                if prob != rate:
-                    if (
-                        len(rate) > 0
-                        if noise == "eff_noise"
-                        else rate != default_field_value[rate_name]
-                    ):
-                        raise ValueError(
-                            f"If both defined, `{rate_name}` and `{prob_name}`"
-                            " must be equal."
-                        )
-                    warnings.warn(
-                        f"Setting {rate_name} with the value from "
-                        f"{prob_name}.",
-                        UserWarning,
-                    )
-                    self._change_attribute(rate_name, prob)
-            self._change_attribute(prob_name, getattr(self, rate_name))
-        assert self.dephasing_prob == self.dephasing_rate
-        assert self.depolarizing_prob == self.depolarizing_rate
-        assert self.eff_noise_probs == self.eff_noise_rates
         positive = {
             "dephasing_rate",
             "depolarizing_rate",
@@ -173,9 +130,6 @@ class NoiseModel:
 
         self._check_noise_types()
         self._check_eff_noise()
-
-    def _change_attribute(self, attr_name: str, new_value: Any) -> None:
-        object.__setattr__(self, attr_name, new_value)
 
     def _check_noise_types(self) -> None:
         for noise_type in self.noise_types:

--- a/pulser-simulation/pulser_simulation/qutip_backend.py
+++ b/pulser-simulation/pulser_simulation/qutip_backend.py
@@ -14,7 +14,6 @@
 """Defines the QutipBackend class."""
 from __future__ import annotations
 
-import warnings
 from typing import Any
 
 from pulser import Sequence
@@ -44,9 +43,7 @@ class QutipBackend(Backend):
                 f"not {type(config)}."
             )
         self._config = config
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=DeprecationWarning)
-            simconfig = SimConfig.from_noise_model(self._config.noise_model)
+        simconfig = SimConfig.from_noise_model(self._config.noise_model)
         self._sim_obj = QutipEmulator.from_sequence(
             sequence,
             sampling_rate=self._config.sampling_rate,

--- a/pulser-simulation/pulser_simulation/simconfig.py
+++ b/pulser-simulation/pulser_simulation/simconfig.py
@@ -114,9 +114,6 @@ class SimConfig:
     eff_noise_rates: list[float] = field(default_factory=list, repr=False)
     eff_noise_opers: list[qutip.Qobj] = field(default_factory=list, repr=False)
     solver_options: Optional[qutip.Options] = None
-    dephasing_prob: float | None = None
-    depolarizing_prob: float | None = None
-    eff_noise_probs: list[float] = field(default_factory=list, repr=False)
 
     @classmethod
     def from_noise_model(cls: Type[T], noise_model: NoiseModel) -> T:
@@ -135,9 +132,6 @@ class SimConfig:
             depolarizing_rate=noise_model.depolarizing_rate,
             eff_noise_rates=noise_model.eff_noise_rates,
             eff_noise_opers=list(map(qutip.Qobj, noise_model.eff_noise_opers)),
-            dephasing_prob=noise_model.dephasing_prob,
-            depolarizing_prob=noise_model.depolarizing_prob,
-            eff_noise_probs=noise_model.eff_noise_probs,
         )
 
     def to_noise_model(self) -> NoiseModel:
@@ -156,9 +150,6 @@ class SimConfig:
             depolarizing_rate=self.depolarizing_rate,
             eff_noise_rates=self.eff_noise_rates,
             eff_noise_opers=[op.full() for op in self.eff_noise_opers],
-            dephasing_prob=self.dephasing_prob,
-            depolarizing_prob=self.depolarizing_prob,
-            eff_noise_probs=self.eff_noise_probs,
         )
 
     def __post_init__(self) -> None:
@@ -179,12 +170,7 @@ class SimConfig:
         self._check_eff_noise_opers_type()
 
         # Runs the noise model checks
-        noise_model = self.to_noise_model()
-        # Update rates and probs
-        for noise in ["dephasing", "depolarizing", "eff_noise"]:
-            for qty in ["prob", "rate"]:
-                attr = f"{noise}_{qty}{'s' if noise=='eff_noise' else ''}"
-                self._change_attribute(attr, getattr(noise_model, attr))
+        self.to_noise_model()
 
     @property
     def spam_dict(self) -> dict[str, float]:

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -146,13 +146,9 @@ class QutipEmulator:
                 "`sampling_rate` is too small, less than 4 data points."
             )
         # Sets the config as well as builds the hamiltonian
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=DeprecationWarning)
-            noise_model: NoiseModel = (
-                config.to_noise_model()
-                if config
-                else SimConfig().to_noise_model()
-            )
+        noise_model: NoiseModel = (
+            config.to_noise_model() if config else SimConfig().to_noise_model()
+        )
         self._hamiltonian = Hamiltonian(
             self.samples_obj,
             self._register.qubits,
@@ -201,9 +197,7 @@ class QutipEmulator:
     @property
     def config(self) -> SimConfig:
         """The current configuration, as a SimConfig instance."""
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=DeprecationWarning)
-            return SimConfig.from_noise_model(self._hamiltonian.config)
+        return SimConfig.from_noise_model(self._hamiltonian.config)
 
     def set_config(self, cfg: SimConfig) -> None:
         """Sets current config to cfg and updates simulation parameters.
@@ -223,9 +217,7 @@ class QutipEmulator:
                 " support simulation of noise types:"
                 f"{', '.join(not_supported)}."
             )
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=DeprecationWarning)
-            self._hamiltonian.set_config(cfg.to_noise_model())
+        self._hamiltonian.set_config(cfg.to_noise_model())
 
     def add_config(self, config: SimConfig) -> None:
         """Updates the current configuration with parameters of another one.
@@ -252,9 +244,7 @@ class QutipEmulator:
                 " support simulation of noise types: "
                 f"{', '.join(not_supported)}."
             )
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=DeprecationWarning)
-            noise_model = config.to_noise_model()
+        noise_model = config.to_noise_model()
         old_noise_set = set(self._hamiltonian.config.noise_types)
         new_noise_set = old_noise_set.union(noise_model.noise_types)
         diff_noise_set = new_noise_set - old_noise_set
@@ -282,9 +272,7 @@ class QutipEmulator:
         param_dict["runs"] = noise_model.runs
         param_dict["samples_per_run"] = noise_model.samples_per_run
         # set config with the new parameters:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=DeprecationWarning)
-            self._hamiltonian.set_config(NoiseModel(**param_dict))
+        self._hamiltonian.set_config(NoiseModel(**param_dict))
 
     def show_config(self, solver_options: bool = False) -> None:
         """Shows current configuration."""
@@ -292,9 +280,7 @@ class QutipEmulator:
 
     def reset_config(self) -> None:
         """Resets configuration to default."""
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=DeprecationWarning)
-            self._hamiltonian.set_config(SimConfig().to_noise_model())
+        self._hamiltonian.set_config(SimConfig().to_noise_model())
 
     @property
     def initial_state(self) -> qutip.Qobj:

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -272,15 +272,12 @@ class QutipEmulator:
             param_dict["laser_waist"] = noise_model.laser_waist
             param_dict["amp_sigma"] = noise_model.amp_sigma
         if "dephasing" in diff_noise_set:
-            param_dict["dephasing_prob"] = noise_model.dephasing_prob
             param_dict["dephasing_rate"] = noise_model.dephasing_rate
         if "depolarizing" in diff_noise_set:
-            param_dict["depolarizing_prob"] = noise_model.depolarizing_prob
             param_dict["depolarizing_rate"] = noise_model.depolarizing_rate
         if "eff_noise" in diff_noise_set:
             param_dict["eff_noise_opers"] = noise_model.eff_noise_opers
             param_dict["eff_noise_rates"] = noise_model.eff_noise_rates
-            param_dict["eff_noise_probs"] = noise_model.eff_noise_probs
         # update runs:
         param_dict["runs"] = noise_model.runs
         param_dict["samples_per_run"] = noise_model.samples_per_run

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -111,35 +111,9 @@ class TestNoiseModel:
         [
             "dephasing_rate",
             "depolarizing_rate",
-            "dephasing_prob",
-            "depolarizing_prob",
         ],
     )
     def test_init_rate_like(self, param, value):
-        def create_noise_model(param, value):
-            if "prob" in param:
-                if value > 0:
-                    with pytest.raises(
-                        ValueError, match=f"{param}` must be equal."
-                    ):
-                        with pytest.warns(
-                            DeprecationWarning,
-                            match=f"{param} is deprecated.",
-                        ):
-                            NoiseModel(
-                                **{
-                                    param: value,
-                                    "dephasing_rate": value * 10,
-                                    "depolarizing_rate": value * 10,
-                                }
-                            )
-                with pytest.warns(
-                    (UserWarning, DeprecationWarning),
-                    match=f"{param}",
-                ):
-                    return NoiseModel(**{param: value})
-            return NoiseModel(**{param: value})
-
         if value < 0:
             param_mess = (
                 "depolarizing_rate"
@@ -151,9 +125,9 @@ class TestNoiseModel:
                 match=f"'{param_mess}' must be None or greater "
                 f"than or equal to zero, not {value}.",
             ):
-                create_noise_model(param, value)
+                NoiseModel(**{param: value})
         else:
-            noise_model = create_noise_model(param, value)
+            noise_model = NoiseModel(**{param: value})
             if "depolarizing" in param:
                 assert noise_model.depolarizing_rate == value
             elif "dephasing" in param:
@@ -187,7 +161,7 @@ class TestNoiseModel:
         matrices["I3"] = np.eye(3)
         return matrices
 
-    def test_eff_noise_probs(self, matrices):
+    def test_eff_noise_rates(self, matrices):
         with pytest.raises(
             ValueError, match="The provided rates must be greater than 0."
         ):
@@ -196,38 +170,6 @@ class TestNoiseModel:
                 eff_noise_opers=[matrices["I"], matrices["X"]],
                 eff_noise_rates=[-1.0, 0.5],
             )
-        with pytest.warns(
-            (UserWarning, DeprecationWarning), match="eff_noise_probs"
-        ):
-            NoiseModel(
-                noise_types=("eff_noise",),
-                eff_noise_opers=[matrices["I"], matrices["X"]],
-                eff_noise_probs=[1.2, 0.5],
-            )
-
-        with pytest.warns(
-            DeprecationWarning, match="eff_noise_probs is deprecated."
-        ):
-            NoiseModel(
-                noise_types=("eff_noise",),
-                eff_noise_opers=[matrices["I"], matrices["X"]],
-                eff_noise_rates=[1.2, 0.5],
-                eff_noise_probs=[1.2, 0.5],
-            )
-
-        with pytest.raises(
-            ValueError,
-            match="If both defined, `eff_noise_rates` and `eff_noise_probs`",
-        ):
-            with pytest.warns(
-                DeprecationWarning, match="eff_noise_probs is deprecated."
-            ):
-                NoiseModel(
-                    noise_types=("eff_noise",),
-                    eff_noise_opers=[matrices["I"], matrices["X"]],
-                    eff_noise_probs=[1.4, 0.5],
-                    eff_noise_rates=[1.2, 0.5],
-                )
 
     def test_eff_noise_opers(self, matrices):
         with pytest.raises(ValueError, match="The operators list length"):

--- a/tests/test_simconfig.py
+++ b/tests/test_simconfig.py
@@ -51,8 +51,7 @@ def test_init():
     )
     config = SimConfig(noise="depolarizing")
     assert config.temperature == 5e-5
-    with pytest.warns(DeprecationWarning, match="is deprecated"):
-        assert config.to_noise_model().temperature == 50
+    assert config.to_noise_model().temperature == 50
     str_config = config.__str__(True)
     assert "depolarizing" in str_config
     config = SimConfig(
@@ -122,7 +121,6 @@ def test_from_noise_model():
         p_false_pos=0.1,
         state_prep_error=0.05,
     )
-    with pytest.warns(DeprecationWarning, match="is deprecated"):
-        assert SimConfig.from_noise_model(noise_model) == SimConfig(
-            noise="SPAM", epsilon=0.1, epsilon_prime=0.4, eta=0.05
-        )
+    assert SimConfig.from_noise_model(noise_model) == SimConfig(
+        noise="SPAM", epsilon=0.1, epsilon_prime=0.4, eta=0.05
+    )

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -490,9 +490,7 @@ def test_run(seq, patch_plt_show):
     good_initial_qobj = qutip.tensor(
         [qutip.basis(sim.dim, 0) for _ in range(sim._hamiltonian._size)]
     )
-    good_initial_qobj_no_dims = qutip.basis(
-        sim.dim**sim._hamiltonian._size, 2
-    )
+    good_initial_qobj_no_dims = qutip.basis(sim.dim**sim._hamiltonian._size, 2)
 
     with pytest.raises(
         ValueError, match="Incompatible shape of initial state"

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -490,7 +490,9 @@ def test_run(seq, patch_plt_show):
     good_initial_qobj = qutip.tensor(
         [qutip.basis(sim.dim, 0) for _ in range(sim._hamiltonian._size)]
     )
-    good_initial_qobj_no_dims = qutip.basis(sim.dim**sim._hamiltonian._size, 2)
+    good_initial_qobj_no_dims = qutip.basis(
+        sim.dim**sim._hamiltonian._size, 2
+    )
 
     with pytest.raises(
         ValueError, match="Incompatible shape of initial state"
@@ -1016,10 +1018,9 @@ def test_noisy_xy(matrices, masked_qubit, noise, result, n_collapse_ops):
     with pytest.raises(
         NotImplementedError, match="mode 'XY' does not support simulation of"
     ):
-        with pytest.warns(DeprecationWarning, match="is deprecated"):
-            sim._hamiltonian.set_config(
-                SimConfig(("SPAM", "doppler")).to_noise_model()
-            )
+        sim._hamiltonian.set_config(
+            SimConfig(("SPAM", "doppler")).to_noise_model()
+        )
     with pytest.raises(
         NotImplementedError, match="simulation of noise types: amplitude"
     ):


### PR DESCRIPTION
This PR removes the already deprecated:
- `dephasing_prob`
- `depolarizing_prob`
- `effective_noise_probs`