### PR TITLE
Fix typo in docstring of Sequence.draw

### DIFF
--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -617,7 +617,11 @@ class BaseDevice(ABC):
         if self.max_runs is not None:
             device_lines.append(f" - Maximum number of runs: {self.max_runs}")
         device_lines += [
-            f" - Channels can be reused: {'Yes' if self.reusable_channels else 'No'}",
+            (
+                " - Channels can be reused: " "Yes"
+                if self.reusable_channels
+                else "No"
+            ),
             f" - Supported bases: {', '.join(self.supported_bases)}",
             f" - Supported states: {', '.join(self.supported_states)}",
         ]
@@ -639,12 +643,12 @@ class BaseDevice(ABC):
             "\nLayout parameters:",
             f" - Requires layout: {'Yes' if self.requires_layout else 'No'}",
         ]
-        try:
+        if hasattr(self, "accepts_new_layouts"):
             layout_lines.append(
-                f" - Accepts new layout: {'Yes' if self.accepts_new_layouts else 'No'}"
+                " - Accepts new layout: " "Yes"
+                if self.accepts_new_layouts
+                else "No"
             )
-        except AttributeError:
-            pass
 
         layout_lines += [
             f" - Minimal number of traps: {self.min_layout_traps}",
@@ -659,11 +663,15 @@ class BaseDevice(ABC):
                 except (AttributeError, TypeError):
                     max_amp = "None"
                 try:
-                    max_abs_detuning = f"{float(cast(float, ch.max_abs_detuning)):.4g} rad/µs"
+                    max_abs_detuning = (
+                        f"{float(cast(float, ch.max_abs_detuning)):.4g} rad/µs"
+                    )
                 except (AttributeError, TypeError):
                     max_abs_detuning = "None"
                 try:
-                    bottom_detuning = f"{float(cast(float, ch.bottom_detuning)):.4g} rad/µs"
+                    bottom_detuning = (
+                        f"{float(cast(float, ch.bottom_detuning)):.4g} rad/µs"
+                    )
                 except (AttributeError, TypeError):
                     bottom_detuning = "None"
 

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -618,8 +618,8 @@ class BaseDevice(ABC):
             device_lines.append(f" - Maximum number of runs: {self.max_runs}")
         device_lines += [
             f" - Channels can be reused: {'Yes' if self.reusable_channels else 'No'}",
-            f" - Supported bases: {", ".join(self.supported_bases)}",
-            f" - Supported states: {", ".join(self.supported_states)}",
+            f" - Supported bases: {', '.join(self.supported_bases)}",
+            f" - Supported states: {', '.join(self.supported_states)}",
         ]
         if self.interaction_coeff is not None:
             device_lines.append(

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -725,6 +725,10 @@ class Device(BaseDevice):
         print("\n".join(header))
         print(self._specs())
 
+    @property
+    def specs(self) -> str:
+        return self._specs(for_docs=True)
+
     def _specs(self, for_docs: bool = False) -> str:
         lines = [
             "\nRegister parameters:",

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -588,7 +588,11 @@ class BaseDevice(ABC):
 
     @property
     def specs(self) -> str:
-        return self._specs(for_docs=True)
+        """
+        Text summarizing the specifications of the device.
+        """
+
+        return self._specs(for_docs=False)
 
     def _specs(self, for_docs: bool = False) -> str:
         lines = [

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -588,7 +588,7 @@ class BaseDevice(ABC):
 
     @property
     def specs(self) -> str:
-        """ Text summarizing the specifications of the device. """
+        """Text summarizing the specifications of the device."""
         return self._specs(for_docs=False)
 
     def _specs(self, for_docs: bool = False) -> str:
@@ -659,22 +659,23 @@ class BaseDevice(ABC):
         ch_lines = ["\nChannels:"]
         for name, ch in {**self.channels, **self.dmm_channels}.items():
             if for_docs:
-                try:
+                max_amp = "None"
+                if ch.max_abs_detuning is not None:
                     max_amp = f"{float(cast(float, ch.max_amp)):.4g} rad/µs"
-                except (AttributeError, TypeError):
-                    max_amp = "None"
-                try:
+
+                max_abs_detuning = "None"
+                if ch.max_abs_detuning is not None:
                     max_abs_detuning = (
                         f"{float(cast(float, ch.max_abs_detuning)):.4g} rad/µs"
                     )
-                except (AttributeError, TypeError):
-                    max_abs_detuning = "None"
-                try:
-                    bottom_detuning = (
-                        f"{float(cast(float, ch.bottom_detuning)):.4g} rad/µs"
-                    )
-                except (AttributeError, TypeError):
-                    bottom_detuning = "None"
+
+                bottom_detuning = "None"
+                if hasattr(ch, "bottom_detuning"):
+                    if ch.bottom_detuning is not None:
+                        bottom_detuning = (
+                            f"{float(cast(float, ch.bottom_detuning)):.4g}"
+                            " rad/µs"
+                        )
 
                 ch_lines += [
                     f" - ID: '{name}'",

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -666,16 +666,12 @@ class BaseDevice(ABC):
                 max_abs_detuning = "None"
                 if ch.max_abs_detuning is not None:
                     max_abs_detuning = (
-                        f"{float(cast(float, ch.max_abs_detuning)):.4g} rad/µs"
+                        f"{float(ch.max_abs_detuning):.4g} rad/µs"
                     )
 
                 bottom_detuning = "None"
-                if hasattr(ch, "bottom_detuning"):
-                    if ch.bottom_detuning is not None:
-                        bottom_detuning = (
-                            f"{float(cast(float, ch.bottom_detuning)):.4g}"
-                            " rad/µs"
-                        )
+                if isinstance(ch, DMM) and ch.bottom_detuning is not None:
+                    bottom_detuning = f"{float(ch.bottom_detuning):.4g} rad/µs"
 
                 ch_lines += [
                     f" - ID: '{name}'",

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -746,6 +746,40 @@ class Device(BaseDevice):
                 f"{self.max_sequence_duration} ns"
             )
 
+        device_lines = [
+            "\nDevice parameters:",
+        ]
+        if self.max_runs is not None:
+            device_lines.append(
+                f" - Maximum number of runs: {self.max_runs}"
+            )
+        device_lines += [
+            f" - Channels can be reused: {'Yes' if self.reusable_channels else 'No'}",
+            f" - Supported bases: {", ".join(self.supported_bases)}",
+            f" - Supported states: {", ".join(self.supported_states)}",
+        ]
+        if self.interaction_coeff is not None:
+            device_lines.append(
+                f" - Ising interaction coefficient: {self.interaction_coeff}"
+            )
+        if self.interaction_coeff_xy is not None:
+            device_lines.append(
+                f" - XY interaction coefficient: {self.interaction_coeff_xy}"
+            )
+
+        if self.default_noise_model is not None:
+            device_lines.append(
+                f" - Default noise model: {self.default_noise_model}"
+            )
+
+        layout_lines = [
+            "\nLayout parameters:",
+            f" - Requires layout: {'Yes' if self.requires_layout else 'No'}",
+            f" - Accepts new layout: {'Yes' if self.accepts_new_layouts else 'No'}",
+            f" - Minimal number of traps: {self.min_layout_traps}",
+            f" - Maximal number of traps: {self.max_layout_traps}"
+        ]
+
         ch_lines = ["\nChannels:"]
         for name, ch in {**self.channels, **self.dmm_channels}.items():
             if for_docs:
@@ -789,7 +823,7 @@ class Device(BaseDevice):
             else:
                 ch_lines.append(f" - '{name}': {ch!r}")
 
-        return "\n".join(lines + ch_lines)
+        return "\n".join(lines + device_lines + layout_lines + ch_lines)
 
     def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -588,10 +588,7 @@ class BaseDevice(ABC):
 
     @property
     def specs(self) -> str:
-        """
-        Text summarizing the specifications of the device.
-        """
-
+        """ Text summarizing the specifications of the device. """
         return self._specs(for_docs=False)
 
     def _specs(self, for_docs: bool = False) -> str:

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -1746,7 +1746,7 @@ class Sequence(Generic[DeviceType]):
 
         Args:
             mode: The curves to draw. 'input'
-                draws only the programmed curves, 'output' the excepted curves
+                draws only the programmed curves, 'output' the expected curves
                 after modulation. 'input+output' will draw both curves except
                 for channels without a defined modulation bandwidth, in which
                 case only the input is drawn.

--- a/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
+++ b/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
@@ -238,6 +238,7 @@ class PasqalCloud(RemoteConnection):
         get_batch_fn = backoff_decorator(self._sdk_connection.get_batch)
         batch = get_batch_fn(id=batch_id)
 
+        assert isinstance(batch.sequence_builder, str)
         seq_builder = Sequence.from_abstract_repr(batch.sequence_builder)
         reg = seq_builder.get_register(include_mappable=True)
         all_qubit_ids = reg.qubit_ids


### PR DESCRIPTION
The dosctring of `Sequence.draw` contained the words "excepted curves" instead of "expected curves".