### PR TITLE
Fix rounding error in RampWaveform samples

### DIFF
--- a/pulser-core/pulser/math/__init__.py
+++ b/pulser-core/pulser/math/__init__.py
@@ -200,6 +200,13 @@ def diff(a: AbstractArrayLike) -> AbstractArray:
     return AbstractArray(np.diff(a.as_array()))
 
 
+def clip(a: AbstractArrayLike, a_min: float, a_max: float) -> AbstractArray:
+    a = AbstractArray(a)
+    if a.is_tensor:
+        return AbstractArray(torch.clamp(a.as_tensor(), a_min, a_max))
+    return AbstractArray(np.clip(a.as_array(), a_min, a_max))
+
+
 def dot(a: AbstractArrayLike, b: AbstractArrayLike) -> AbstractArray:
     a, b = map(AbstractArray, (a, b))
     if a.is_tensor or b.is_tensor:

--- a/pulser-core/pulser/waveforms.py
+++ b/pulser-core/pulser/waveforms.py
@@ -599,8 +599,9 @@ class RampWaveform(Waveform):
         Returns:
             A numpy array with a value for each time step.
         """
-        return (
-            self._slope * np.arange(self._duration, dtype=float) + self._start
+        return pm.clip(
+            self._slope * np.arange(self._duration, dtype=float) + self._start,
+            *sorted(map(float, [self._start, self._stop])),
         )
 
     @property

--- a/tests/test_waveforms.py
+++ b/tests/test_waveforms.py
@@ -164,6 +164,11 @@ def test_custom():
 def test_ramp():
     assert np.isclose(ramp.slope, 7e-3, atol=1e-5)
 
+    ramp_samples = RampWaveform(
+        3000, top := 25.757450291031688, 0
+    ).samples.as_array()
+    assert np.all(np.logical_and(ramp_samples <= top, ramp_samples >= 0))
+
 
 def test_blackman():
     with pytest.raises(TypeError):


### PR DESCRIPTION
Rounding errors in the generation of a `RampWaveform`'s samples could lead the edge values to lie outside of the range of the `start`and `stop` values. This ensures they stay within said range.