### PR TITLE
Fix normalisation in ring of atoms

### DIFF
--- a/tutorials/simulating_sequences.ipynb
+++ b/tutorials/simulating_sequences.ipynb
@@ -51,7 +51,7 @@
     "R_interatomic = pulser.MockDevice.rydberg_blockade_radius(U)\n",
     "coords = (\n",
     "    R_interatomic\n",
-    "    / (2 * np.tan(np.pi / L))\n",
+    "    / (2 * np.sin(np.pi / L))\n",
     "    * np.array(\n",
     "        [\n",
     "            (np.cos(theta * 2 * np.pi / L), np.sin(theta * 2 * np.pi / L))\n",


### PR DESCRIPTION
The original formulas was normalized using np.tan(np.pi / L). However, this is not correct, as can be checked by computing the normalization between the distances between the atoms (one does not get R_interatomic).

Here is a quick code to show the issue:
```python
import numpy as np


def setup_coords(L, R_interatomic, fn=np.sin):

    coords = (
        R_interatomic
        / (2 * fn(np.pi / L))
        * np.array(
            [
                (np.cos(theta * 2 * np.pi / L), np.sin(theta * 2 * np.pi / L))
                for theta in range(L)
            ]
        )
    )

    distances = np.linalg.norm(coords - np.roll(coords, shift=1, axis=0), axis=1)

    return distances


L = 5
R_interatomic = 1

print("sin:", setup_coords(L, R_interatomic, fn=np.sin))
print("tan:", setup_coords(L, R_interatomic, fn=np.tan))
```
which gives
```python
sin: [1. 1. 1. 1. 1.]
tan: [0.80901699 0.80901699 0.80901699 0.80901699 0.80901699]
```