### PR TITLE
Incorporate automatic layout generation in `Register`

### DIFF
--- a/pulser-core/pulser/register/_layout_gen.py
+++ b/pulser-core/pulser/register/_layout_gen.py
@@ -16,22 +16,23 @@ from __future__ import annotations
 import numpy as np
 from scipy.spatial.distance import cdist
 
-from pulser.register import Register, RegisterLayout
+from pulser.register import RegisterLayout
 
 
 def generate_register_layout(
-    register: Register,
+    atom_coords: np.ndarray,
     min_trap_dist: float,
     max_radial_dist: int,
     max_layout_filling: float,
     optimal_layout_filling: float | None = None,
     mesh_resolution: float = 1.0,
+    min_traps: int = 1,
     slug: str | None = None,
 ) -> RegisterLayout:
-    """Generates a layout for a register.
+    """Generates a layout from a collection of coordinates.
 
     Args:
-        register: The register to generate the layout for.
+        atom_coords: The coordinates where atoms will be placed.
         device: The Pulser device on which the layout and register
             will be implemented.
         min_trap_dist: The minimum distance between traps.
@@ -41,6 +42,7 @@ def generate_register_layout(
             atoms to traps. If not given, takes max_layout_filling.
         mesh_resolution: The spacing between points in the mesh of candidate
             coordinates, in µm.
+        min_traps: The minimum number of traps in the resulting layout.
         slug: An optional slug for the resulting layout.
 
     Returns:
@@ -56,28 +58,36 @@ def generate_register_layout(
     coords = np.c_[x[in_circle].ravel(), y[in_circle].ravel()]
 
     # Get the atoms in the register (the "seeds")
-    seeds = list(register.qubits.values())
+    seeds = list(atom_coords)
     N_seeds = len(seeds)
 
     # Record indices and distances between coords and seeds
     c_indx = np.arange(len(coords))
     all_dists = cdist(coords, seeds)
 
-    total_extra_traps = (
-        np.ceil(N_seeds / optimal_layout_filling).astype(int) - N_seeds
-    )
     min_extra_traps = (
-        np.ceil(N_seeds / max_layout_filling).astype(int) - N_seeds
+        # Accounts for the case when the needed number is less than min_traps
+        max(np.ceil(N_seeds / max_layout_filling).astype(int), min_traps)
+        - N_seeds
     )
+
+    # Use max() in case min_traps is larger than the optimal number
+    total_extra_traps = max(
+        np.ceil(N_seeds / optimal_layout_filling).astype(int) - N_seeds,
+        min_extra_traps,
+    )
+
     # This is the region where we can still add traps
     region_left = np.all(all_dists > min_trap_dist, axis=1)
     # The traps start out as being just the seeds
     traps = seeds.copy()
     for i in range(total_extra_traps):
-        if not np.any(region_left) and i + 1 < min_extra_traps:
-            raise RuntimeError(
-                f"Failed to find a site for {min_extra_traps - i} traps."
-            )
+        if not np.any(region_left):
+            if i + 1 < min_extra_traps:
+                raise RuntimeError(
+                    f"Failed to find a site for {min_extra_traps - i} traps."
+                )
+            break
         # Select the point in the valid region that is closest to a seed
         selected = c_indx[region_left][
             np.argmin(np.min(all_dists[region_left][:, :N_seeds], axis=1))

--- a/pulser-core/pulser/register/_layout_gen.py
+++ b/pulser-core/pulser/register/_layout_gen.py
@@ -1,0 +1,90 @@
+# Copyright 2024 Pulser Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import numpy as np
+from scipy.spatial.distance import cdist
+
+from pulser.register import Register, RegisterLayout
+
+
+def generate_register_layout(
+    register: Register,
+    min_trap_dist: float,
+    max_radial_dist: int,
+    max_layout_filling: float,
+    optimal_layout_filling: float | None = None,
+    mesh_resolution: float = 1.0,
+    slug: str | None = None,
+) -> RegisterLayout:
+    """Generates a layout for a register.
+
+    Args:
+        register: The register to generate the layout for.
+        device: The Pulser device on which the layout and register
+            will be implemented.
+        min_trap_dist: The minimum distance between traps.
+        max_radial_dist: The maximum distance from the origin.
+        max_layout_filling: The maximum ratio of atoms to traps.
+        optimal_layout_filling: An optional value for the optimal ratio of
+            atoms to traps. If not given, takes max_layout_filling.
+        mesh_resolution: The spacing between points in the mesh of candidate
+            coordinates, in µm.
+        slug: An optional slug for the resulting layout.
+
+    Returns:
+        RegisterLayout: The register layout.
+    """
+    optimal_layout_filling = optimal_layout_filling or max_layout_filling
+
+    # Generate all coordinates where a trap can be placed
+    lx = 2 * max_radial_dist
+    side = np.linspace(0, lx, num=int(lx / mesh_resolution)) - max_radial_dist
+    x, y = np.meshgrid(side, side)
+    in_circle = x**2 + y**2 <= max_radial_dist**2
+    coords = np.c_[x[in_circle].ravel(), y[in_circle].ravel()]
+
+    # Get the atoms in the register (the "seeds")
+    seeds = list(register.qubits.values())
+    N_seeds = len(seeds)
+
+    # Record indices and distances between coords and seeds
+    c_indx = np.arange(len(coords))
+    all_dists = cdist(coords, seeds)
+
+    total_extra_traps = (
+        np.ceil(N_seeds / optimal_layout_filling).astype(int) - N_seeds
+    )
+    min_extra_traps = (
+        np.ceil(N_seeds / max_layout_filling).astype(int) - N_seeds
+    )
+    # This is the region where we can still add traps
+    region_left = np.all(all_dists > min_trap_dist, axis=1)
+    # The traps start out as being just the seeds
+    traps = seeds.copy()
+    for i in range(total_extra_traps):
+        if not np.any(region_left) and i + 1 < min_extra_traps:
+            raise RuntimeError(
+                f"Failed to find a site for {min_extra_traps - i} traps."
+            )
+        # Select the point in the valid region that is closest to a seed
+        selected = c_indx[region_left][
+            np.argmin(np.min(all_dists[region_left][:, :N_seeds], axis=1))
+        ]
+        # Add the selected point to the traps
+        traps.append(coords[selected])
+        # Add the distances to the new trap
+        all_dists = np.append(all_dists, cdist(coords, [traps[-1]]), axis=1)
+        region_left *= all_dists[:, -1] > min_trap_dist
+    return RegisterLayout(traps, slug=slug)

--- a/pulser-core/pulser/register/_layout_gen.py
+++ b/pulser-core/pulser/register/_layout_gen.py
@@ -16,10 +16,8 @@ from __future__ import annotations
 import numpy as np
 from scipy.spatial.distance import cdist
 
-from pulser.register import RegisterLayout
 
-
-def generate_register_layout(
+def generate_layout_trap_coordinates(
     atom_coords: np.ndarray,
     min_trap_dist: float,
     max_radial_dist: int,
@@ -27,9 +25,9 @@ def generate_register_layout(
     optimal_layout_filling: float | None = None,
     mesh_resolution: float = 1.0,
     min_traps: int = 1,
-    slug: str | None = None,
-) -> RegisterLayout:
-    """Generates a layout from a collection of coordinates.
+    max_traps: int | None = None,
+) -> list[np.ndarray]:
+    """Generates layout traps for a collection of atomic coordinates.
 
     Args:
         atom_coords: The coordinates where atoms will be placed.
@@ -43,10 +41,7 @@ def generate_register_layout(
         mesh_resolution: The spacing between points in the mesh of candidate
             coordinates, in µm.
         min_traps: The minimum number of traps in the resulting layout.
-        slug: An optional slug for the resulting layout.
-
-    Returns:
-        RegisterLayout: The register layout.
+        max_traps: The maximum number of traps in the resulting layout.
     """
     optimal_layout_filling = optimal_layout_filling or max_layout_filling
 
@@ -58,32 +53,33 @@ def generate_register_layout(
     coords = np.c_[x[in_circle].ravel(), y[in_circle].ravel()]
 
     # Get the atoms in the register (the "seeds")
-    seeds = list(atom_coords)
+    seeds: list[np.ndarray] = list(atom_coords)
     N_seeds = len(seeds)
 
     # Record indices and distances between coords and seeds
     c_indx = np.arange(len(coords))
     all_dists = cdist(coords, seeds)
 
-    min_extra_traps = (
-        # Accounts for the case when the needed number is less than min_traps
-        max(np.ceil(N_seeds / max_layout_filling).astype(int), min_traps)
-        - N_seeds
+    # Accounts for the case when the needed number is less than min_traps
+    min_traps = max(
+        np.ceil(N_seeds / max_layout_filling).astype(int), min_traps
     )
 
     # Use max() in case min_traps is larger than the optimal number
-    total_extra_traps = max(
-        np.ceil(N_seeds / optimal_layout_filling).astype(int) - N_seeds,
-        min_extra_traps,
+    target_traps = max(
+        np.ceil(N_seeds / optimal_layout_filling).astype(int),
+        min_traps,
     )
+    if max_traps:
+        target_traps = min(target_traps, max_traps)
 
     # This is the region where we can still add traps
     region_left = np.all(all_dists > min_trap_dist, axis=1)
     # The traps start out as being just the seeds
     traps = seeds.copy()
-    for i in range(total_extra_traps):
+    for i in range(N_seeds, target_traps):
         if not np.any(region_left):
-            if i + 1 < min_extra_traps:
+            if i < (min_extra_traps := min_traps - N_seeds):
                 raise RuntimeError(
                     f"Failed to find a site for {min_extra_traps - i} traps."
                 )
@@ -97,4 +93,4 @@ def generate_register_layout(
         # Add the distances to the new trap
         all_dists = np.append(all_dists, cdist(coords, [traps[-1]]), axis=1)
         region_left *= all_dists[:, -1] > min_trap_dist
-    return RegisterLayout(traps, slug=slug)
+    return traps

--- a/pulser-core/pulser/register/_layout_gen.py
+++ b/pulser-core/pulser/register/_layout_gen.py
@@ -85,12 +85,8 @@ def generate_trap_coordinates(
     region_left = np.all(all_dists > min_trap_dist, axis=1)
     # The traps start out as being just the seeds
     traps = seeds.copy()
-    for i in range(n_seeds, target_traps):
+    for _ in range(target_traps - n_seeds):
         if not np.any(region_left):
-            if i < (min_extra_traps := min_traps - n_seeds):
-                raise RuntimeError(
-                    f"Failed to find a site for {min_extra_traps - i} traps."
-                )
             break
         # Select the point in the valid region that is closest to a seed
         selected = c_indx[region_left][
@@ -101,4 +97,8 @@ def generate_trap_coordinates(
         # Add the distances to the new trap
         all_dists = np.append(all_dists, cdist(coords, [traps[-1]]), axis=1)
         region_left *= all_dists[:, -1] > min_trap_dist
+    if len(traps) < min_traps:
+        raise RuntimeError(
+            f"Failed to find a site for {min_traps - len(traps)} traps."
+        )
     return traps

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -31,7 +31,7 @@ from pulser.json.abstract_repr.deserializer import (
     deserialize_abstract_register,
 )
 from pulser.json.utils import stringify_qubit_ids
-from pulser.register._layout_gen import generate_register_layout
+from pulser.register._layout_gen import generate_layout_trap_coordinates
 from pulser.register._reg_drawer import RegDrawer
 from pulser.register.base_register import BaseRegister, QubitId
 
@@ -356,15 +356,16 @@ class Register(BaseRegister, RegDrawer):
             raise TypeError(
                 f"'device' must be of type Device, not {type(device)}."
             )
-        layout = generate_register_layout(
+        trap_coords = generate_layout_trap_coordinates(
             self.sorted_coords,
             min_trap_dist=device.min_atom_distance,
             max_radial_dist=device.max_radial_distance,
             max_layout_filling=device.max_layout_filling,
             optimal_layout_filling=device.optimal_layout_filling,
             min_traps=device.min_layout_traps,
-            slug=layout_slug,
+            max_traps=device.max_layout_traps,
         )
+        layout = pulser.register.RegisterLayout(trap_coords, slug=layout_slug)
         trap_ids = layout.get_traps_from_coordinates(*self.sorted_coords)
         reg_from_layout = layout.define_register(*trap_ids)
         if validate:

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Mapping
-from typing import Any, Optional, Union, cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -331,7 +331,6 @@ class Register(BaseRegister, RegDrawer):
     def with_automatic_layout(
         self,
         device: Device,
-        validate: bool = True,
         layout_slug: str | None = None,
     ) -> Register:
         """Replicates the register with an automatically generated layout.
@@ -340,8 +339,6 @@ class Register(BaseRegister, RegDrawer):
 
         Args:
             device: The device constraints for the layout generation.
-            validate: Whether to validate the generated RegisterLayout
-                against the provided device.
             layout_slug: An optional slug for the generated layout.
 
         Raises:
@@ -367,16 +364,7 @@ class Register(BaseRegister, RegDrawer):
         )
         layout = pulser.register.RegisterLayout(trap_coords, slug=layout_slug)
         trap_ids = layout.get_traps_from_coordinates(*self.sorted_coords)
-        reg_from_layout = layout.define_register(*trap_ids)
-        if validate:
-            try:
-                device.validate_register(reg_from_layout)
-            except Exception as e:
-                raise RuntimeError(
-                    "When defined from the layout, the register fails device "
-                    "validation."
-                ) from e
-        return cast(Register, reg_from_layout)
+        return cast(Register, layout.define_register(*trap_ids))
 
     def rotated(self, degrees: float) -> Register:
         """Makes a new rotated register.

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -31,7 +31,7 @@ from pulser.json.abstract_repr.deserializer import (
     deserialize_abstract_register,
 )
 from pulser.json.utils import stringify_qubit_ids
-from pulser.register._layout_gen import generate_layout_trap_coordinates
+from pulser.register._layout_gen import generate_trap_coordinates
 from pulser.register._reg_drawer import RegDrawer
 from pulser.register.base_register import BaseRegister, QubitId
 
@@ -353,7 +353,7 @@ class Register(BaseRegister, RegDrawer):
             raise TypeError(
                 f"'device' must be of type Device, not {type(device)}."
             )
-        trap_coords = generate_layout_trap_coordinates(
+        trap_coords = generate_trap_coordinates(
             self.sorted_coords,
             min_trap_dist=device.min_atom_distance,
             max_radial_dist=device.max_radial_distance,

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Mapping
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union, cast, TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -31,8 +31,12 @@ from pulser.json.abstract_repr.deserializer import (
     deserialize_abstract_register,
 )
 from pulser.json.utils import stringify_qubit_ids
+from pulser.register._layout_gen import generate_register_layout
 from pulser.register._reg_drawer import RegDrawer
 from pulser.register.base_register import BaseRegister, QubitId
+
+if TYPE_CHECKING:
+    from pulser.devices import Device
 
 
 class Register(BaseRegister, RegDrawer):
@@ -323,6 +327,55 @@ class Register(BaseRegister, RegDrawer):
         coords = pm.AbstractArray(patterns.triangular_hex(n_qubits)) * spacing_
 
         return cls.from_coordinates(coords, center=False, prefix=prefix)
+
+    def with_automatic_layout(
+        self,
+        device: Device,
+        validate: bool = True,
+        layout_slug: str | None = None,
+    ) -> Register:
+        """Replicates the register with an automatically generated layout.
+
+        The generated `RegisterLayout` can be accessed via `Register.layout`.
+
+        Args:
+            device: The device constraints for the layout generation.
+            validate: Whether to validate the generated RegisterLayout
+                against the provided device.
+            layout_slug: An optional slug for the generated layout.
+
+        Raises:
+            RuntimeError: If the automatic layout generation fails to meet
+                the device constraints.
+
+        Returns:
+            Register: A new register instance with identical qubit IDs and
+            coordinates but also the newly generated RegisterLayout.
+        """
+        if not isinstance(device, pulser.devices.Device):
+            raise TypeError(
+                f"'device' must be of type Device, not {type(device)}."
+            )
+        layout = generate_register_layout(
+            self.sorted_coords,
+            min_trap_dist=device.min_atom_distance,
+            max_radial_dist=device.max_radial_distance,
+            max_layout_filling=device.max_layout_filling,
+            optimal_layout_filling=device.optimal_layout_filling,
+            min_traps=device.min_layout_traps,
+            slug=layout_slug,
+        )
+        trap_ids = layout.get_traps_from_coordinates(*self.sorted_coords)
+        reg_from_layout = layout.define_register(*trap_ids)
+        if validate:
+            try:
+                device.validate_register(reg_from_layout)
+            except Exception as e:
+                raise RuntimeError(
+                    "When defined from the layout, the register fails device "
+                    "validation."
+                ) from e
+        return cast(Register, reg_from_layout)
 
     def rotated(self, degrees: float) -> Register:
         """Makes a new rotated register.

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -642,3 +642,18 @@ def test_automatic_layout(optimal_filling):
         reg.with_automatic_layout(
             dataclasses.replace(device, min_layout_traps=200)
         )
+
+    # The Register is larger than max_traps
+    big_reg = Register.square(8, spacing=5)
+    min_traps = np.ceil(len(big_reg.qubit_ids) / max_layout_filling)
+    with pytest.raises(
+        RuntimeError, match="Failed to find a site for 2 traps"
+    ):
+        big_reg.with_automatic_layout(
+            dataclasses.replace(device, max_layout_traps=int(min_traps - 2))
+        )
+    # Without max_traps, it would still work
+    assert (
+        big_reg.with_automatic_layout(device).layout.number_of_traps
+        >= min_traps
+    )

--- a/tutorials/advanced_features/Backends for Sequence Execution.ipynb
+++ b/tutorials/advanced_features/Backends for Sequence Execution.ipynb
@@ -62,7 +62,11 @@
     "Sequence execution on a QPU is done through the `QPUBackend`, which is a remote backend. Therefore, it requires a remote backend connection, which should be open from the start due to two additional QPU constraints:\n",
     "\n",
     "1. The `Device` must be chosen among the options available at the moment, which can be found through `connection.fetch_available_devices()`.\n",
-    "2. The `Register` must be defined from one of the register layouts calibrated for the chosen `Device`, which are found under `Device.calibrated_register_layouts`. Check out [this tutorial](reg_layouts.nblink) for more information on how to define a `Register` from a `RegisterLayout`.\n",
+    "2. If in the chosen device `Device.requires_layout` is `True`, the `Register` must be defined from a register layout:  \n",
+    "    -  If `Device.accepts_new_layouts` is `False`, use one of the register layouts calibrated for the chosen `Device` (found under `Device.calibrated_register_layouts`). Check out [this tutorial](reg_layouts.nblink) for more information on how to define a `Register` from a `RegisterLayout`.\n",
+    "    - Otherwise, we may choose to define our own custom layout or rely on `Register.with_automatic_layout()` to\n",
+    "    give us a register from an automatically generated register layout that fits our desired register while obeying the device constraints. \n",
+    "\n",
     "\n",
     "On the contrary, execution on emulator backends imposes no further restriction on the device and the register. We will stick to emulator backends in this tutorial, so we will forego the requirements of QPU backends in the following steps."
    ]


### PR DESCRIPTION
- Adds an algorithm for defining the layout trap coordinates from a set of atomic coordinates
- Defines `Register.with_automatic_layout(device: Device)`, which allows the user to get an automatically generated layout that obeys the `device` constrains from any register

Closes #748 .