### PR TITLE
Add leakage

### DIFF
--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -37,7 +37,7 @@ ChannelType = TypeVar("ChannelType", bound="Channel")
 OPTIONAL_ABSTR_CH_FIELDS = ("min_avg_amp",)
 
 # States ranked in decreasing order of their associated eigenenergy
-States = Literal["u", "d", "r", "g", "h"]  # TODO: add "x" for leakage
+States = Literal["u", "d", "r", "g", "h", "x"]
 
 STATES_RANK = get_args(States)
 
@@ -138,6 +138,9 @@ class Channel(ABC):
             * - Hyperfine state
               - :math:`|h\rangle`
               - ``"h"``
+            * - Error state
+              - :math:`|h\rangle`
+              - ``"x"``
         """
         return EIGENSTATES[self.basis]
 

--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -139,7 +139,7 @@ class Channel(ABC):
               - :math:`|h\rangle`
               - ``"h"``
             * - Error state
-              - :math:`|h\rangle`
+              - :math:`|x\rangle`
               - ``"x"``
         """
         return EIGENSTATES[self.basis]

--- a/pulser-core/pulser/noise_model.py
+++ b/pulser-core/pulser/noise_model.py
@@ -401,16 +401,8 @@ class NoiseModel:
             if operator.ndim != 2:
                 raise ValueError(f"Operator '{op!r}' is not a 2D array.")
 
-            # TODO: Modify when effective noise can be provided for leakage
-            if operator.shape != possible_shapes[0] and (
-                with_leakage or operator.shape != possible_shapes[1]
-            ):
-                err_type = (
-                    NotImplementedError
-                    if operator.shape in possible_shapes
-                    else ValueError
-                )
-                raise err_type(
+            if operator.shape not in possible_shapes:
+                raise ValueError(
                     f"With{'' if with_leakage else 'out'} leakage, operator's "
                     f"shape must be {possible_shapes[0]}, "
                     f"not {operator.shape}."

--- a/pulser-simulation/pulser_simulation/hamiltonian.py
+++ b/pulser-simulation/pulser_simulation/hamiltonian.py
@@ -134,7 +134,7 @@ class Hamiltonian:
                 )
 
         if "depolarizing" in config.noise_types:
-            if "all" in basis_name == "all":
+            if "all" in basis_name:
                 # Go back to previous config
                 raise NotImplementedError(
                     "Cannot include depolarizing noise in all-basis."

--- a/pulser-simulation/pulser_simulation/hamiltonian.py
+++ b/pulser-simulation/pulser_simulation/hamiltonian.py
@@ -83,9 +83,6 @@ class Hamiltonian:
         )
 
         # Stores the qutip operators used in building the Hamiltonian
-        self.operators: dict[str, defaultdict[str, dict]] = {
-            addr: defaultdict(dict) for addr in ["Global", "Local"]
-        }
         self._collapse_ops: list[qutip.Qobj] = []
 
         self.set_config(config)
@@ -205,6 +202,9 @@ class Hamiltonian:
             self.basis = basis
             self.op_matrix = op_matrix
             self.dim = len(eigenbasis)
+            self.operators: dict[str, defaultdict[str, dict]] = {
+                addr: defaultdict(dict) for addr in ["Global", "Local"]
+            }
         else:
             self._build_collapse_operators(
                 cfg, self.basis_name, self.eigenbasis, self.op_matrix

--- a/pulser-simulation/pulser_simulation/hamiltonian.py
+++ b/pulser-simulation/pulser_simulation/hamiltonian.py
@@ -136,7 +136,7 @@ class Hamiltonian:
             if "all" in self.basis_name == "all":
                 # Go back to previous config
                 raise NotImplementedError(
-                    "Cannot include eff_noise noise in all-basis."
+                    "Cannot include depolarizing noise in all-basis."
                 )
             # NOTE: These operators only make sense when basis != "all"
             b, a = self.eigenbasis[:2]

--- a/pulser-simulation/pulser_simulation/hamiltonian.py
+++ b/pulser-simulation/pulser_simulation/hamiltonian.py
@@ -224,7 +224,14 @@ class Hamiltonian:
         """Populates samples dictionary with every pulse in the sequence."""
         local_noises = True
         if set(self.config.noise_types).issubset(
-            {"dephasing", "relaxation", "SPAM", "depolarizing", "eff_noise"}
+            {
+                "dephasing",
+                "relaxation",
+                "SPAM",
+                "depolarizing",
+                "eff_noise",
+                "leakage",
+            }
         ):
             local_noises = (
                 "SPAM" in self.config.noise_types

--- a/pulser-simulation/pulser_simulation/qutip_result.py
+++ b/pulser-simulation/pulser_simulation/qutip_result.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Union, cast
+from typing import cast
 
 import numpy as np
 import qutip

--- a/pulser-simulation/pulser_simulation/qutip_result.py
+++ b/pulser-simulation/pulser_simulation/qutip_result.py
@@ -70,7 +70,9 @@ class QutipResult(Result):
         if self.meas_basis == "XY":
             if self._dim == 3:
                 return "XY_with_error"
-            assert self._dim == 2
+            assert (
+                self._dim == 2
+            ), f"In XY, state's dimension can only be 2 or 3, not {self._dim}."
             return "XY"
         if self._dim == 4:
             return "all_with_error"
@@ -78,6 +80,9 @@ class QutipResult(Result):
             if self.matching_meas_basis:
                 return self.meas_basis + "_with_error"
             return "all"
+        assert (
+            self._dim == 2
+        ), f"In Ising, state's dimension can be 2, 3 or 4, not {self._dim}."
         if not self.matching_meas_basis:
             return (
                 "digital"
@@ -126,7 +131,7 @@ class QutipResult(Result):
             }
             if self.meas_basis not in one_state_dict:
                 raise RuntimeError(
-                    f"Unknown measurement basis '{self.meas_basis}' "
+                    f"Unknown measurement basis '{self.meas_basis}'."
                 )
             one_state_idx = self._eigenbasis.index(
                 one_state_dict[self.meas_basis]

--- a/pulser-simulation/pulser_simulation/simconfig.py
+++ b/pulser-simulation/pulser_simulation/simconfig.py
@@ -38,13 +38,9 @@ SUPPORTED_NOISES: dict = {
         "doppler",
         "eff_noise",
         "SPAM",
+        "leakage",
     },
-    "XY": {
-        "dephasing",
-        "depolarizing",
-        "eff_noise",
-        "SPAM",
-    },
+    "XY": {"dephasing", "depolarizing", "eff_noise", "SPAM", "leakage"},
 }
 
 # Maps the noise model parameters with a different name in SimConfig

--- a/pulser-simulation/pulser_simulation/simresults.py
+++ b/pulser-simulation/pulser_simulation/simresults.py
@@ -397,8 +397,9 @@ class CoherentResults(SimulationResults):
         else:
             if meas_basis != self._basis_name.split("_with_error")[0]:
                 raise ValueError(
-                    f"`meas_basis` associated to basis_name '{self._basis_name}'"
-                    f" must be '{self._basis_name.split("_with_error")[0]}'."
+                    f"`meas_basis` associated to basis_name '"
+                    f"{self._basis_name}' must be '"
+                    f"{self._basis_name.split("_with_error")[0]}'."
                 )
         self._meas_basis = meas_basis
         self._results = tuple(run_output)

--- a/pulser-simulation/pulser_simulation/simresults.py
+++ b/pulser-simulation/pulser_simulation/simresults.py
@@ -263,15 +263,17 @@ class NoisyResults(SimulationResults):
                 sequence ('ground-rydberg' or 'digital' - 'all' basis or any
                 basis with the suffix "with_error" make no sense after
                 projection on bitstrings). Defaults to 'digital' if given value
-                'all'.
+                'all' or 'all_with_error', and to 'ground-rydberg', 'XY',
+                'digital' if given respectively 'ground-rydberg_with_error',
+                'XY_with_error' or 'digital_with_error'.
             sim_times: Times at which Simulation object returned
                 the results.
             n_measures: Number of measurements needed to compute this
                 result when doing the simulation.
         """
         basis = basis_name.split("_with_error")
-        basis_name_ = "digital" if basis_name[0] == "all" else basis_name
         assert len(basis) == 1 or (len(basis) == 2 and basis[1] == "")
+        basis_name_ = "digital" if basis[0] == "all" else basis[0]
         super().__init__(size, basis_name_, sim_times)
         self.n_measures = n_measures
         self._results = tuple(run_output)

--- a/pulser-simulation/pulser_simulation/simresults.py
+++ b/pulser-simulation/pulser_simulation/simresults.py
@@ -51,17 +51,17 @@ class SimulationResults(ABC, Results[ResultType]):
         Args:
             size: The number of atoms in the register.
             basis_name: The basis indicating the addressed atoms after
-                the pulse sequence ('ground-rydberg', 'digital' or 'all').
+                the pulse sequence ('ground-rydberg', 'digital' or 'all' or one
+                of these 3 bases with the suffix "_with_error").
             sim_times: Array of times (in µs) when simulation results are
                 returned.
         """
         self._dim = 3 if basis_name == "all" else 2
         self._size = size
-        if basis_name not in {"ground-rydberg", "digital", "all", "XY"}:
-            raise ValueError(
-                "`basis_name` must be 'ground-rydberg', 'digital', 'all' or "
-                "'XY'."
-            )
+        bases = ["ground-rydberg", "digital", "all", "XY"]
+        bases += [basis + "_with_error" for basis in bases]
+        if basis_name not in bases:
+            raise ValueError(f"`basis_name` must be in {bases}")
         self._basis_name = basis_name
         self._sim_times = sim_times
 
@@ -259,16 +259,19 @@ class NoisyResults(SimulationResults):
                 represented as a bitstring. There is one Counter for each time
                 the simulation was asked to return a result.
             size: The number of atoms in the register.
-            basis_name: Basis indicating the addressed atoms after
-                the pulse sequence ('ground-rydberg' or 'digital' - 'all' basis
-                makes no sense after projection on bitstrings). Defaults to
-                'digital' if given value 'all'.
+            basis_name: Basis indicating the addressed atoms after the pulse
+                sequence ('ground-rydberg' or 'digital' - 'all' basis or any
+                basis with the suffix "with_error" make no sense after
+                projection on bitstrings). Defaults to 'digital' if given value
+                'all'.
             sim_times: Times at which Simulation object returned
                 the results.
             n_measures: Number of measurements needed to compute this
                 result when doing the simulation.
         """
-        basis_name_ = "digital" if basis_name == "all" else basis_name
+        basis = basis_name.split("_with_error")
+        basis_name_ = "digital" if basis_name[0] == "all" else basis_name
+        assert len(basis) == 1 or (len(basis) == 2 and basis[1] == "")
         super().__init__(size, basis_name_, sim_times)
         self.n_measures = n_measures
         self._results = tuple(run_output)
@@ -375,25 +378,27 @@ class CoherentResults(SimulationResults):
                 simulated.
             size: The number of atoms in the register.
             basis_name: The basis indicating the addressed atoms after
-                the pulse sequence ('ground-rydberg', 'digital' or 'all').
+                the pulse sequence ('ground-rydberg', 'digital' or 'all' or
+                one of these bases with the suffix "_with_error").
             sim_times: Times at which Simulation object returned the
                 results.
             meas_basis: The basis in which a sampling measurement
-                is desired.
+                is desired (must be in "ground-rydberg" or "digital").
             meas_errors: If measurement errors
                 are involved, give them in a dictionary with "epsilon" and
                 "epsilon_prime".
         """
         super().__init__(size, basis_name, sim_times)
-        if self._basis_name == "all":
+        if "all" in self._basis_name:
             if meas_basis not in {"ground-rydberg", "digital"}:
                 raise ValueError(
                     "`meas_basis` must be 'ground-rydberg' or 'digital'."
                 )
         else:
-            if meas_basis != self._basis_name:
+            if meas_basis != self._basis_name.split("_with_error")[0]:
                 raise ValueError(
-                    "`meas_basis` and `basis_name` must have the same value."
+                    f"`meas_basis` associated to basis_name '{self._basis_name}'"
+                    f" must be '{self._basis_name.split("_with_error")[0]}'."
                 )
         self._meas_basis = meas_basis
         self._results = tuple(run_output)
@@ -425,9 +430,8 @@ class CoherentResults(SimulationResults):
         Args:
             t: Time (in µs) at which to return the state.
             reduce_to_basis: Reduces the full state vector
-                to the given basis ("ground-rydberg" or "digital"), if the
-                population of the states to be ignored is negligible. Doesn't
-                apply to XY mode.
+                to the given basis ("ground-rydberg", "digital" or "XY"), if
+                the population of the states to be ignored is negligible.
             ignore_global_phase: If True and if the final state is a vector,
                 changes the final state's global phase such that the largest
                 term (in absolute value) is real.
@@ -461,9 +465,8 @@ class CoherentResults(SimulationResults):
 
         Args:
             reduce_to_basis: Reduces the full state vector
-                to the given basis ("ground-rydberg" or "digital"), if the
-                population of the states to be ignored is negligible. Doesn't
-                apply to XY mode.
+                to the given basis ("ground-rydberg", "digital" or "XY"), if
+                the population of the states to be ignored is negligible.
             ignore_global_phase: If True, changes the
                 final state's global phase such that the largest term (in
                 absolute value) is real.
@@ -499,7 +502,7 @@ class CoherentResults(SimulationResults):
             # ground-rydberg
             good = (
                 1 - state_n
-                if self._basis_name == "ground-rydberg"
+                if "ground-rydberg" in self._basis_name
                 else state_n
             )
             return (

--- a/pulser-simulation/pulser_simulation/simresults.py
+++ b/pulser-simulation/pulser_simulation/simresults.py
@@ -271,9 +271,8 @@ class NoisyResults(SimulationResults):
             n_measures: Number of measurements needed to compute this
                 result when doing the simulation.
         """
-        basis = basis_name.split("_with_error")
-        assert len(basis) == 1 or (len(basis) == 2 and basis[1] == "")
-        basis_name_ = "digital" if basis[0] == "all" else basis[0]
+        basis = basis_name.replace("_with_error", "")
+        basis_name_ = "digital" if basis == "all" else basis
         super().__init__(size, basis_name_, sim_times)
         self.n_measures = n_measures
         self._results = tuple(run_output)
@@ -397,11 +396,11 @@ class CoherentResults(SimulationResults):
                     "`meas_basis` must be 'ground-rydberg' or 'digital'."
                 )
         else:
-            if meas_basis != self._basis_name.split("_with_error")[0]:
+            expected_meas_basis = self._basis_name.replace("_with_error", "")
+            if meas_basis != expected_meas_basis:
                 raise ValueError(
                     f"`meas_basis` associated to basis_name '"
-                    f"{self._basis_name}' must be '"
-                    f"{self._basis_name.split("_with_error")[0]}'."
+                    f"{self._basis_name}' must be '{expected_meas_basis}'."
                 )
         self._meas_basis = meas_basis
         self._results = tuple(run_output)

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -200,11 +200,21 @@ class QutipEmulator:
         """The current configuration, as a SimConfig instance."""
         return SimConfig.from_noise_model(self._hamiltonian.config)
 
-    def set_config(self, cfg: SimConfig) -> None:
+    def set_config(
+        self,
+        cfg: SimConfig,
+        state: Union[str, np.ndarray, qutip.Qobj] = "all-ground",
+    ) -> None:
         """Sets current config to cfg and updates simulation parameters.
 
         Args:
             cfg: New configuration.
+            state: The initial state.
+                Choose between:
+
+                - "all-ground" for all atoms in ground state
+                - An ArrayLike with a shape compatible with the system
+                - A Qobj object
         """
         if not isinstance(cfg, SimConfig):
             raise ValueError(f"Object {cfg} is not a valid `SimConfig`.")
@@ -219,8 +229,13 @@ class QutipEmulator:
                 f"{', '.join(not_supported)}."
             )
         self._hamiltonian.set_config(cfg.to_noise_model())
+        self.set_initial_state(state)
 
-    def add_config(self, config: SimConfig) -> None:
+    def add_config(
+        self,
+        config: SimConfig,
+        state: Union[str, np.ndarray, qutip.Qobj] = "all-ground",
+    ) -> None:
         """Updates the current configuration with parameters of another one.
 
         Mostly useful when dealing with multiple noise types in different
@@ -231,6 +246,12 @@ class QutipEmulator:
 
         Args:
             config: SimConfig to retrieve parameters from.
+            state: The initial state.
+                Choose between:
+
+                - "all-ground" for all atoms in ground state
+                - An ArrayLike with a shape compatible with the system
+                - A Qobj object
         """
         if not isinstance(config, SimConfig):
             raise ValueError(f"Object {config} is not a valid `SimConfig`")
@@ -262,6 +283,7 @@ class QutipEmulator:
         # set config with the new parameters:
         param_dict.pop("noise_types")
         self._hamiltonian.set_config(NoiseModel(**param_dict))
+        self.set_initial_state(state)
 
     def show_config(self, solver_options: bool = False) -> None:
         """Shows current configuration."""

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -615,6 +615,7 @@ class QutipEmulator:
                 "depolarizing",
                 "eff_noise",
                 "amplitude",
+                "leakage",
             }
         ) and (
             # If amplitude is in noise, not resampling needs amp_sigma=0.

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -163,10 +163,10 @@ class QutipEmulator:
         if self.samples_obj._measurement:
             self._meas_basis = self.samples_obj._measurement
         else:
-            if self._hamiltonian.basis_name in {"digital", "all"}:
+            if "all" in self.basis_name:
                 self._meas_basis = "digital"
             else:
-                self._meas_basis = self._hamiltonian.basis_name
+                self._meas_basis = self.basis_name.split("_with_error")[0]
         self.set_initial_state("all-ground")
 
     @property
@@ -556,14 +556,14 @@ class QutipEmulator:
                     tuple(self._hamiltonian._qdict),
                     self._meas_basis,
                     state,
-                    self._meas_basis == self._hamiltonian.basis_name,
+                    self._meas_basis in self.basis_name,
                 )
                 for state in result.states
             ]
             return CoherentResults(
                 results,
                 self._hamiltonian._size,
-                self._hamiltonian.basis_name,
+                self.basis_name,
                 self._eval_times_array,
                 self._meas_basis,
                 meas_errors,
@@ -650,7 +650,7 @@ class QutipEmulator:
         return NoisyResults(
             results,
             self._hamiltonian._size,
-            self._hamiltonian.basis_name,
+            self.basis_name,
             self._eval_times_array,
             n_measures,
         )

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -28,6 +28,7 @@ from numpy.typing import ArrayLike
 
 import pulser.sampler as sampler
 from pulser import Sequence
+from pulser.channels.base_channel import States
 from pulser.devices._device_datacls import BaseDevice
 from pulser.noise_model import NoiseModel
 from pulser.register.base_register import BaseRegister
@@ -190,7 +191,7 @@ class QutipEmulator:
         return self._hamiltonian.basis_name
 
     @property
-    def basis(self) -> dict[str, Any]:
+    def basis(self) -> dict[States, Any]:
         """The basis in which result is expressed."""
         return self._hamiltonian.basis
 

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -167,7 +167,7 @@ class QutipEmulator:
             if "all" in self.basis_name:
                 self._meas_basis = "digital"
             else:
-                self._meas_basis = self.basis_name.split("_with_error")[0]
+                self._meas_basis = self.basis_name.replace("_with_error", "")
         self.set_initial_state("all-ground")
 
     @property

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -205,12 +205,6 @@ class QutipEmulator:
 
         Args:
             cfg: New configuration.
-            state: The initial state.
-                Choose between:
-
-                - "all-ground" for all atoms in ground state
-                - An ArrayLike with a shape compatible with the system
-                - A Qobj object
         """
         if not isinstance(cfg, SimConfig):
             raise ValueError(f"Object {cfg} is not a valid `SimConfig`.")
@@ -255,12 +249,6 @@ class QutipEmulator:
 
         Args:
             config: SimConfig to retrieve parameters from.
-            state: The initial state.
-                Choose between:
-
-                - "all-ground" for all atoms in ground state
-                - An ArrayLike with a shape compatible with the system
-                - A Qobj object
         """
         if not isinstance(config, SimConfig):
             raise ValueError(f"Object {config} is not a valid `SimConfig`")

--- a/tests/test_noise_model.py
+++ b/tests/test_noise_model.py
@@ -234,11 +234,9 @@ class TestNoiseModel:
                 eff_noise_rates=[1.0],
                 with_leakage=True,
             )
-        with pytest.raises(
-            NotImplementedError, match="With leakage, operator's shape"
-        ):
+        with pytest.raises(ValueError, match="With leakage, operator's shape"):
             NoiseModel(
-                eff_noise_opers=[matrices["I4"]],
+                eff_noise_opers=[np.eye(5)],
                 eff_noise_rates=[1.0],
                 with_leakage=True,
             )

--- a/tests/test_simconfig.py
+++ b/tests/test_simconfig.py
@@ -110,12 +110,10 @@ def test_eff_noise_opers(matrices):
             eff_noise_opers=[matrices["I"]],
             eff_noise_rates=[1.0],
         )
-    with pytest.raises(
-        NotImplementedError, match="With leakage, operator's shape"
-    ):
+    with pytest.raises(ValueError, match="With leakage, operator's shape"):
         SimConfig(
             noise=("eff_noise", "leakage"),
-            eff_noise_opers=[matrices["I4"]],
+            eff_noise_opers=[qeye(5)],
             eff_noise_rates=[1.0],
         )
     with pytest.raises(ValueError, match="Without leakage, operator's shape"):

--- a/tests/test_simresults.py
+++ b/tests/test_simresults.py
@@ -83,7 +83,7 @@ def test_initialization(results):
         CoherentResults(rr_state, 1, "all", None, "XY")
     with pytest.raises(
         ValueError,
-        match="`meas_basis` associated to basis_name 'ground-rydberg' must be ",
+        match="`meas_basis` associated to basis_name 'ground-rydberg' must be",
     ):
         CoherentResults(
             rr_state, 1, "ground-rydberg", [0], "wrong_measurement_basis"

--- a/tests/test_simresults.py
+++ b/tests/test_simresults.py
@@ -72,15 +72,16 @@ def results_noisy(sim):
 def results(sim):
     return sim.run()
 
+
 @pytest.mark.parametrize(
-    ["basis", "exp_basis"], 
+    ["basis", "exp_basis"],
     [
         ("ground-rydberg_with_error", "ground-rydberg"),
-        ("digital_with_error", "digital"), 
-        ("all_with_error", "digital"), 
-        ("all", "digital"), 
-        ("XY_with_error", "XY")
-    ]
+        ("digital_with_error", "digital"),
+        ("all_with_error", "digital"),
+        ("all", "digital"),
+        ("XY_with_error", "XY"),
+    ],
 )
 def test_initialization(results, basis, exp_basis):
     rr_state = qutip.tensor([qutip.basis(2, 0), qutip.basis(2, 0)])
@@ -88,7 +89,8 @@ def test_initialization(results, basis, exp_basis):
         CoherentResults(rr_state, 2, "bad_basis", None, [0])
     if "all" in basis:
         with pytest.raises(
-            ValueError, match="`meas_basis` must be 'ground-rydberg' or 'digital'."
+            ValueError,
+            match="`meas_basis` must be 'ground-rydberg' or 'digital'.",
         ):
             CoherentResults(rr_state, 1, basis, None, "XY")
     else:
@@ -96,9 +98,7 @@ def test_initialization(results, basis, exp_basis):
             ValueError,
             match=f"`meas_basis` associated to basis_name '{basis}' must be",
         ):
-            CoherentResults(
-                rr_state, 1, basis, [0], "wrong_measurement_basis"
-            )
+            CoherentResults(rr_state, 1, basis, [0], "wrong_measurement_basis")
     with pytest.raises(
         ValueError, match="only values of 'epsilon' and 'epsilon_prime'"
     ):
@@ -119,15 +119,16 @@ def test_initialization(results, basis, exp_basis):
         [qutip.basis(2, 1), qutip.basis(2, 1)]
     )
 
+
 @pytest.mark.parametrize(
-    ["basis", "exp_basis"], 
+    ["basis", "exp_basis"],
     [
         ("ground-rydberg_with_error", "ground-rydberg"),
-        ("digital_with_error", "digital"), 
-        ("all_with_error", "digital"), 
-        ("all", "digital"), 
-        ("XY_with_error", "XY")
-    ]
+        ("digital_with_error", "digital"),
+        ("all_with_error", "digital"),
+        ("all", "digital"),
+        ("XY_with_error", "XY"),
+    ],
 )
 def test_init_noisy(basis, exp_basis):
     state = qutip.tensor([qutip.basis(2, 0), qutip.basis(2, 0)])
@@ -224,7 +225,6 @@ def test_get_final_state_noisy(reg, pi_pulse):
     assert res3.results[-1] == Counter(
         {"10": 0.8666666666666667, "00": 0.12, "11": 0.013333333333333334}
     )
-    sim_leakage = QutipEmulator.from_sequence(seq_, config=noisy_config)
 
 
 def test_get_state_float_time(results):

--- a/tests/test_simresults.py
+++ b/tests/test_simresults.py
@@ -83,7 +83,7 @@ def test_initialization(results):
         CoherentResults(rr_state, 1, "all", None, "XY")
     with pytest.raises(
         ValueError,
-        match="`meas_basis` and `basis_name` must have the same value.",
+        match="`meas_basis` associated to basis_name 'ground-rydberg' must be ",
     ):
         CoherentResults(
             rr_state, 1, "ground-rydberg", [0], "wrong_measurement_basis"

--- a/tests/test_simresults.py
+++ b/tests/test_simresults.py
@@ -72,33 +72,42 @@ def results_noisy(sim):
 def results(sim):
     return sim.run()
 
-
-def test_initialization(results):
+@pytest.mark.parametrize(
+    ["basis", "exp_basis"], 
+    [
+        ("ground-rydberg_with_error", "ground-rydberg"),
+        ("digital_with_error", "digital"), 
+        ("all_with_error", "digital"), 
+        ("all", "digital"), 
+        ("XY_with_error", "XY")
+    ]
+)
+def test_initialization(results, basis, exp_basis):
     rr_state = qutip.tensor([qutip.basis(2, 0), qutip.basis(2, 0)])
     with pytest.raises(ValueError, match="`basis_name` must be"):
         CoherentResults(rr_state, 2, "bad_basis", None, [0])
-    with pytest.raises(
-        ValueError, match="`meas_basis` must be 'ground-rydberg' or 'digital'."
-    ):
-        CoherentResults(rr_state, 1, "all", None, "XY")
-    with pytest.raises(
-        ValueError,
-        match="`meas_basis` associated to basis_name 'ground-rydberg' must be",
-    ):
-        CoherentResults(
-            rr_state, 1, "ground-rydberg", [0], "wrong_measurement_basis"
-        )
-    with pytest.raises(ValueError, match="`basis_name` must be"):
-        NoisyResults(rr_state, 2, "bad_basis", [0], 123)
+    if "all" in basis:
+        with pytest.raises(
+            ValueError, match="`meas_basis` must be 'ground-rydberg' or 'digital'."
+        ):
+            CoherentResults(rr_state, 1, basis, None, "XY")
+    else:
+        with pytest.raises(
+            ValueError,
+            match=f"`meas_basis` associated to basis_name '{basis}' must be",
+        ):
+            CoherentResults(
+                rr_state, 1, basis, [0], "wrong_measurement_basis"
+            )
     with pytest.raises(
         ValueError, match="only values of 'epsilon' and 'epsilon_prime'"
     ):
         CoherentResults(
             rr_state,
             1,
-            "ground-rydberg",
+            basis,
             [0],
-            "ground-rydberg",
+            exp_basis,
             {"eta": 0.1, "epsilon": 0.0, "epsilon_prime": 0.4},
         )
 
@@ -109,6 +118,22 @@ def test_initialization(results):
     assert results.states[0] == qutip.tensor(
         [qutip.basis(2, 1), qutip.basis(2, 1)]
     )
+
+@pytest.mark.parametrize(
+    ["basis", "exp_basis"], 
+    [
+        ("ground-rydberg_with_error", "ground-rydberg"),
+        ("digital_with_error", "digital"), 
+        ("all_with_error", "digital"), 
+        ("all", "digital"), 
+        ("XY_with_error", "XY")
+    ]
+)
+def test_init_noisy(basis, exp_basis):
+    state = qutip.tensor([qutip.basis(2, 0), qutip.basis(2, 0)])
+    with pytest.raises(ValueError, match="`basis_name` must be"):
+        NoisyResults(state, 2, "bad_basis", [0], 123)
+    assert NoisyResults(state, 2, basis, [0], 100)._basis_name == exp_basis
 
 
 @pytest.mark.parametrize("noisychannel", [True, False])
@@ -199,6 +224,7 @@ def test_get_final_state_noisy(reg, pi_pulse):
     assert res3.results[-1] == Counter(
         {"10": 0.8666666666666667, "00": 0.12, "11": 0.013333333333333334}
     )
+    sim_leakage = QutipEmulator.from_sequence(seq_, config=noisy_config)
 
 
 def test_get_state_float_time(results):

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -579,7 +579,7 @@ def test_run(seq, patch_plt_show):
     ):
         sim.run(progress_bar=1)
 
-    sim.set_config(SimConfig("SPAM", eta=0.1))
+    sim.set_config(SimConfig("SPAM", eta=0.1), good_initial_qobj_no_dims)
     with pytest.raises(
         NotImplementedError,
         match="Can't combine state preparation errors with an initial state "
@@ -925,7 +925,7 @@ res_deph_relax = {
         ),
         (
             ("eff_noise", "leakage"),
-            {"111": 1000},
+            {"111": 948, "011": 43, "110": 9},
             2,
         ),
     ],
@@ -952,9 +952,11 @@ def test_noises_all(matrices, reg, noise, result, n_collapse_ops, seq):
         hyp_deph_op = qutip.Qobj(
             [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, 0]]
         )
+        eff_rate = 1.0
     else:
         deph_op = qutip.Qobj([[1, 0, 0], [0, 0, 0], [0, 0, 0]])
         hyp_deph_op = qutip.Qobj([[0, 0, 0], [0, 0, 0], [0, 0, 1]])
+        eff_rate = 0.2
     sim = QutipEmulator.from_sequence(
         seq,  # resulting state should be hhh
         sampling_rate=0.01,
@@ -964,7 +966,7 @@ def test_noises_all(matrices, reg, noise, result, n_collapse_ops, seq):
             hyperfine_dephasing_rate=0.1,
             relaxation_rate=1.0,
             eff_noise_opers=[deph_op, hyp_deph_op],
-            eff_noise_rates=[0.2, 0.2],
+            eff_noise_rates=[eff_rate, eff_rate],
         ),
     )
     with pytest.raises(
@@ -1147,6 +1149,7 @@ res1 = {"0000": 892, "1000": 47, "0100": 25, "0001": 19, "0010": 17}
 res2 = {"0000": 962, "0010": 13, "1000": 13, "0100": 12}
 res3 = {"0000": 904, "0100": 43, "0010": 24, "1000": 19, "0001": 10}
 res4 = {"0000": 969, "0001": 18, "1000": 13}
+res5 = {"0000": 909, "0001": 34, "0010": 28, "1000": 17, "0100": 12}
 
 
 @pytest.mark.parametrize(
@@ -1154,7 +1157,7 @@ res4 = {"0000": 969, "0001": 18, "1000": 13}
     [
         (None, "dephasing", res1, 1),
         (None, "eff_noise", res1, 1),
-        (None, "leakage", res1, 1),
+        (None, "leakage", res5, 1),
         (None, "depolarizing", res2, 3),
         ("atom0", "dephasing", res3, 1),
         ("atom1", "dephasing", res4, 1),

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -925,7 +925,7 @@ res_deph_relax = {
         ),
         (
             ("eff_noise", "leakage"),
-            {"111": 958, "110": 19, "011": 12, "101": 11},
+            {"111": 1000},
             2,
         ),
     ],
@@ -967,7 +967,6 @@ def test_noises_all(matrices, reg, noise, result, n_collapse_ops, seq):
             eff_noise_rates=[0.2, 0.2],
         ),
     )
-
     with pytest.raises(
         ValueError,
         match="Incompatible shape for effective noise operator n°0.",

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -93,6 +93,7 @@ def matrices():
     pauli["Y"] = qutip.sigmay()
     pauli["Z"] = qutip.sigmaz()
     pauli["I3"] = qutip.qeye(3)
+    pauli["Z3"] = qutip.Qobj([[1, 0, 0], [0, -1, 0], [0, 0, 0]])
     return pauli
 
 
@@ -248,27 +249,45 @@ def test_extraction_of_sequences(seq):
                         ).all()
 
 
-def test_building_basis_and_projection_operators(seq, reg):
+@pytest.mark.parametrize("leakage", [False, True])
+def test_building_basis_and_projection_operators(seq, reg, leakage, matrices):
     # All three levels:
-    sim = QutipEmulator.from_sequence(seq, sampling_rate=0.01)
-    assert sim.basis_name == "all"
-    assert sim.dim == 3
-    assert sim.basis == {
-        "r": qutip.basis(3, 0),
-        "g": qutip.basis(3, 1),
-        "h": qutip.basis(3, 2),
+    def _config(dim):
+        return (
+            SimConfig(
+                ("leakage", "eff_noise"),
+                eff_noise_opers=[qutip.qeye(dim)],
+                eff_noise_rates=[0.0],
+            )
+            if leakage
+            else SimConfig()
+        )
+
+    dim = 3 + leakage
+    sim = QutipEmulator.from_sequence(
+        seq, sampling_rate=0.01, config=_config(dim)
+    )
+    assert sim.basis_name == "all" + ("_with_error" if leakage else "")
+    assert sim.dim == dim
+    basis_dict = {
+        "r": qutip.basis(dim, 0),
+        "g": qutip.basis(dim, 1),
+        "h": qutip.basis(dim, 2),
     }
+    if leakage:
+        basis_dict["x"] = qutip.basis(dim, 3)
+    assert sim.basis == basis_dict
     assert (
         sim._hamiltonian.op_matrix["sigma_rr"]
-        == qutip.basis(3, 0) * qutip.basis(3, 0).dag()
+        == qutip.basis(dim, 0) * qutip.basis(dim, 0).dag()
     )
     assert (
         sim._hamiltonian.op_matrix["sigma_gr"]
-        == qutip.basis(3, 1) * qutip.basis(3, 0).dag()
+        == qutip.basis(dim, 1) * qutip.basis(dim, 0).dag()
     )
     assert (
         sim._hamiltonian.op_matrix["sigma_hg"]
-        == qutip.basis(3, 2) * qutip.basis(3, 1).dag()
+        == qutip.basis(dim, 2) * qutip.basis(dim, 1).dag()
     )
 
     # Check local operator building method:
@@ -289,51 +308,71 @@ def test_building_basis_and_projection_operators(seq, reg):
     seq2.declare_channel("global", "rydberg_global")
     pi_pls = Pulse.ConstantDetuning(BlackmanWaveform(1000, np.pi), 0.0, 0)
     seq2.add(pi_pls, "global")
-    sim2 = QutipEmulator.from_sequence(seq2, sampling_rate=0.01)
-    assert sim2.basis_name == "ground-rydberg"
-    assert sim2.dim == 2
-    assert sim2.basis == {"r": qutip.basis(2, 0), "g": qutip.basis(2, 1)}
+    dim = 2 + leakage
+    sim2 = QutipEmulator.from_sequence(
+        seq2, sampling_rate=0.01, config=_config(dim)
+    )
+    assert sim2.basis_name == "ground-rydberg" + (
+        "_with_error" if leakage else ""
+    )
+    assert sim2.dim == dim
+    basis_dict = {"r": qutip.basis(dim, 0), "g": qutip.basis(dim, 1)}
+    if leakage:
+        basis_dict["x"] = qutip.basis(dim, 2)
+    assert sim2.basis == basis_dict
     assert (
         sim2._hamiltonian.op_matrix["sigma_rr"]
-        == qutip.basis(2, 0) * qutip.basis(2, 0).dag()
+        == qutip.basis(dim, 0) * qutip.basis(dim, 0).dag()
     )
     assert (
         sim2._hamiltonian.op_matrix["sigma_gr"]
-        == qutip.basis(2, 1) * qutip.basis(2, 0).dag()
+        == qutip.basis(dim, 1) * qutip.basis(dim, 0).dag()
     )
 
     # Digital
     seq2b = Sequence(reg, DigitalAnalogDevice)
     seq2b.declare_channel("local", "raman_local", "target")
     seq2b.add(pi_pls, "local")
-    sim2b = QutipEmulator.from_sequence(seq2b, sampling_rate=0.01)
-    assert sim2b.basis_name == "digital"
-    assert sim2b.dim == 2
-    assert sim2b.basis == {"g": qutip.basis(2, 0), "h": qutip.basis(2, 1)}
+    sim2b = QutipEmulator.from_sequence(
+        seq2b, sampling_rate=0.01, config=_config(dim)
+    )
+    assert sim2b.basis_name == "digital" + ("_with_error" if leakage else "")
+    assert sim2b.dim == dim
+    basis_dict = {"g": qutip.basis(dim, 0), "h": qutip.basis(dim, 1)}
+    if leakage:
+        basis_dict["x"] = qutip.basis(dim, 2)
+    assert sim2b.basis == basis_dict
     assert (
         sim2b._hamiltonian.op_matrix["sigma_gg"]
-        == qutip.basis(2, 0) * qutip.basis(2, 0).dag()
+        == qutip.basis(dim, 0) * qutip.basis(dim, 0).dag()
     )
     assert (
         sim2b._hamiltonian.op_matrix["sigma_hg"]
-        == qutip.basis(2, 1) * qutip.basis(2, 0).dag()
+        == qutip.basis(dim, 1) * qutip.basis(dim, 0).dag()
     )
 
     # Local ground-rydberg
     seq2c = Sequence(reg, DigitalAnalogDevice)
     seq2c.declare_channel("local_ryd", "rydberg_local", "target")
     seq2c.add(pi_pls, "local_ryd")
-    sim2c = QutipEmulator.from_sequence(seq2c, sampling_rate=0.01)
-    assert sim2c.basis_name == "ground-rydberg"
-    assert sim2c.dim == 2
-    assert sim2c.basis == {"r": qutip.basis(2, 0), "g": qutip.basis(2, 1)}
+    sim2c = QutipEmulator.from_sequence(
+        seq2c, sampling_rate=0.01, config=_config(dim)
+    )
+    assert sim2c.basis_name == "ground-rydberg" + (
+        "_with_error" if leakage else ""
+    )
+    assert sim2c.dim == dim
+    basis_dict = {"r": qutip.basis(dim, 0), "g": qutip.basis(dim, 1)}
+    if leakage:
+        basis_dict["x"] = qutip.basis(dim, 2)
+    assert sim2c.basis == basis_dict
     assert (
         sim2c._hamiltonian.op_matrix["sigma_rr"]
-        == qutip.basis(2, 0) * qutip.basis(2, 0).dag()
+        == qutip.basis(dim, 0) * qutip.basis(dim, 0).dag()
     )
     assert (
         sim2c._hamiltonian.op_matrix["sigma_gr"]
-        == qutip.basis(2, 1) * qutip.basis(2, 0).dag()
+        == qutip.basis(dim, 1) * qutip.basis(dim, 0).dag()
     )
 
     # Global XY
@@ -346,21 +385,26 @@ def test_building_basis_and_projection_operators(seq, reg):
         match="Bases used in samples should be supported by device.",
     ):
         QutipEmulator(sampler.sample(seq2), seq2.register, DigitalAnalogDevice)
-    sim2 = QutipEmulator.from_sequence(seq2, sampling_rate=0.01)
-    assert sim2.basis_name == "XY"
-    assert sim2.dim == 2
-    assert sim2.basis == {"u": qutip.basis(2, 0), "d": qutip.basis(2, 1)}
+    sim2 = QutipEmulator.from_sequence(
+        seq2, sampling_rate=0.01, config=_config(dim)
+    )
+    assert sim2.basis_name == "XY" + ("_with_error" if leakage else "")
+    assert sim2.dim == dim
+    basis_dict = {"u": qutip.basis(dim, 0), "d": qutip.basis(dim, 1)}
+    if leakage:
+        basis_dict["x"] = qutip.basis(dim, 2)
+    assert sim2.basis == basis_dict
     assert (
         sim2._hamiltonian.op_matrix["sigma_uu"]
-        == qutip.basis(2, 0) * qutip.basis(2, 0).dag()
+        == qutip.basis(dim, 0) * qutip.basis(dim, 0).dag()
     )
     assert (
         sim2._hamiltonian.op_matrix["sigma_du"]
-        == qutip.basis(2, 1) * qutip.basis(2, 0).dag()
+        == qutip.basis(dim, 1) * qutip.basis(dim, 0).dag()
     )
     assert (
         sim2._hamiltonian.op_matrix["sigma_ud"]
-        == qutip.basis(2, 0) * qutip.basis(2, 1).dag()
+        == qutip.basis(dim, 0) * qutip.basis(dim, 1).dag()
     )
 
 
@@ -696,17 +740,6 @@ def test_noise(seq, matrices):
     )
     with pytest.raises(NotImplementedError, match="Cannot include"):
         sim2.set_config(SimConfig(noise="depolarizing"))
-    with pytest.raises(
-        NotImplementedError,
-        match="mode 'ising' does not support simulation of",
-    ):
-        sim2.set_config(
-            SimConfig(
-                ("leakage", "eff_noise"),
-                eff_noise_opers=[matrices["I3"]],
-                eff_noise_rates=[0.1],
-            )
-        )
     assert sim2.config.spam_dict == {
         "eta": 0.9,
         "epsilon": 0.01,
@@ -749,6 +782,7 @@ def test_noise_with_zero_epsilons(seq, matrices):
         ("depolarizing", {"0": 587, "1": 413}, 3),
         (("dephasing", "depolarizing", "relaxation"), {"0": 587, "1": 413}, 5),
         (("eff_noise", "dephasing"), {"0": 595, "1": 405}, 2),
+        (("eff_noise", "leakage"), {"0": 519, "1": 481}, 1),
     ],
 )
 def test_noises_rydberg(matrices, noise, result, n_collapse_ops):
@@ -765,7 +799,9 @@ def test_noises_rydberg(matrices, noise, result, n_collapse_ops):
         sampling_rate=0.01,
         config=SimConfig(
             noise=noise,
-            eff_noise_opers=[matrices["Z"]],
+            eff_noise_opers=[
+                matrices["Z3"] if "leakage" in noise else matrices["Z"]
+            ],
             eff_noise_rates=[0.025],
         ),
     )
@@ -826,6 +862,7 @@ eff_deph_res = {"111": 958, "110": 19, "011": 12, "101": 11}
         ("depolarizing", depo_res, 3),
         (("dephasing", "depolarizing"), deph_depo_res, 4),
         (("eff_noise", "dephasing"), eff_deph_res, 2),
+        (("eff_noise", "leakage"), {"111": 991, "110": 9}, 1),
     ],
 )
 def test_noises_digital(matrices, noise, result, n_collapse_ops, seq_digital):
@@ -837,7 +874,9 @@ def test_noises_digital(matrices, noise, result, n_collapse_ops, seq_digital):
         config=SimConfig(
             noise=noise,
             hyperfine_dephasing_rate=0.05,
-            eff_noise_opers=[matrices["Z"]],
+            eff_noise_opers=[
+                matrices["Z3"] if "leakage" in noise else matrices["Z"]
+            ],
             eff_noise_rates=[0.025],
         ),
     )
@@ -884,6 +923,11 @@ res_deph_relax = {
             {"111": 922, "110": 33, "011": 23, "101": 21, "100": 1},
             4,
         ),
+        (
+            ("eff_noise", "leakage"),
+            {"111": 958, "110": 19, "011": 12, "101": 11},
+            2,
+        ),
     ],
 )
 def test_noises_all(matrices, reg, noise, result, n_collapse_ops, seq):
@@ -901,8 +945,16 @@ def test_noises_all(matrices, reg, noise, result, n_collapse_ops, seq):
         seq.add(twopi_pulse, "ryd_glob")
         # Measure in the rydberg basis
         seq.measure()
-    deph_op = qutip.Qobj([[1, 0, 0], [0, 0, 0], [0, 0, 0]])
-    hyp_deph_op = qutip.Qobj([[0, 0, 0], [0, 0, 0], [0, 0, 1]])
+    if "leakage" in noise:
+        deph_op = qutip.Qobj(
+            [[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
+        )
+        hyp_deph_op = qutip.Qobj(
+            [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, 0]]
+        )
+    else:
+        deph_op = qutip.Qobj([[1, 0, 0], [0, 0, 0], [0, 0, 0]])
+        hyp_deph_op = qutip.Qobj([[0, 0, 0], [0, 0, 0], [0, 0, 1]])
     sim = QutipEmulator.from_sequence(
         seq,  # resulting state should be hhh
         sampling_rate=0.01,
@@ -1103,6 +1155,7 @@ res4 = {"0000": 969, "0001": 18, "1000": 13}
     [
         (None, "dephasing", res1, 1),
         (None, "eff_noise", res1, 1),
+        (None, "leakage", res1, 1),
         (None, "depolarizing", res2, 3),
         ("atom0", "dephasing", res3, 1),
         ("atom1", "dephasing", res4, 1),
@@ -1124,16 +1177,6 @@ def test_noisy_xy(matrices, masked_qubit, noise, result, n_collapse_ops):
     with pytest.raises(
         NotImplementedError, match="mode 'XY' does not support simulation of"
     ):
-        sim.set_config(
-            SimConfig(
-                ("leakage", "eff_noise"),
-                eff_noise_opers=[matrices["I3"]],
-                eff_noise_rates=[0.1],
-            )
-        )
-    with pytest.raises(
-        NotImplementedError, match="mode 'XY' does not support simulation of"
-    ):
         sim.set_config(SimConfig(("SPAM", "doppler")))
     with pytest.raises(ValueError, match="is not a valid"):
         sim._hamiltonian.set_config(SimConfig(("SPAM", "doppler")))
@@ -1151,9 +1194,15 @@ def test_noisy_xy(matrices, masked_qubit, noise, result, n_collapse_ops):
     # SPAM simulation is implemented:
     sim.set_config(
         SimConfig(
-            ("SPAM", noise),
+            (
+                ("SPAM", noise)
+                if noise != "leakage"
+                else ("SPAM", "leakage", "eff_noise")
+            ),
             eta=0.4,
-            eff_noise_opers=[matrices["Z"]],
+            eff_noise_opers=[
+                matrices["Z"] if noise != "leakage" else matrices["Z3"]
+            ],
             eff_noise_rates=[0.025],
         )
     )

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -753,7 +753,6 @@ def test_config(matrices):
     assert sim._initial_state == qutip.tensor(
         [qutip.basis(2, 1) for _ in range(2)]
     )
-    print("Final test")
     # Currently in ground state => initial state is extended without warning
     sim.set_config(
         SimConfig(

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -289,7 +289,11 @@ def test_building_basis_and_projection_operators(seq, reg, leakage, matrices):
         sim._hamiltonian.op_matrix["sigma_hg"]
         == qutip.basis(dim, 2) * qutip.basis(dim, 1).dag()
     )
-
+    if leakage:
+        assert (
+            sim._hamiltonian.op_matrix["sigma_xr"]
+            == qutip.basis(dim, 3) * qutip.basis(dim, 0).dag()
+        )
     # Check local operator building method:
     with pytest.raises(ValueError, match="Duplicate atom"):
         sim.build_operator([("sigma_gg", ["target", "target"])])
@@ -328,7 +332,11 @@ def test_building_basis_and_projection_operators(seq, reg, leakage, matrices):
         sim2._hamiltonian.op_matrix["sigma_gr"]
         == qutip.basis(dim, 1) * qutip.basis(dim, 0).dag()
     )
-
+    if leakage:
+        assert (
+            sim2._hamiltonian.op_matrix["sigma_xr"]
+            == qutip.basis(dim, 2) * qutip.basis(dim, 0).dag()
+        )
     # Digital
     seq2b = Sequence(reg, DigitalAnalogDevice)
     seq2b.declare_channel("local", "raman_local", "target")
@@ -350,6 +358,11 @@ def test_building_basis_and_projection_operators(seq, reg, leakage, matrices):
         sim2b._hamiltonian.op_matrix["sigma_hg"]
         == qutip.basis(dim, 1) * qutip.basis(dim, 0).dag()
     )
+    if leakage:
+        assert (
+            sim2b._hamiltonian.op_matrix["sigma_xh"]
+            == qutip.basis(dim, 2) * qutip.basis(dim, 1).dag()
+        )
 
     # Local ground-rydberg
     seq2c = Sequence(reg, DigitalAnalogDevice)
@@ -374,7 +387,11 @@ def test_building_basis_and_projection_operators(seq, reg, leakage, matrices):
         sim2c._hamiltonian.op_matrix["sigma_gr"]
         == qutip.basis(dim, 1) * qutip.basis(dim, 0).dag()
     )
-
+    if leakage:
+        assert (
+            sim2c._hamiltonian.op_matrix["sigma_xg"]
+            == qutip.basis(dim, 2) * qutip.basis(dim, 1).dag()
+        )
     # Global XY
     seq2 = Sequence(reg, MockDevice)
     seq2.declare_channel("global", "mw_global")
@@ -406,6 +423,11 @@ def test_building_basis_and_projection_operators(seq, reg, leakage, matrices):
         sim2._hamiltonian.op_matrix["sigma_ud"]
         == qutip.basis(dim, 0) * qutip.basis(dim, 1).dag()
     )
+    if leakage:
+        assert (
+            sim2._hamiltonian.op_matrix["sigma_ux"]
+            == qutip.basis(dim, 0) * qutip.basis(dim, 2).dag()
+        )
 
 
 def test_empty_sequences(reg):


### PR DESCRIPTION
Implements the "leakage" noise. When "leakage" is provided as a `noise` in the `SimConfig`:
- Adds a state "x" in the eigenbasis of the computation.
- Rebuilds, the basis, dim, op_matrix associated to the computational basis
- Rebuilds the `operators` in Hamiltonian (see `construct_hamiltonian`) since they changed size
- Modifies the initial state of QutipEmulator (defaults to "all-ground")