### PR TITLE
Improve the NoiseModel unused parameters warning message

### DIFF
--- a/pulser-core/pulser/noise_model.py
+++ b/pulser-core/pulser/noise_model.py
@@ -258,12 +258,16 @@ class NoiseModel:
         object.__setattr__(
             self, "noise_types", tuple(sorted(true_noise_types))
         )
+        non_zero_relevant_params = [
+            p for p in relevant_params if param_vals[p]
+        ]
         for param_, val_ in param_vals.items():
             object.__setattr__(self, param_, val_)
             if val_ and param_ not in relevant_params:
                 warnings.warn(
                     f"{param_!r} is not used by any active noise type "
-                    f"{self.noise_types}.",
+                    f"in {self.noise_types} when the only defined parameters "
+                    f"are {non_zero_relevant_params}.",
                     stacklevel=2,
                 )
 

--- a/tests/test_noise_model.py
+++ b/tests/test_noise_model.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from __future__ import annotations
 
+import re
+
 import numpy as np
 import pytest
 
@@ -86,7 +88,14 @@ class TestNoiseModel:
     )
     @pytest.mark.parametrize("unused_param", ["runs", "samples_per_run"])
     def test_unused_params(self, unused_param, noise_param):
-        with pytest.warns(UserWarning, match=f"'{unused_param}' is not used"):
+        with pytest.warns(
+            UserWarning,
+            match=re.escape(
+                f"'{unused_param}' is not used by any active noise type in"
+                f" {(_PARAM_TO_NOISE_TYPE[noise_param],)} when the only "
+                f"defined parameters are {[noise_param]}"
+            ),
+        ):
             NoiseModel(**{unused_param: 100, noise_param: 1.0})
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
The warning message indicating there are unused parameters in the `NoiseModel` now includes the non-zero noise parameters, e.g. for
```
pulser.NoiseModel(p_false_pos=0.1, runs=10)
```

Before:
```
UserWarning: 'runs' is not used by any active noise type ('SPAM',).
```

After:
```
UserWarning: 'runs' is not used by any active noise type in ('SPAM',) when the only defined parameters are ['p_false_pos'].
```

Fixes #742 .