### PR TITLE
Fix CI tests on "macos" for python < 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - develop
-  pull_request:
 
 jobs:
   full-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - develop
+  pull_request:
 
 jobs:
   full-tests:
@@ -15,8 +16,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Python 3.8 and 3.9 does not run on macos-latest (14)
+        # Uses macos-13 for 3.8 and 3.9 and macos-latest for >=3.10 
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        exclude:
+          - os: macos-latest
+            python-version: "3.8"
+          - os: macos-latest
+            python-version: "3.9"
+          - os: macos-13
+            python-version: "3.10"
+          - os: macos-13
+            python-version: "3.11"
     steps:
       - name: Check out Pulser
         uses: actions/checkout@v4


### PR DESCRIPTION
`macos-latest` no longer supports Python 3.8 and 3.9 so I'm using `macos-13` for these versions instead.