### PR TITLE
Change Channel.__repr__() to the default from dataclass

### DIFF
--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -54,7 +54,7 @@ def get_states_from_bases(bases: Collection[str]) -> list[States]:
     return [state for state in STATES_RANK if state in all_states]
 
 
-@dataclass(init=True, repr=False, frozen=True)
+@dataclass(init=True, frozen=True)
 class Channel(ABC):
     """Base class of a hardware channel.
 
@@ -595,7 +595,7 @@ class Channel(ABC):
         rise_time_us = self._eom_buffer_time / 2 * 1e-3
         return MODBW_TO_TR / rise_time_us
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         config = (
             f".{self.addressing}(Max Absolute Detuning: "
             f"{self.max_abs_detuning}"

--- a/pulser-core/pulser/channels/channels.py
+++ b/pulser-core/pulser/channels/channels.py
@@ -22,7 +22,7 @@ from pulser.channels.base_channel import Channel, Literal
 from pulser.channels.eom import RydbergEOM
 
 
-@dataclass(init=True, repr=False, frozen=True)
+@dataclass(init=True, frozen=True)
 class Raman(Channel):
     """Raman beam channel.
 
@@ -36,7 +36,7 @@ class Raman(Channel):
         return "digital"
 
 
-@dataclass(init=True, repr=False, frozen=True)
+@dataclass(init=True, frozen=True)
 class Rydberg(Channel):
     """Rydberg beam channel.
 
@@ -62,7 +62,7 @@ class Rydberg(Channel):
         return "ground-rydberg"
 
 
-@dataclass(init=True, repr=False, frozen=True)
+@dataclass(init=True, frozen=True)
 class Microwave(Channel):
     """Microwave adressing channel.
 

--- a/pulser-core/pulser/channels/dmm.py
+++ b/pulser-core/pulser/channels/dmm.py
@@ -28,7 +28,7 @@ from pulser.register.weight_maps import DetuningMap
 OPTIONAL_ABSTR_DMM_FIELDS = ["total_bottom_detuning"]
 
 
-@dataclass(init=True, repr=False, frozen=True)
+@dataclass(init=True, frozen=True)
 class DMM(Channel):
     """Defines a Detuning Map Modulator (DMM) Channel.
 


### PR DESCRIPTION
The old, prettier __repr__ assigned manually is now accessed trough the __str__() method of the Channel class, as proposed in issue #767 