### PR TITLE
Add method to Sequence to estimate delay introduced before adding pulse

### DIFF
--- a/pulser-core/pulser/sequence/_schedule.py
+++ b/pulser-core/pulser/sequence/_schedule.py
@@ -396,14 +396,15 @@ class _Schedule(Dict[str, _ChannelSchedule]):
             else:
                 self.wait_for_fall(channel_id)
 
-    def add_pulse(
+    def get_next_time_slot(
         self,
         pulse: Pulse,
         channel: str,
         phase_barrier_ts: list[int],
         protocol: str,
         phase_drift_params: _PhaseDriftParams | None = None,
-    ) -> None:
+        block_if_exceeds: bool = False,
+    ) -> _TimeSlot:
         def corrected_phase(tf: int) -> pm.AbstractArray:
             phase_drift = pm.AbstractArray(
                 phase_drift_params.calc_phase_drift(tf)
@@ -447,11 +448,10 @@ class _Schedule(Dict[str, _ChannelSchedule]):
         delay_duration = max(current_max_t - t0, phase_jump_buffer)
         if delay_duration > 0:
             delay_duration = self[channel].adjust_duration(delay_duration)
-            self.add_delay(delay_duration, channel)
 
         ti = t0 + delay_duration
         tf = ti + pulse.duration
-        self._check_duration(tf)
+        self._check_duration(tf, block_if_exceeds)
         # dataclasses.replace() does not work on Pulse (because init=False)
         if phase_drift_params is not None:
             pulse = Pulse(
@@ -460,7 +460,29 @@ class _Schedule(Dict[str, _ChannelSchedule]):
                 phase=corrected_phase(ti),
                 post_phase_shift=pulse.post_phase_shift,
             )
-        self[channel].slots.append(_TimeSlot(pulse, ti, tf, last.targets))
+        return _TimeSlot(pulse, ti, tf, last.targets)
+
+    def add_pulse(
+        self,
+        pulse: Pulse,
+        channel: str,
+        phase_barrier_ts: list[int],
+        protocol: str,
+        phase_drift_params: _PhaseDriftParams | None = None,
+    ) -> None:
+        last = self[channel][-1]
+        time_slot = self.get_next_time_slot(
+            pulse,
+            channel,
+            phase_barrier_ts,
+            protocol,
+            phase_drift_params,
+            True,
+        )
+        delay_duration = time_slot.ti - last.tf
+        if delay_duration > 0:
+            self.add_delay(delay_duration, channel)
+        self[channel].slots.append(time_slot)
 
     def add_delay(self, duration: int, channel: str) -> None:
         last = self[channel][-1]
@@ -557,9 +579,12 @@ class _Schedule(Dict[str, _ChannelSchedule]):
             phase = pm.AbstractArray(0.0)
         return phase
 
-    def _check_duration(self, t: int) -> None:
+    def _check_duration(self, t: int, block_if_exceeds: bool = True) -> None:
         if self.max_duration is not None and t > self.max_duration:
-            raise RuntimeError(
+            msg = (
                 "The sequence's duration exceeded the maximum duration allowed"
                 f" by the device ({self.max_duration} ns)."
             )
+            if block_if_exceeds:
+                raise RuntimeError(msg)
+            warnings.warn(msg, UserWarning)

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -1430,14 +1430,16 @@ class Sequence(Generic[DeviceType]):
             eom_settings = self._schedule[channel].eom_blocks[-1]
             if np.any(pulse.amplitude.samples != eom_settings.rabi_freq):
                 warnings.warn(
-                    f"Channel {channel} is in EOM mode, amplitude of the pulse"
-                    f" must be constant, equal to {eom_settings.rabi_freq}.",
+                    f"Channel {channel} is in EOM mode, the amplitude of the "
+                    "pulse will be constant and equal to "
+                    f"{eom_settings.rabi_freq}.",
                     UserWarning,
                 )
             if np.any(pulse.detuning.samples != eom_settings.detuning_on):
                 warnings.warn(
-                    f"Channel {channel} is in EOM mode, detuning of the pulse "
-                    f"must be constant, equal to {eom_settings.detuning_on}.",
+                    f"Channel {channel} is in EOM mode, the detuning of the "
+                    "pulse will be constant and equal to "
+                    f"{eom_settings.detuning_on}.",
                     UserWarning,
                 )
         channel_obj = self._schedule[channel].channel_obj
@@ -1462,7 +1464,7 @@ class Sequence(Generic[DeviceType]):
         phase_barriers = [
             self._basis_ref[basis][q].phase.last_time for q in last.targets
         ]
-        next_time_slot = self._schedule.get_next_time_slot(
+        next_time_slot = self._schedule.make_next_pulse_slot(
             pulse,
             channel,
             phase_barriers,

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1797,7 +1797,9 @@ def test_estimate_added_delay(eom):
     ):
         seq.estimate_added_delay(pulse_0, "ising")
 
-    # With DMM
+
+def test_estimate_added_delay_dmm():
+    pulse_0 = Pulse.ConstantPulse(100, 1, 0, 0)
     det_pulse = Pulse.ConstantPulse(100, 0, -1, 0)
     seq = Sequence(Register.square(2, 5), DigitalAnalogDevice)
     seq.declare_channel("ising", "rydberg_global")

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1782,6 +1782,19 @@ def test_estimate_added_delay(eom):
         seq.estimate_added_delay(
             pulser.Pulse.ConstantPulse(4000, 1, 0, np.pi), "ising"
         )
+    var = seq.declare_variable("var", dtype=int)
+    with pytest.raises(
+        ValueError, match="Can't compute the delay to add before a pulse"
+    ):
+        seq.estimate_added_delay(Pulse.ConstantPulse(var, 1, 0, 0), "ising")
+    # We shift the phase of just one qubit, which blocks addition
+    # of new pulses on this basis
+    seq.phase_shift(1.0, 0, basis="ground-rydberg")
+    with pytest.raises(
+        ValueError,
+        match="Cannot do a multiple-target pulse on qubits with different",
+    ):
+        seq.estimate_added_delay(pulse_0, "ising")
 
 
 @pytest.mark.parametrize("qubit_ids", [["q0", "q1", "q2"], [0, 1, 2]])

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1746,7 +1746,7 @@ def test_estimate_added_delay(eom):
         seq.enable_eom_mode("ising", 1, 0)
         with pytest.warns(
             UserWarning,
-            match="Channel ising is in EOM mode, amplitude of the pulse",
+            match="Channel ising is in EOM mode, the amplitude",
         ):
             assert (
                 seq.estimate_added_delay(
@@ -1756,7 +1756,7 @@ def test_estimate_added_delay(eom):
             )
         with pytest.warns(
             UserWarning,
-            match="Channel ising is in EOM mode, detuning of the pulse",
+            match="Channel ising is in EOM mode, the detuning",
         ):
             assert (
                 seq.estimate_added_delay(


### PR DESCRIPTION
Adds the method `estimate_add_delay` to Sequence.
Has the same signature as the `add` method.
Takes into account AOM and EOM Pulses (raise a Warning if the Pulse added is not Constant, with amplitude and detuning equal to the rabi_fres and detuning_on of the EOM Block)
Raise a Warning if the duration of the added Pulse exceeds the duration of the Sequence.
Fixes #761 