### PR TITLE
Fixes to the amplitude noise implementation

### DIFF
--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -254,6 +254,10 @@ class Channel(ABC):
                     "'propagation_dir' must be given as a non-zero 3D vector;"
                     f" got {self.propagation_dir} instead."
                 )
+            # Make sure it's stored as a tuple
+            object.__setattr__(
+                self, "propagation_dir", tuple(self.propagation_dir)
+            )
 
     @property
     def rise_time(self) -> int:

--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -34,7 +34,7 @@ warnings.filterwarnings("once", "A duration of")
 
 ChannelType = TypeVar("ChannelType", bound="Channel")
 
-OPTIONAL_ABSTR_CH_FIELDS = ("min_avg_amp",)
+OPTIONAL_ABSTR_CH_FIELDS = ("min_avg_amp", "propagation_dir")
 
 # States ranked in decreasing order of their associated eigenenergy
 States = Literal["u", "d", "r", "g", "h", "x"]
@@ -78,6 +78,8 @@ class Channel(ABC):
         min_avg_amp: The minimum average amplitude of a pulse (when not zero).
         mod_bandwidth: The modulation bandwidth at -3dB (50% reduction), in
             MHz.
+        propagation_dir: The propagation direction of the beam leaving the
+            channel, given as a vector in 3D space.
 
     Example:
         To create a channel targeting the 'ground-rydberg' transition globally,
@@ -96,6 +98,7 @@ class Channel(ABC):
     min_avg_amp: float = 0
     mod_bandwidth: Optional[float] = None  # MHz
     eom_config: Optional[BaseEOM] = field(init=False, default=None)
+    propagation_dir: tuple[float, float, float] | None = None
 
     @property
     def name(self) -> str:
@@ -244,6 +247,14 @@ class Channel(ABC):
                 "modulation bandwidth."
             )
 
+        if self.propagation_dir is not None:
+            dir_vector = np.array(self.propagation_dir, dtype=float)
+            if dir_vector.size != 3 or np.sum(dir_vector) == 0.0:
+                raise ValueError(
+                    "'propagation_dir' must be given as a non-zero 3D vector;"
+                    f" got {self.propagation_dir} instead."
+                )
+
     @property
     def rise_time(self) -> int:
         """The rise time (in ns).
@@ -340,6 +351,7 @@ class Channel(ABC):
         cls: Type[ChannelType],
         max_abs_detuning: Optional[float],
         max_amp: Optional[float],
+        # TODO: Impose a default propagation_dir in pulser-core 1.3
         **kwargs: Any,
     ) -> ChannelType:
         """Initializes the channel with global addressing.

--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -78,8 +78,8 @@ class Channel(ABC):
         min_avg_amp: The minimum average amplitude of a pulse (when not zero).
         mod_bandwidth: The modulation bandwidth at -3dB (50% reduction), in
             MHz.
-        propagation_dir: The propagation direction of the beam leaving the
-            channel, given as a vector in 3D space.
+        propagation_dir: The propagation direction of the beam associated with
+            the channel, given as a vector in 3D space.
 
     Example:
         To create a channel targeting the 'ground-rydberg' transition globally,
@@ -199,7 +199,12 @@ class Channel(ABC):
                     getattr(self, p) is None
                 ), f"'{p}' must be left as None in a Global channel."
         else:
+            assert self.addressing == "Local"
             parameters += local_only
+            if self.propagation_dir is not None:
+                raise NotImplementedError(
+                    "'propagation_dir' must be left as None in Local channels."
+                )
 
         for param in parameters:
             value = getattr(self, param)
@@ -377,6 +382,8 @@ class Channel(ABC):
                 bandwidth at -3dB (50% reduction), in MHz.
             min_avg_amp: The minimum average amplitude of a pulse (when not
                 zero).
+            propagation_dir: The propagation direction of the beam associated
+                with the channel, given as a vector in 3D space.
         """
         # Can't initialize a channel whose addressing is determined internally
         for cls_field in fields(cls):

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -24,6 +24,7 @@ from typing import Any, Literal, cast, get_args
 import numpy as np
 from scipy.spatial.distance import squareform
 
+import pulser
 import pulser.json.abstract_repr as pulser_abstract_repr
 import pulser.math as pm
 from pulser.channels.base_channel import Channel, States, get_states_from_bases
@@ -565,7 +566,13 @@ class BaseDevice(ABC):
         for ch_name, ch_obj in self.channels.items():
             ch_list.append(ch_obj._to_abstract_repr(ch_name))
         # Add version and channels to params
-        params.update({"version": "1", "channels": ch_list})
+        params.update(
+            {
+                "version": "1",
+                "pulser_version": pulser.__version__,
+                "channels": ch_list,
+            }
+        )
         dmm_list = []
         for dmm_name, dmm_obj in self.dmm_channels.items():
             dmm_list.append(dmm_obj._to_abstract_repr(dmm_name))

--- a/pulser-core/pulser/json/abstract_repr/schemas/device-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/device-schema.json
@@ -82,6 +82,22 @@
             "null"
           ]
         },
+        "propagation_dir": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The propagation direction of the beam leaving the channel."
+        },
         "total_bottom_detuning": {
           "description": "Minimum possible detuning of the whole DMM channel (in rad/µs), must be below zero.",
           "type": [
@@ -520,6 +536,22 @@
                 "number",
                 "null"
               ]
+            },
+            "propagation_dir": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 3,
+                  "minItems": 3,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The propagation direction of the beam leaving the channel."
             }
           },
           "required": [
@@ -610,6 +642,22 @@
                 "number",
                 "null"
               ]
+            },
+            "propagation_dir": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 3,
+                  "minItems": 3,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The propagation direction of the beam leaving the channel."
             }
           },
           "required": [
@@ -700,6 +748,22 @@
                 "number",
                 "null"
               ]
+            },
+            "propagation_dir": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 3,
+                  "minItems": 3,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The propagation direction of the beam leaving the channel."
             }
           },
           "required": [
@@ -857,6 +921,22 @@
                 "number",
                 "null"
               ]
+            },
+            "propagation_dir": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 3,
+                  "minItems": 3,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The propagation direction of the beam leaving the channel."
             }
           },
           "required": [
@@ -950,6 +1030,22 @@
                 "number",
                 "null"
               ]
+            },
+            "propagation_dir": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 3,
+                  "minItems": 3,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The propagation direction of the beam leaving the channel."
             }
           },
           "required": [
@@ -1043,6 +1139,22 @@
                 "number",
                 "null"
               ]
+            },
+            "propagation_dir": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 3,
+                  "minItems": 3,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The propagation direction of the beam leaving the channel."
             }
           },
           "required": [
@@ -1193,6 +1305,22 @@
                 "number",
                 "null"
               ]
+            },
+            "propagation_dir": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 3,
+                  "minItems": 3,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The propagation direction of the beam leaving the channel."
             }
           },
           "required": [
@@ -1274,6 +1402,22 @@
                 "number",
                 "null"
               ]
+            },
+            "propagation_dir": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 3,
+                  "minItems": 3,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The propagation direction of the beam leaving the channel."
             }
           },
           "required": [
@@ -1355,6 +1499,22 @@
                 "number",
                 "null"
               ]
+            },
+            "propagation_dir": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 3,
+                  "minItems": 3,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The propagation direction of the beam leaving the channel."
             }
           },
           "required": [
@@ -1500,6 +1660,22 @@
                 "number",
                 "null"
               ]
+            },
+            "propagation_dir": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 3,
+                  "minItems": 3,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The propagation direction of the beam leaving the channel."
             }
           },
           "required": [
@@ -1581,6 +1757,22 @@
                 "number",
                 "null"
               ]
+            },
+            "propagation_dir": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 3,
+                  "minItems": 3,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The propagation direction of the beam leaving the channel."
             }
           },
           "required": [
@@ -1662,6 +1854,22 @@
                 "number",
                 "null"
               ]
+            },
+            "propagation_dir": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "number"
+                  },
+                  "maxItems": 3,
+                  "minItems": 3,
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The propagation direction of the beam leaving the channel."
             }
           },
           "required": [
@@ -1750,6 +1958,22 @@
             "number",
             "null"
           ]
+        },
+        "propagation_dir": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The propagation direction of the beam leaving the channel."
         },
         "total_bottom_detuning": {
           "description": "Minimum possible detuning of the whole DMM channel (in rad/µs), must be below zero.",

--- a/pulser-core/pulser/noise_model.py
+++ b/pulser-core/pulser/noise_model.py
@@ -144,10 +144,11 @@ class NoiseModel:
         p_false_neg: Probability of measuring a false negative.
         temperature: Temperature, set in µK, of the atoms in the array.
             Also sets the standard deviation of the speed of the atoms.
-        laser_waist: Waist of the gaussian laser, set in µm, for global
-            pulses.
-        amp_sigma: Dictates the fluctuations in amplitude as a standard
-            deviation of a normal distribution centered in 1.
+        laser_waist: Waist of the gaussian lasers, set in µm, for global
+            pulses. Assumed to be the same for all global channels.
+        amp_sigma: Dictates the fluctuations in amplitude of global pulses
+            from run to run as a standard deviation of a normal distribution
+            centered in 1. Assumed to be the same for all global channels.
         relaxation_rate: The rate of relaxation from the Rydberg to the
             ground state (in 1/µs). Corresponds to 1/T1.
         dephasing_rate: The rate of a dephasing occuring (in 1/µs) in a

--- a/pulser-simulation/pulser_simulation/simconfig.py
+++ b/pulser-simulation/pulser_simulation/simconfig.py
@@ -15,8 +15,8 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field, fields
-from math import sqrt
 from typing import Any, Optional, Tuple, Type, TypeVar, Union, cast
 
 import qutip
@@ -58,7 +58,7 @@ def doppler_sigma(temperature: float) -> float:
     Arg:
         temperature: The temperature in K.
     """
-    return KEFF * sqrt(KB * temperature / MASS)
+    return KEFF * math.sqrt(KB * temperature / MASS)
 
 
 @dataclass(frozen=True)
@@ -133,7 +133,7 @@ class SimConfig:
             noise_model.noise_types,
             noise_model.state_prep_error,
             noise_model.amp_sigma,
-            noise_model.laser_waist,
+            noise_model.laser_waist or float("inf"),
         )
         for param in relevant_params:
             kwargs[_DIFF_NOISE_PARAMS.get(param, param)] = getattr(
@@ -148,7 +148,7 @@ class SimConfig:
             cast(Tuple[NoiseTypes, ...], self.noise),
             self.eta,
             self.amp_sigma,
-            self.laser_waist,
+            None if math.isinf(self.laser_waist) else self.laser_waist,
         )
         kwargs = {}
         for param in relevant_params:

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -232,6 +232,9 @@ class TestDevice:
     def test_device_schema(self, abstract_device):
         validate_abstract_repr(json.dumps(abstract_device), "device")
 
+    def test_pulser_version(self, abstract_device):
+        assert abstract_device["pulser_version"] == pulser.__version__
+
     def test_roundtrip(self, abstract_device):
         def _roundtrip(abstract_device):
             device = deserialize_device(json.dumps(abstract_device))

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -509,6 +509,7 @@ class TestDevice:
         "ch_obj",
         [
             Rydberg.Global(None, None, min_avg_amp=1),
+            Rydberg.Global(None, None, propagation_dir=(1, 0, 0)),
             Rydberg.Global(
                 None,
                 None,

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -65,12 +65,15 @@ def test_bad_init_global_channel(bad_param, bad_value):
         ("mod_bandwidth", -1e4),
         ("mod_bandwidth", MODBW_TO_TR * 1e3 + 1),
         ("min_avg_amp", -1e-3),
+        ("propagation_dir", (1, 0, 0)),
     ],
 )
 def test_bad_init_local_channel(bad_param, bad_value):
     kwargs = dict(max_abs_detuning=None, max_amp=None)
     kwargs[bad_param] = bad_value
-    if bad_param == "mod_bandwidth" and bad_value > 1:
+    if (
+        bad_param == "mod_bandwidth" and bad_value > 1
+    ) or bad_param == "propagation_dir":
         error_type = NotImplementedError
     else:
         error_type = ValueError

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -36,6 +36,8 @@ from pulser.waveforms import BlackmanWaveform, ConstantWaveform
         ("mod_bandwidth", 0),
         ("mod_bandwidth", MODBW_TO_TR * 1e3 + 1),
         ("min_avg_amp", -1e-3),
+        ("propagation_dir", (0, 0, 0)),
+        ("propagation_dir", [1, 0]),
     ],
 )
 def test_bad_init_global_channel(bad_param, bad_value):

--- a/tests/test_simconfig.py
+++ b/tests/test_simconfig.py
@@ -138,9 +138,19 @@ def test_noise_model_conversion():
     noise_model = NoiseModel(
         p_false_neg=0.4,
         p_false_pos=0.1,
+        amp_sigma=1e-3,
+        runs=10,
+        samples_per_run=1,
     )
     expected_simconfig = SimConfig(
-        noise="SPAM", epsilon=0.1, epsilon_prime=0.4, eta=0.0
+        noise=("SPAM", "amplitude"),
+        epsilon=0.1,
+        epsilon_prime=0.4,
+        eta=0.0,
+        amp_sigma=1e-3,
+        laser_waist=float("inf"),
+        runs=10,
+        samples_per_run=1,
     )
     assert SimConfig.from_noise_model(noise_model) == expected_simconfig
     assert expected_simconfig.to_noise_model() == noise_model

--- a/tests/test_simresults.py
+++ b/tests/test_simresults.py
@@ -309,7 +309,7 @@ def test_expect_noisy(results_noisy):
     with pytest.raises(ValueError, match="non-diagonal"):
         results_noisy.expect([bad_op])
     op = qutip.tensor([qutip.qeye(2), qutip.basis(2, 0).proj()])
-    assert np.isclose(results_noisy.expect([op])[0][-1], 0.7333333333333334)
+    assert np.isclose(results_noisy.expect([op])[0][-1], 0.7466666666666667)
 
 
 def test_plot(results_noisy, results):
@@ -326,7 +326,7 @@ def test_sim_without_measurement(seq_no_meas):
     )
     results_no_meas = sim_no_meas.run()
     assert results_no_meas.sample_final_state() == Counter(
-        {"11": 587, "10": 165, "01": 164, "00": 84}
+        {"11": 580, "10": 173, "01": 167, "00": 80}
     )
 
 
@@ -358,7 +358,7 @@ def test_sample_final_state_three_level(seq_no_meas, pi_pulse):
 def test_sample_final_state_noisy(seq_no_meas, results_noisy):
     np.random.seed(123)
     assert results_noisy.sample_final_state(N_samples=1234) == Counter(
-        {"11": 725, "10": 265, "01": 192, "00": 52}
+        {"11": 676, "10": 244, "01": 218, "00": 96}
     )
     res_3level = QutipEmulator.from_sequence(
         seq_no_meas, config=SimConfig(noise=("SPAM", "doppler"), runs=10)


### PR DESCRIPTION
- Adds information of the beam's propagation direction to `Channel` 
- Makes finite-waist effects depend on the position relative to the optical axis
- Makes amplitude fluctuations occur from run to run instead of pulse to pulse
- Fixes the transfer of `laser_waist` between `NoiseModel` and `SimConfig`
- Starts adding the `pulser_version` to serialized devices 

Note: To avoid disruptions for serialized devices between different versions, `propagation_dir` is defaulting to `None` in all channels and `QutipEmulator` is assuming using `propagation_dir=(0,1,0)` whenever it encounter `None`. In a future version, it would make more sense to change the default `propagation_dir` of `Global` channels to be `(0,1,0)` and remove this assumption from `QutipEmulator`. 

Fixes #712 