### PR TITLE
Add layout-restricting parameters to BaseDevice

### DIFF
--- a/pulser-core/pulser/json/abstract_repr/schemas/device-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/device-schema.json
@@ -166,6 +166,10 @@
               "description": "The largest fraction of a layout that can be filled with atoms.",
               "type": "number"
             },
+            "max_layout_traps": {
+              "description": "The maximum number of traps a layout can have.",
+              "type": "number"
+            },
             "max_radial_distance": {
               "description": "Maximum distance an atom can be from the center of the array (in µm).",
               "type": "number"
@@ -182,9 +186,17 @@
               "description": "The closest together two atoms can be (in μm).",
               "type": "number"
             },
+            "min_layout_traps": {
+              "description": "The minimum number of traps a layout can have.",
+              "type": "number"
+            },
             "name": {
               "description": "A unique name for the device.",
               "type": "string"
+            },
+            "optimal_layout_filling": {
+              "description": "The optimal fraction of a layout that should be filled with atoms.",
+              "type": "number"
             },
             "pre_calibrated_layouts": {
               "description": "Register layouts already calibrated on the device.",
@@ -288,6 +300,10 @@
               "description": "The largest fraction of a layout that can be filled with atoms.",
               "type": "number"
             },
+            "max_layout_traps": {
+              "description": "The maximum number of traps a layout can have.",
+              "type": "number"
+            },
             "max_radial_distance": {
               "description": "Maximum distance an atom can be from the center of the array (in µm).",
               "type": [
@@ -307,9 +323,17 @@
               "description": "The closest together two atoms can be (in μm).",
               "type": "number"
             },
+            "min_layout_traps": {
+              "description": "The minimum number of traps a layout can have.",
+              "type": "number"
+            },
             "name": {
               "description": "A unique name for the device.",
               "type": "string"
+            },
+            "optimal_layout_filling": {
+              "description": "The optimal fraction of a layout that should be filled with atoms.",
+              "type": "number"
             },
             "requires_layout": {
               "description": "Whether the register used in the sequence must be created from a register layout.  Only enforced in QPU execution.",

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -479,6 +479,9 @@ class TestDevice:
         [
             (MockDevice, "max_sequence_duration", 1000),
             (MockDevice, "max_runs", 100),
+            (MockDevice, "optimal_layout_filling", 0.4),
+            (MockDevice, "min_layout_traps", 10),
+            (MockDevice, "max_layout_traps", 200),
             (MockDevice, "requires_layout", True),
             (AnalogDevice, "requires_layout", False),
             (AnalogDevice, "accepts_new_layouts", False),

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -47,6 +47,8 @@ def test_params():
         min_atom_distance=1,
         max_atom_num=None,
         max_radial_distance=None,
+        min_layout_traps=10,
+        max_layout_traps=100,
     )
 
 
@@ -121,6 +123,36 @@ def test_post_init_type_checks(test_params, param, value, msg):
             0.0,
             "maximum layout filling fraction must be greater than 0. and"
             " less than or equal to 1.",
+        ),
+        (
+            "optimal_layout_filling",
+            0.0,
+            "When defined, the optimal layout filling fraction must be greater"
+            " than 0. and less than or equal to `max_layout_filling`",
+        ),
+        (
+            "optimal_layout_filling",
+            0.9,
+            "When defined, the optimal layout filling fraction must be greater"
+            " than 0. and less than or equal to `max_layout_filling`",
+        ),
+        (
+            "min_layout_traps",
+            0,
+            "'min_layout_traps' must be greater than zero",
+        ),
+        ("max_layout_traps", 0, None),
+        (
+            "max_atom_num",
+            100,
+            "With the given maximum layout filling and maximum number "
+            "of traps, a layout supports at most 50 atoms",
+        ),
+        (
+            "max_layout_traps",
+            9,
+            "must be greater than or equal to the minimum number of "
+            "layout traps",
         ),
         (
             "channel_ids",
@@ -335,6 +367,22 @@ def test_validate_layout():
                 12, DigitalAnalogDevice.min_atom_distance - 1e-6
             )
         )
+
+    restricted_device = replace(
+        DigitalAnalogDevice, min_layout_traps=10, max_layout_traps=200
+    )
+    with pytest.raises(
+        ValueError,
+        match="The device requires register layouts to have "
+        "at least 10 traps",
+    ):
+        restricted_device.validate_layout(TriangularLatticeLayout(9, 10))
+    with pytest.raises(
+        ValueError,
+        match="The device requires register layouts to have "
+        "at most 200 traps",
+    ):
+        restricted_device.validate_layout(TriangularLatticeLayout(201, 10))
 
     valid_layout = RegisterLayout(
         Register.square(


### PR DESCRIPTION
- Adds three new layout-specific parameters to `BaseDevice`:
   - `optimal_layout_filling`: An optional value for the fraction of a layout that should be filled with atoms.
   - `min_layout_traps`: The minimum number of traps a layout can have.
   - `max_layout_traps`: An optional value for the maximum number of traps a layout can have.
- Includes these new values in `BaseDevice.validate_layout()` 

Closes #749 .