### PR TITLE
Attempt to compare pulser versions when abstract repr validation fails

### DIFF
--- a/pulser-core/pulser/json/abstract_repr/schemas/device-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/device-schema.json
@@ -205,6 +205,10 @@
               },
               "type": "array"
             },
+            "pulser_version": {
+              "description": "The pulser version used to serialize the object.",
+              "type": "string"
+            },
             "requires_layout": {
               "description": "Whether the register used in the sequence must be created from a register layout.  Only enforced in QPU execution.",
               "type": "boolean"
@@ -334,6 +338,10 @@
             "optimal_layout_filling": {
               "description": "The optimal fraction of a layout that should be filled with atoms.",
               "type": "number"
+            },
+            "pulser_version": {
+              "description": "The pulser version used to serialize the object.",
+              "type": "string"
             },
             "requires_layout": {
               "description": "Whether the register used in the sequence must be created from a register layout.  Only enforced in QPU execution.",

--- a/pulser-core/pulser/json/abstract_repr/schemas/layout-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/layout-schema.json
@@ -29,6 +29,10 @@
           },
           "type": "array"
         },
+        "pulser_version": {
+          "description": "The pulser version used to serialize the object.",
+          "type": "string"
+        },
         "slug": {
           "description": "An optional name for the layout.",
           "type": "string"
@@ -53,6 +57,10 @@
             "type": "array"
           },
           "type": "array"
+        },
+        "pulser_version": {
+          "description": "The pulser version used to serialize the object.",
+          "type": "string"
         },
         "slug": {
           "description": "An optional name for the layout.",

--- a/pulser-core/pulser/json/abstract_repr/schemas/noise-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/noise-schema.json
@@ -83,6 +83,10 @@
         "p_false_pos": {
           "type": "number"
         },
+        "pulser_version": {
+          "description": "The pulser version used to serialize the object.",
+          "type": "string"
+        },
         "relaxation_rate": {
           "type": "number"
         },

--- a/pulser-core/pulser/json/abstract_repr/schemas/register-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/register-schema.json
@@ -69,6 +69,10 @@
           },
           "type": "array"
         },
+        "pulser_version": {
+          "description": "The pulser version used to serialize the object.",
+          "type": "string"
+        },
         "slug": {
           "description": "An optional name for the layout.",
           "type": "string"
@@ -93,6 +97,10 @@
             "type": "array"
           },
           "type": "array"
+        },
+        "pulser_version": {
+          "description": "The pulser version used to serialize the object.",
+          "type": "string"
         },
         "slug": {
           "description": "An optional name for the layout.",
@@ -125,6 +133,10 @@
           "$ref": "#/definitions/Layout2D",
           "description": "The trap layout underlying the register."
         },
+        "pulser_version": {
+          "description": "The pulser version used to serialize the object.",
+          "type": "string"
+        },
         "register": {
           "description": "A 2D register containing a set of atoms.",
           "items": {
@@ -144,6 +156,10 @@
         "layout": {
           "$ref": "#/definitions/Layout3D",
           "description": "The trap layout underlying the register."
+        },
+        "pulser_version": {
+          "description": "The pulser version used to serialize the object.",
+          "type": "string"
         },
         "register": {
           "description": "A 3D register containing a set of atoms.",

--- a/pulser-core/pulser/json/abstract_repr/schemas/sequence-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/sequence-schema.json
@@ -395,6 +395,10 @@
           },
           "type": "array"
         },
+        "pulser_version": {
+          "description": "The pulser version used to serialize the object.",
+          "type": "string"
+        },
         "slug": {
           "description": "An optional name for the layout.",
           "type": "string"
@@ -419,6 +423,10 @@
             "type": "array"
           },
           "type": "array"
+        },
+        "pulser_version": {
+          "description": "The pulser version used to serialize the object.",
+          "type": "string"
         },
         "slug": {
           "description": "An optional name for the layout.",
@@ -1013,6 +1021,10 @@
               },
               "type": "array"
             },
+            "pulser_version": {
+              "description": "The pulser version used to serialize the object.",
+              "type": "string"
+            },
             "register": {
               "description": "A 2D register containing a set of atoms.",
               "items": {
@@ -1110,6 +1122,10 @@
               },
               "type": "array"
             },
+            "pulser_version": {
+              "description": "The pulser version used to serialize the object.",
+              "type": "string"
+            },
             "register": {
               "description": "A 3D register containing a set of atoms.",
               "items": {
@@ -1206,6 +1222,10 @@
                 "$ref": "#/definitions/Operation"
               },
               "type": "array"
+            },
+            "pulser_version": {
+              "description": "The pulser version used to serialize the object.",
+              "type": "string"
             },
             "register": {
               "description": "A  list of qubit IDs.",

--- a/pulser-core/pulser/json/abstract_repr/validation.py
+++ b/pulser-core/pulser/json/abstract_repr/validation.py
@@ -17,7 +17,7 @@ from importlib.metadata import version
 from typing import Literal
 
 import jsonschema
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 from referencing import Registry, Resource
 
 import pulser
@@ -60,7 +60,11 @@ def validate_abstract_repr(
     try:
         jsonschema.validate(**validate_args)
     except Exception as exc:
-        ser_pulser_version = Version(obj.get("pulser_version", "0.0.0"))
+        try:
+            ser_pulser_version = Version(obj.get("pulser_version", "0.0.0"))
+        except InvalidVersion:
+            # In case the serialized version is invalid
+            raise exc
         if Version(pulser.__version__) < ser_pulser_version:
             raise AbstractReprError(
                 "The provided object is invalid under the current abstract "

--- a/pulser-core/pulser/json/abstract_repr/validation.py
+++ b/pulser-core/pulser/json/abstract_repr/validation.py
@@ -17,11 +17,16 @@ from importlib.metadata import version
 from typing import Literal
 
 import jsonschema
+from packaging.version import Version
 from referencing import Registry, Resource
 
+import pulser
 from pulser.json.abstract_repr import SCHEMAS, SCHEMAS_PATH
+from pulser.json.exceptions import AbstractReprError
 
-LEGACY_JSONSCHEMA = "4.18" > version("jsonschema") >= "4.17.3"
+LEGACY_JSONSCHEMA = (
+    Version("4.18") > Version(version("jsonschema")) >= Version("4.17.3")
+)
 
 REGISTRY: Registry = Registry(
     [
@@ -52,4 +57,18 @@ def validate_abstract_repr(
         )
     else:  # pragma: no cover
         validate_args["registry"] = REGISTRY
-    jsonschema.validate(**validate_args)
+    try:
+        jsonschema.validate(**validate_args)
+    except Exception as exc:
+        ser_pulser_version = Version(obj.get("pulser_version", "0.0.0"))
+        if Version(pulser.__version__) < ser_pulser_version:
+            raise AbstractReprError(
+                "The provided object is invalid under the current abstract "
+                "representation schema. It appears it was serialized with a "
+                f"more recent version of pulser ({ser_pulser_version!s}) than "
+                f"the one currently being used ({pulser.__version__}). "
+                "It is possible validation failed because new features have "
+                "since been added; consider upgrading your pulser "
+                "installation and retrying."
+            ) from exc
+        raise exc

--- a/pulser-core/requirements.txt
+++ b/pulser-core/requirements.txt
@@ -1,6 +1,7 @@
 jsonschema >= 4.17.3, < 5
 referencing
 matplotlib < 4
+packaging   # This is already required by matplotlib but we use it too
 # Numpy 1.20 introduces type hints, 1.24.0 breaks matplotlib < 3.6.1
 numpy >= 1.20, != 1.24.0, < 2
 scipy < 2

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -26,6 +26,7 @@ import jsonschema.exceptions
 import numpy as np
 import pytest
 
+import pulser
 from pulser import Pulse, Register, Register3D, Sequence, devices
 from pulser.channels import Rydberg
 from pulser.channels.eom import RydbergBeam, RydbergEOM
@@ -573,6 +574,19 @@ class TestDevice:
 
 def validate_schema(instance):
     validate_abstract_repr(json.dumps(instance), "sequence")
+
+
+def test_pulser_version_mismatch():
+    curr_ver = pulser.__version__
+    higher_ver = f"{int(curr_ver[0])+1}{curr_ver[1:]}"
+    obj_str = json.dumps({"pulser_version": higher_ver})
+    with pytest.raises(
+        AbstractReprError,
+        match="It is possible validation failed because new features have "
+        "since been added; consider upgrading your pulser "
+        "installation and retrying.",
+    ):
+        validate_abstract_repr(obj_str, "device")
 
 
 class TestSerialization:

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -587,6 +587,9 @@ def test_pulser_version_mismatch():
         "installation and retrying.",
     ):
         validate_abstract_repr(obj_str, "device")
+    obj_str = json.dumps({"pulser_version": "bad_version"})
+    with pytest.raises(jsonschema.ValidationError):
+        validate_abstract_repr(obj_str, "device")
 
 
 class TestSerialization:


### PR DESCRIPTION
- [x] In case abstract repr validation fails, attempts to fetch the stored pulser version and compares it with the current one. If the current one is lower, informs the user that the failures might stem from added features in the new version
- [x] Schema allows the pulser version to be added in top-level serialized objects