### PR TITLE
Add lightshift coefficients to RydbergEOM

### DIFF
--- a/pulser-core/pulser/channels/eom.py
+++ b/pulser-core/pulser/channels/eom.py
@@ -311,11 +311,10 @@ class RydbergEOM(_RydbergEOMDefaults, BaseEOM, _RydbergEOM):
         # limit_rabi_freq is the maximum effective rabi frequency value
         # below which the lightshift can be zero
         if rabi_frequency <= limit_rabi_freq:
-            base_amp = np.sqrt(2 * rabi_frequency * self.intermediate_detuning)
-            sqrt_shift_factor = np.sqrt(shift_factor)
+            base_amp_squared = 2 * rabi_frequency * self.intermediate_detuning
             return {
-                self.limiting_beam: base_amp / sqrt_shift_factor,
-                ~self.limiting_beam: base_amp * sqrt_shift_factor,
+                self.limiting_beam: np.sqrt(base_amp_squared / shift_factor),
+                ~self.limiting_beam: np.sqrt(base_amp_squared * shift_factor),
             }
 
         # The limiting beam is at its maximum amplitude while the other

--- a/pulser-core/pulser/json/abstract_repr/schemas/device-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/device-schema.json
@@ -377,6 +377,10 @@
                 {
                   "additionalProperties": false,
                   "properties": {
+                    "blue_shift_coeff": {
+                      "description": "The weight coefficient of the blue beam's contribution to the lightshift.",
+                      "type": "number"
+                    },
                     "controlled_beams": {
                       "description": "The beams that can be switched on/off with an EOM.",
                       "items": {
@@ -415,6 +419,10 @@
                     "multiple_beam_control": {
                       "description": "Whether both EOMs can be used simultaneously or not.",
                       "type": "boolean"
+                    },
+                    "red_shift_coeff": {
+                      "description": "The weight coefficient of the blue beam's contribution to the lightshift.",
+                      "type": "number"
                     }
                   },
                   "required": [
@@ -703,6 +711,10 @@
                 {
                   "additionalProperties": false,
                   "properties": {
+                    "blue_shift_coeff": {
+                      "description": "The weight coefficient of the blue beam's contribution to the lightshift.",
+                      "type": "number"
+                    },
                     "controlled_beams": {
                       "description": "The beams that can be switched on/off with an EOM.",
                       "items": {
@@ -741,6 +753,10 @@
                     "multiple_beam_control": {
                       "description": "Whether both EOMs can be used simultaneously or not.",
                       "type": "boolean"
+                    },
+                    "red_shift_coeff": {
+                      "description": "The weight coefficient of the blue beam's contribution to the lightshift.",
+                      "type": "number"
                     }
                   },
                   "required": [
@@ -1043,6 +1059,10 @@
                 {
                   "additionalProperties": false,
                   "properties": {
+                    "blue_shift_coeff": {
+                      "description": "The weight coefficient of the blue beam's contribution to the lightshift.",
+                      "type": "number"
+                    },
                     "controlled_beams": {
                       "description": "The beams that can be switched on/off with an EOM.",
                       "items": {
@@ -1081,6 +1101,10 @@
                     "multiple_beam_control": {
                       "description": "Whether both EOMs can be used simultaneously or not.",
                       "type": "boolean"
+                    },
+                    "red_shift_coeff": {
+                      "description": "The weight coefficient of the blue beam's contribution to the lightshift.",
+                      "type": "number"
                     }
                   },
                   "required": [
@@ -1342,6 +1366,10 @@
                 {
                   "additionalProperties": false,
                   "properties": {
+                    "blue_shift_coeff": {
+                      "description": "The weight coefficient of the blue beam's contribution to the lightshift.",
+                      "type": "number"
+                    },
                     "controlled_beams": {
                       "description": "The beams that can be switched on/off with an EOM.",
                       "items": {
@@ -1380,6 +1408,10 @@
                     "multiple_beam_control": {
                       "description": "Whether both EOMs can be used simultaneously or not.",
                       "type": "boolean"
+                    },
+                    "red_shift_coeff": {
+                      "description": "The weight coefficient of the blue beam's contribution to the lightshift.",
+                      "type": "number"
                     }
                   },
                   "required": [

--- a/pulser-core/pulser/sequence/_schedule.py
+++ b/pulser-core/pulser/sequence/_schedule.py
@@ -23,6 +23,7 @@ import numpy as np
 
 from pulser.channels.base_channel import Channel
 from pulser.channels.dmm import DMM
+from pulser.channels.eom import RydbergBeam
 from pulser.pulse import Pulse
 from pulser.register.base_register import QubitId
 from pulser.register.weight_maps import DetuningMap
@@ -45,7 +46,8 @@ class _EOMSettings:
     detuning_on: float
     detuning_off: float
     ti: int
-    tf: Optional[int] = None
+    tf: int | None = None
+    switching_beams: tuple[RydbergBeam, ...] = ()
 
 
 @dataclass
@@ -337,6 +339,7 @@ class _Schedule(Dict[str, _ChannelSchedule]):
         amp_on: float,
         detuning_on: float,
         detuning_off: float,
+        switching_beams: tuple[RydbergBeam, ...] = (),
         _skip_buffer: bool = False,
     ) -> None:
         channel_obj = self[channel_id].channel_obj
@@ -368,6 +371,7 @@ class _Schedule(Dict[str, _ChannelSchedule]):
             detuning_on=detuning_on,
             detuning_off=detuning_off,
             ti=self[channel_id][-1].tf,
+            switching_beams=switching_beams,
         )
 
         self[channel_id].eom_blocks.append(eom_settings)

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -1149,8 +1149,14 @@ class Sequence(Generic[DeviceType]):
             detuning_on = cast(float, detuning_on)
             eom_config = cast(RydbergEOM, channel_obj.eom_config)
             if not isinstance(optimal_detuning_off, Parametrized):
-                detuning_off = eom_config.calculate_detuning_off(
-                    amp_on, detuning_on, optimal_detuning_off
+                (
+                    detuning_off,
+                    switching_beams,
+                ) = eom_config.calculate_detuning_off(
+                    amp_on,
+                    detuning_on,
+                    optimal_detuning_off,
+                    return_switching_beams=True,
                 )
                 off_pulse = Pulse.ConstantPulse(
                     channel_obj.min_duration, 0.0, detuning_off, 0.0
@@ -1166,7 +1172,7 @@ class Sequence(Generic[DeviceType]):
                     drift_rate=-detuning_off, ti=self.get_duration(channel)
                 )
                 self._schedule.enable_eom(
-                    channel, amp_on, detuning_on, detuning_off
+                    channel, amp_on, detuning_on, detuning_off, switching_beams
                 )
                 if correct_phase_drift:
                     buffer_slot = self._last(channel)

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -366,7 +366,23 @@ class TestDevice:
                         red_shift_coeff=1.4,
                     ),
                 ),
-                marks=pytest.mark.xfail(reason="Needes new schema"),
+                marks=pytest.mark.xfail(reason="Needs new schema"),
+            ),
+            pytest.param(
+                Rydberg.Global(
+                    None,
+                    None,
+                    mod_bandwidth=5,
+                    eom_config=RydbergEOM(
+                        max_limiting_amp=10,
+                        mod_bandwidth=20,
+                        limiting_beam=RydbergBeam.RED,
+                        intermediate_detuning=1000,
+                        controlled_beams=tuple(RydbergBeam),
+                        blue_shift_coeff=1.4,
+                    ),
+                ),
+                marks=pytest.mark.xfail(reason="Needs new schema"),
             ),
         ],
     )

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -352,37 +352,31 @@ class TestDevice:
                     custom_buffer_time=500,
                 ),
             ),
-            pytest.param(
-                Rydberg.Global(
-                    None,
-                    None,
-                    mod_bandwidth=5,
-                    eom_config=RydbergEOM(
-                        max_limiting_amp=10,
-                        mod_bandwidth=20,
-                        limiting_beam=RydbergBeam.RED,
-                        intermediate_detuning=1000,
-                        controlled_beams=tuple(RydbergBeam),
-                        red_shift_coeff=1.4,
-                    ),
+            Rydberg.Global(
+                None,
+                None,
+                mod_bandwidth=5,
+                eom_config=RydbergEOM(
+                    max_limiting_amp=10,
+                    mod_bandwidth=20,
+                    limiting_beam=RydbergBeam.RED,
+                    intermediate_detuning=1000,
+                    controlled_beams=tuple(RydbergBeam),
+                    red_shift_coeff=1.4,
                 ),
-                marks=pytest.mark.xfail(reason="Needs new schema"),
             ),
-            pytest.param(
-                Rydberg.Global(
-                    None,
-                    None,
-                    mod_bandwidth=5,
-                    eom_config=RydbergEOM(
-                        max_limiting_amp=10,
-                        mod_bandwidth=20,
-                        limiting_beam=RydbergBeam.RED,
-                        intermediate_detuning=1000,
-                        controlled_beams=tuple(RydbergBeam),
-                        blue_shift_coeff=1.4,
-                    ),
+            Rydberg.Global(
+                None,
+                None,
+                mod_bandwidth=5,
+                eom_config=RydbergEOM(
+                    max_limiting_amp=10,
+                    mod_bandwidth=20,
+                    limiting_beam=RydbergBeam.RED,
+                    intermediate_detuning=1000,
+                    controlled_beams=tuple(RydbergBeam),
+                    blue_shift_coeff=1.4,
                 ),
-                marks=pytest.mark.xfail(reason="Needs new schema"),
             ),
         ],
     )

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -352,6 +352,22 @@ class TestDevice:
                     custom_buffer_time=500,
                 ),
             ),
+            pytest.param(
+                Rydberg.Global(
+                    None,
+                    None,
+                    mod_bandwidth=5,
+                    eom_config=RydbergEOM(
+                        max_limiting_amp=10,
+                        mod_bandwidth=20,
+                        limiting_beam=RydbergBeam.RED,
+                        intermediate_detuning=1000,
+                        controlled_beams=tuple(RydbergBeam),
+                        red_shift_coeff=1.4,
+                    ),
+                ),
+                marks=pytest.mark.xfail(reason="Needes new schema"),
+            ),
         ],
     )
     def test_optional_channel_fields(self, ch_obj):

--- a/tests/test_eom.py
+++ b/tests/test_eom.py
@@ -151,9 +151,8 @@ def test_detuning_off(
     zero_det = calc_offset(amp)  # detuning when both beams are off = offset
     assert np.isclose(eom._lightshift(amp, *RydbergBeam), -zero_det)
     assert eom._lightshift(amp) == 0.0
-    det_off_options, switching_beams_opts = eom.detuning_off_options(
-        amp, detuning_on, return_switching_beams=True
-    )
+    det_off_options = eom.detuning_off_options(amp, detuning_on)
+    switching_beams_opts = eom._switching_beams_combos
     assert len(det_off_options) == len(switching_beams_opts)
     assert len(det_off_options) == 2 + multiple_beam_control
     order = np.argsort(det_off_options)

--- a/tests/test_eom.py
+++ b/tests/test_eom.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import pytest
 
 from pulser.channels.eom import MODBW_TO_TR, RydbergBeam, RydbergEOM
@@ -39,6 +40,8 @@ def params():
         ("intermediate_detuning", 0),
         ("custom_buffer_time", 0.1),
         ("custom_buffer_time", 0),
+        ("red_shift_coeff", -1.1),
+        ("red_shift_coeff", 0),
     ],
 )
 def test_bad_value_init_eom(bad_param, bad_value, params):
@@ -93,13 +96,29 @@ def test_bad_controlled_beam(params):
     assert RydbergEOM(**params).controlled_beams == tuple(RydbergBeam)
 
 
+@pytest.mark.parametrize("limiting_beam", list(RydbergBeam))
+@pytest.mark.parametrize("red_shift_coeff", [0.5, 1.0, 1.8])
 @pytest.mark.parametrize("multiple_beam_control", [True, False])
 @pytest.mark.parametrize("limit_amp_fraction", [0.5, 2])
-def test_detuning_off(multiple_beam_control, limit_amp_fraction, params):
+def test_detuning_off(
+    limiting_beam,
+    red_shift_coeff,
+    multiple_beam_control,
+    limit_amp_fraction,
+    params,
+):
     params["multiple_beam_control"] = multiple_beam_control
+    params["red_shift_coeff"] = red_shift_coeff
+    params["limiting_beam"] = limiting_beam
     eom = RydbergEOM(**params)
-    limit_amp = params["max_limiting_amp"] ** 2 / (
-        2 * params["intermediate_detuning"]
+    limit_amp = (
+        params["max_limiting_amp"] ** 2
+        / (2 * params["intermediate_detuning"])
+        * np.sqrt(
+            red_shift_coeff
+            if limiting_beam == RydbergBeam.RED
+            else 1 / red_shift_coeff
+        )
     )
     amp = limit_amp_fraction * limit_amp
 
@@ -107,30 +126,56 @@ def test_detuning_off(multiple_beam_control, limit_amp_fraction, params):
         # Manually calculates the offset needed to correct the lightshift
         # coming from a difference in power between the beams
         if amp <= limit_amp:
-            # Below limit_amp, red_amp=blue_amp so there is no lightshift
+            # Below limit_amp, there is no lightshift
             return 0.0
-        assert params["limiting_beam"] == RydbergBeam.RED
-        red_amp = params["max_limiting_amp"]
-        blue_amp = 2 * params["intermediate_detuning"] * amp / red_amp
+        limit_amp_ = params["max_limiting_amp"]
+        non_limit_amp = 2 * params["intermediate_detuning"] * amp / limit_amp_
+        red_amp = (
+            limit_amp_ if limiting_beam == RydbergBeam.RED else non_limit_amp
+        )
+        blue_amp = (
+            limit_amp_ if limiting_beam == RydbergBeam.BLUE else non_limit_amp
+        )
         # The offset to have resonance when the pulse is on is -lightshift
-        return -(blue_amp**2 - red_amp**2) / (
+        return -(blue_amp**2 - red_shift_coeff * red_amp**2) / (
             4 * params["intermediate_detuning"]
         )
 
     # Case where the EOM pulses are resonant
     detuning_on = 0.0
     zero_det = calc_offset(amp)  # detuning when both beams are off = offset
-    assert eom._lightshift(amp, *RydbergBeam) == -zero_det
+    assert np.isclose(eom._lightshift(amp, *RydbergBeam), -zero_det)
     assert eom._lightshift(amp) == 0.0
-    det_off_options = eom.detuning_off_options(amp, detuning_on)
+    det_off_options, switching_beams_opts = eom.detuning_off_options(
+        amp, detuning_on, return_switching_beams=True
+    )
+    assert len(det_off_options) == len(switching_beams_opts)
     assert len(det_off_options) == 2 + multiple_beam_control
-    det_off_options.sort()
+    order = np.argsort(det_off_options)
+    det_off_options = det_off_options[order]
+    switching_beams_opts = [switching_beams_opts[ind] for ind in order]
     assert det_off_options[0] < zero_det  # RED on
+    assert switching_beams_opts[0] == (RydbergBeam.BLUE,)
     next_ = 1
     if multiple_beam_control:
-        assert det_off_options[next_] == zero_det  # All off
+        assert np.isclose(det_off_options[next_], zero_det)  # All off
+        assert switching_beams_opts[1] == tuple(RydbergBeam)
         next_ += 1
     assert det_off_options[next_] > zero_det  # BLUE on
+    assert switching_beams_opts[next_] == (RydbergBeam.RED,)
+    calculated_det_off, switching_beams = eom.calculate_detuning_off(
+        amp,
+        detuning_on,
+        optimal_detuning_off=0,
+        return_switching_beams=True,
+    )
+    assert (
+        switching_beams
+        == switching_beams_opts[
+            det_off_options.tolist().index(calculated_det_off)
+        ]
+    )
+    assert calculated_det_off == min(det_off_options, key=abs)
 
     # Case where the EOM pulses are off-resonant
     detuning_on = 1.0
@@ -143,4 +188,7 @@ def test_detuning_off(multiple_beam_control, limit_amp_fraction, params):
         assert len(off_options) == 1
         # The new detuning_off is shifted by the new detuning_on,
         # since that changes the offset compared the resonant case
-        assert off_options[0] == det_off_options[ind] + detuning_on
+        assert np.isclose(off_options[0], det_off_options[ind] + detuning_on)
+        assert off_options[0] == eom_.calculate_detuning_off(
+            amp, detuning_on, optimal_detuning_off=0.0
+        )


### PR DESCRIPTION
- [x] Adds `blue_shift_coeff` and `red_shift_coeff` to accommodate for each beam's contribution to lightshift
- [x] Records which beams are switching in a given EOM block to `_EOMSettings`
- [x] Supports the new parameters in the abstract repr JSON schema