### PR TITLE
[FEAT] Handle batches with partial results

### DIFF
--- a/pulser-core/pulser/backend/remote.py
+++ b/pulser-core/pulser/backend/remote.py
@@ -121,10 +121,9 @@ class RemoteResults(Results):
         some jobs associated to the submission do not have results.
 
         Returns:
-            dict[str, Result]: A dictionary mapping the job ID to their results.
+            dict[str, Result]: A dictionary mapping the job ID to its results.
             Jobs with no result are omitted.
         """
-
         results = {
             k: v[1]
             for k, v in self._connection._query_job_progress(
@@ -183,7 +182,7 @@ class RemoteConnection(ABC):
         Unlike `_fetch_result`, this method does not raise an error if some
         jobs associated to the submission do not have results.
 
-        It returns a dictionnary mapping the job ID to their status and results.
+        It returns a dictionnary mapping the job ID to its status and results.
         """
         pass
 

--- a/pulser-core/pulser/backend/remote.py
+++ b/pulser-core/pulser/backend/remote.py
@@ -120,8 +120,9 @@ class RemoteResults(Results):
         Unlike the `results` property, this method does not raise an error if
         some jobs associated to the submission do not have results.
 
-        It returns a dictionnary mapping the job ID to their results. Jobs with
-        no result are omitted.
+        Returns:
+            dict[str, Result]: A dictionary mapping the job ID to their results. 
+            Jobs with no result are omitted.
         """
 
         results = {
@@ -176,7 +177,7 @@ class RemoteConnection(ABC):
     def _query_job_progress(
         self, submission_id: str
     ) -> Mapping[str, tuple[JobStatus, Result | None]]:
-        """Fetches the status and results of a submission.
+        """Fetches the status and results of all the jobs in a submission.
 
         Unlike `_fetch_result`, this method does not raise an error if some
         jobs associated to the submission do not have results.

--- a/pulser-core/pulser/backend/remote.py
+++ b/pulser-core/pulser/backend/remote.py
@@ -103,6 +103,13 @@ class RemoteResults(Results):
         """Gets the status of the remote submission."""
         return self._connection._get_submission_status(self._submission_id)
 
+    def _get_available_result(self, submission_id: str) -> dict[str, Result]:
+        """Return available results and ignore jobs with no results."""
+        return {
+            k: v
+            for k, v in self._connection._query_result(submission_id).items()
+        }
+
     def __getattr__(self, name: str) -> Any:
         if name == "_results":
             status = self.get_status()

--- a/pulser-core/pulser/backend/remote.py
+++ b/pulser-core/pulser/backend/remote.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import typing
 from abc import ABC, abstractmethod
 from enum import Enum, auto
-from typing import Any, TypedDict
+from typing import Any, Mapping, TypedDict
 
 from pulser.backend.abc import Backend
 from pulser.devices import Device
@@ -108,6 +108,7 @@ class RemoteResults(Results):
         return {
             k: v
             for k, v in self._connection._query_result(submission_id).items()
+            if v is not None
         }
 
     def __getattr__(self, name: str) -> Any:
@@ -144,6 +145,10 @@ class RemoteConnection(ABC):
         self, submission_id: str, job_ids: list[str] | None
     ) -> typing.Sequence[Result]:
         """Fetches the results of a completed submission."""
+        pass
+
+    @abstractmethod
+    def _query_result(self, submission_id: str) -> Mapping[str, Result | None]:
         pass
 
     @abstractmethod

--- a/pulser-core/pulser/backend/remote.py
+++ b/pulser-core/pulser/backend/remote.py
@@ -121,7 +121,7 @@ class RemoteResults(Results):
         some jobs associated to the submission do not have results.
 
         Returns:
-            dict[str, Result]: A dictionary mapping the job ID to their results. 
+            dict[str, Result]: A dictionary mapping the job ID to their results.
             Jobs with no result are omitted.
         """
 
@@ -145,6 +145,7 @@ class RemoteResults(Results):
                         self._submission_id, self._job_ids
                     )
                 )
+                return self._results
             except RemoteResultsError as e:
                 raise RemoteResultsError(
                     "Results are not available for all jobs. Use the "

--- a/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
+++ b/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
@@ -195,7 +195,8 @@ class PasqalCloud(RemoteConnection):
             status, result = jobs[id]
             if status in {JobStatus.PENDING, JobStatus.RUNNING}:
                 raise RemoteResultsError(
-                    f"The results are not yet available, job {id} status is {status}."
+                    f"The results are not yet available, job {id} status is "
+                    f"{status}."
                 )
             if result is None:
                 raise RemoteResultsError(f"No results found for job {id}.")

--- a/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
+++ b/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
@@ -193,7 +193,7 @@ class PasqalCloud(RemoteConnection):
         results: list[Result] = []
         for id in job_ids:
             status, result = jobs[id]
-            if status != {JobStatus.PENDING, JobStatus.RUNNING}:
+            if status in {JobStatus.PENDING, JobStatus.RUNNING}:
                 raise RemoteResultsError(
                     f"The results are not yet available, job {id} status is {status}."
                 )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -90,6 +90,7 @@ def test_emulator_config_type_errors(param, msg):
 class _MockConnection(RemoteConnection):
     def __init__(self):
         self._status_calls = 0
+        self._progress_calls = 0
         self.result = SampledResult(
             ("q0", "q1"),
             meas_basis="ground-rydberg",
@@ -102,6 +103,10 @@ class _MockConnection(RemoteConnection):
     def _fetch_result(
         self, submission_id: str, job_ids: list[str] | None = None
     ) -> typing.Sequence[Result]:
+        self._progress_calls += 1
+        if self._progress_calls == 1:
+            raise RemoteResultsError("Results not available")
+
         return (self.result,)
 
     def _query_job_progress(
@@ -110,9 +115,6 @@ class _MockConnection(RemoteConnection):
         return {"abcd": (JobStatus.DONE, self.result)}
 
     def _get_submission_status(self, submission_id: str) -> SubmissionStatus:
-        self._status_calls += 1
-        if self._status_calls == 1:
-            return SubmissionStatus.RUNNING
         return SubmissionStatus.DONE
 
 
@@ -181,10 +183,16 @@ def test_qpu_backend(sequence):
 
     with pytest.raises(
         RemoteResultsError,
-        match="The results are not available. The submission's status is"
-        " SubmissionStatus.RUNNING",
+        match=(
+            "Results are not available for all jobs. "
+            "Use the `get_available_results` method to retrieve partial "
+            "results."
+        ),
     ):
         remote_results.results
 
     results = remote_results.results
     assert results[0].sampling_dist == {"00": 1.0}
+
+    available_results = remote_results.get_available_results("id")
+    assert available_results == {"abcd": connection.result}

--- a/tests/test_pasqal.py
+++ b/tests/test_pasqal.py
@@ -225,8 +225,19 @@ def test_partial_results():
     )
 
     fixt.mock_cloud_sdk.get_batch.reset_mock()
-    with pytest.raises(RemoteResultsError):
+    with pytest.raises(
+        RemoteResultsError,
+        match=(
+            "Results are not available for all jobs. Use the "
+            "`get_available_results` method to retrieve partial results."
+        ),
+    ):
         remote_results.results
+    fixt.mock_cloud_sdk.get_batch.assert_called_once_with(
+        id=remote_results.batch_id
+    )
+    fixt.mock_cloud_sdk.get_batch.reset_mock()
+
     available_results = remote_results.get_available_results(batch.id)
     assert available_results == {
         job.id: SampledResult(
@@ -237,6 +248,10 @@ def test_partial_results():
         for job in batch.ordered_jobs
         if job.result is not None
     }
+    fixt.mock_cloud_sdk.get_batch.assert_called_once_with(
+        id=remote_results.batch_id
+    )
+    fixt.mock_cloud_sdk.get_batch.reset_mock()
 
     batch = MockBatch(
         status="DONE",
@@ -252,8 +267,19 @@ def test_partial_results():
         fixt.pasqal_cloud,
     )
 
-    with pytest.raises(RemoteResultsError):
+    with pytest.raises(
+        RemoteResultsError,
+        match=(
+            "Results are not available for all jobs. Use the "
+            "`get_available_results` method to retrieve partial results."
+        ),
+    ):
         remote_results.results
+    fixt.mock_cloud_sdk.get_batch.assert_called_once_with(
+        id=remote_results.batch_id
+    )
+    fixt.mock_cloud_sdk.get_batch.reset_mock()
+
     available_results = remote_results.get_available_results(batch.id)
     assert available_results == {
         job.id: SampledResult(
@@ -264,6 +290,10 @@ def test_partial_results():
         for job in batch.ordered_jobs
         if job.result is not None
     }
+    fixt.mock_cloud_sdk.get_batch.assert_called_once_with(
+        id=remote_results.batch_id
+    )
+    fixt.mock_cloud_sdk.get_batch.reset_mock()
 
 
 @pytest.mark.parametrize("mimic_qpu", [False, True])

--- a/tests/test_pasqal.py
+++ b/tests/test_pasqal.py
@@ -66,14 +66,21 @@ virtual_device = dataclasses.replace(
     test_device.to_virtual(), name="test-virtual"
 )
 
-_seq = Sequence(
-    SquareLatticeLayout(5, 5, 5).make_mappable_register(10), test_device
-)
+
+def build_test_sequence() -> Sequence:
+    seq = Sequence(
+        SquareLatticeLayout(5, 5, 5).make_mappable_register(10), test_device
+    )
+    seq.declare_channel("rydberg_global", "rydberg_global")
+    seq.measure()
+    return seq
 
 
 @pytest.fixture
 def seq():
-    return copy.deepcopy(_seq)
+    return Sequence(
+        SquareLatticeLayout(5, 5, 5).make_mappable_register(10), test_device
+    )
 
 
 class _MockJob:
@@ -102,10 +109,7 @@ class MockBatch:
             _MockJob(result={"11": 10}),
         ]
     )
-    seq_ = copy.deepcopy(_seq)
-    seq_.declare_channel("rydberg_global", "rydberg_global")
-    seq_.measure()
-    sequence_builder = seq_.to_abstract_repr()
+    sequence_builder = build_test_sequence().to_abstract_repr()
 
 
 @pytest.fixture

--- a/tests/test_pasqal.py
+++ b/tests/test_pasqal.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import copy
 import dataclasses
 import re
 from pathlib import Path


### PR DESCRIPTION
- Stop raising an Exception if one of the job of the batch has no results after fetching. 
- Stop raising an exception when fetching results if the status of the batch is a termination status.

Currently if one of the job of a batch fails, it is impossible to retrieve the results for any jobs of the batch - this raises an exception. In this PR, I suggest instead to add `None` to the list of results for that submission when a job has no results. I don't know if returning None is the most idiomatic way to do this in pulser; I also contemplated creating a new subclass of `Result` called `EmptyResult` but I wanted to gather some feedback before going for that because it would imply some refactoring of the `Result` class and I'm not entirely convinced it would bring much.
