### PR TITLE
Allow definition of a custom phase jump time + Suppress output modulation for phase

### DIFF
--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -34,7 +34,11 @@ warnings.filterwarnings("once", "A duration of")
 
 ChannelType = TypeVar("ChannelType", bound="Channel")
 
-OPTIONAL_ABSTR_CH_FIELDS = ("min_avg_amp", "propagation_dir")
+OPTIONAL_ABSTR_CH_FIELDS = (
+    "min_avg_amp",
+    "custom_phase_jump_time",
+    "propagation_dir",
+)
 
 # States ranked in decreasing order of their associated eigenenergy
 States = Literal["u", "d", "r", "g", "h", "x"]
@@ -78,6 +82,9 @@ class Channel(ABC):
         min_avg_amp: The minimum average amplitude of a pulse (when not zero).
         mod_bandwidth: The modulation bandwidth at -3dB (50% reduction), in
             MHz.
+        custom_phase_jump_time: An optional custom value for the phase jump
+            time that overrides the default value estimated from the modulation
+            bandwidth.
         propagation_dir: The propagation direction of the beam associated with
             the channel, given as a vector in 3D space.
 
@@ -97,6 +104,7 @@ class Channel(ABC):
     max_duration: Optional[int] = int(1e8)  # ns
     min_avg_amp: float = 0
     mod_bandwidth: Optional[float] = None  # MHz
+    custom_phase_jump_time: int | None = None
     eom_config: Optional[BaseEOM] = field(init=False, default=None)
     propagation_dir: tuple[float, float, float] | None = None
 
@@ -172,6 +180,7 @@ class Channel(ABC):
             "max_duration",
             "mod_bandwidth",
             "min_avg_amp",
+            "custom_phase_jump_time",
         ]
         non_negative = [
             "max_amp",
@@ -179,6 +188,7 @@ class Channel(ABC):
             "min_retarget_interval",
             "fixed_retarget_t",
             "min_avg_amp",
+            "custom_phase_jump_time",
         ]
         local_only = [
             "min_retarget_interval",
@@ -191,6 +201,7 @@ class Channel(ABC):
             "max_duration",
             "mod_bandwidth",
             "max_targets",
+            "custom_phase_jump_time",
         ]
 
         if self.addressing == "Global":
@@ -280,9 +291,14 @@ class Channel(ABC):
     def phase_jump_time(self) -> int:
         """Time taken to change the phase between consecutive pulses (in ns).
 
-        Corresponds to two times the rise time.
+        Corresponds to two times the rise time when `custom_phase_jump_time`
+        is not defined.
         """
-        return self.rise_time * 2
+        return (
+            self.rise_time * 2
+            if self.custom_phase_jump_time is None
+            else self.custom_phase_jump_time
+        )
 
     def is_virtual(self) -> bool:
         """Whether the channel is virtual (i.e. partially defined)."""
@@ -336,6 +352,9 @@ class Channel(ABC):
                 bandwidth at -3dB (50% reduction), in MHz.
             min_avg_amp: The minimum average amplitude of a pulse (when not
                 zero).
+            custom_phase_jump_time: An optional custom value for the phase jump
+                time that overrides the default value estimated from the
+                modulation bandwidth.
         """
         # Can't initialize a channel whose addressing is determined internally
         for cls_field in fields(cls):
@@ -382,6 +401,9 @@ class Channel(ABC):
                 bandwidth at -3dB (50% reduction), in MHz.
             min_avg_amp: The minimum average amplitude of a pulse (when not
                 zero).
+            custom_phase_jump_time: An optional custom value for the phase jump
+                time that overrides the default value estimated from the
+                modulation bandwidth.
             propagation_dir: The propagation direction of the beam associated
                 with the channel, given as a vector in 3D space.
         """

--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -294,7 +294,7 @@ class Channel(ABC):
         Corresponds to two times the rise time when `custom_phase_jump_time`
         is not defined.
         """
-        return (
+        return int(
             self.rise_time * 2
             if self.custom_phase_jump_time is None
             else self.custom_phase_jump_time

--- a/pulser-core/pulser/json/abstract_repr/schemas/device-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/device-schema.json
@@ -31,6 +31,13 @@
           "description": "The duration of a clock cycle (in ns).",
           "type": "number"
         },
+        "custom_phase_jump_time": {
+          "description": "An optional custom value for the phase jump time that overrides the  default value estimated from the modulation bandwidth.",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
         "eom_config": {
           "description": "Configuration of an associated EOM.",
           "type": "null"
@@ -417,6 +424,13 @@
               "description": "The duration of a clock cycle (in ns).",
               "type": "number"
             },
+            "custom_phase_jump_time": {
+              "description": "An optional custom value for the phase jump time that overrides the  default value estimated from the modulation bandwidth.",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
             "eom_config": {
               "anyOf": [
                 {
@@ -587,6 +601,13 @@
               "description": "The duration of a clock cycle (in ns).",
               "type": "number"
             },
+            "custom_phase_jump_time": {
+              "description": "An optional custom value for the phase jump time that overrides the  default value estimated from the modulation bandwidth.",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
             "eom_config": {
               "description": "Configuration of an associated EOM.",
               "type": "null"
@@ -692,6 +713,13 @@
             "clock_period": {
               "description": "The duration of a clock cycle (in ns).",
               "type": "number"
+            },
+            "custom_phase_jump_time": {
+              "description": "An optional custom value for the phase jump time that overrides the  default value estimated from the modulation bandwidth.",
+              "type": [
+                "number",
+                "null"
+              ]
             },
             "eom_config": {
               "description": "Configuration of an associated EOM.",
@@ -799,6 +827,13 @@
               "description": "The duration of a clock cycle (in ns).",
               "type": "number"
             },
+            "custom_phase_jump_time": {
+              "description": "An optional custom value for the phase jump time that overrides the  default value estimated from the modulation bandwidth.",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
             "eom_config": {
               "anyOf": [
                 {
@@ -972,6 +1007,13 @@
               "description": "The duration of a clock cycle (in ns).",
               "type": "number"
             },
+            "custom_phase_jump_time": {
+              "description": "An optional custom value for the phase jump time that overrides the  default value estimated from the modulation bandwidth.",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
             "eom_config": {
               "description": "Configuration of an associated EOM.",
               "type": "null"
@@ -1080,6 +1122,13 @@
             "clock_period": {
               "description": "The duration of a clock cycle (in ns).",
               "type": "number"
+            },
+            "custom_phase_jump_time": {
+              "description": "An optional custom value for the phase jump time that overrides the  default value estimated from the modulation bandwidth.",
+              "type": [
+                "number",
+                "null"
+              ]
             },
             "eom_config": {
               "description": "Configuration of an associated EOM.",
@@ -1195,6 +1244,13 @@
               "description": "The duration of a clock cycle (in ns).",
               "type": "number"
             },
+            "custom_phase_jump_time": {
+              "description": "An optional custom value for the phase jump time that overrides the  default value estimated from the modulation bandwidth.",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
             "eom_config": {
               "anyOf": [
                 {
@@ -1356,6 +1412,13 @@
               "description": "The duration of a clock cycle (in ns).",
               "type": "number"
             },
+            "custom_phase_jump_time": {
+              "description": "An optional custom value for the phase jump time that overrides the  default value estimated from the modulation bandwidth.",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
             "eom_config": {
               "description": "Configuration of an associated EOM.",
               "type": "null"
@@ -1452,6 +1515,13 @@
             "clock_period": {
               "description": "The duration of a clock cycle (in ns).",
               "type": "number"
+            },
+            "custom_phase_jump_time": {
+              "description": "An optional custom value for the phase jump time that overrides the  default value estimated from the modulation bandwidth.",
+              "type": [
+                "number",
+                "null"
+              ]
             },
             "eom_config": {
               "description": "Configuration of an associated EOM.",
@@ -1550,6 +1620,13 @@
               "description": "The duration of a clock cycle (in ns).",
               "type": "number"
             },
+            "custom_phase_jump_time": {
+              "description": "An optional custom value for the phase jump time that overrides the  default value estimated from the modulation bandwidth.",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
             "eom_config": {
               "anyOf": [
                 {
@@ -1711,6 +1788,13 @@
               "description": "The duration of a clock cycle (in ns).",
               "type": "number"
             },
+            "custom_phase_jump_time": {
+              "description": "An optional custom value for the phase jump time that overrides the  default value estimated from the modulation bandwidth.",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
             "eom_config": {
               "description": "Configuration of an associated EOM.",
               "type": "null"
@@ -1807,6 +1891,13 @@
             "clock_period": {
               "description": "The duration of a clock cycle (in ns).",
               "type": "number"
+            },
+            "custom_phase_jump_time": {
+              "description": "An optional custom value for the phase jump time that overrides the  default value estimated from the modulation bandwidth.",
+              "type": [
+                "number",
+                "null"
+              ]
             },
             "eom_config": {
               "description": "Configuration of an associated EOM.",
@@ -1910,6 +2001,13 @@
         "clock_period": {
           "description": "The duration of a clock cycle (in ns).",
           "type": "number"
+        },
+        "custom_phase_jump_time": {
+          "description": "An optional custom value for the phase jump time that overrides the  default value estimated from the modulation bandwidth.",
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "eom_config": {
           "description": "Configuration of an associated EOM.",

--- a/pulser-core/pulser/sampler/samples.py
+++ b/pulser-core/pulser/sampler/samples.py
@@ -424,9 +424,16 @@ class ChannelSamples:
             new_samples["amp"] = channel_obj.modulate(self.amp)
             new_samples["det"] = channel_obj.modulate(self.det, keep_ends=True)
 
-        new_samples["phase"] = channel_obj.modulate(self.phase, keep_ends=True)
-        new_samples["_centered_phase"] = channel_obj.modulate(
-            self.centered_phase, keep_ends=True
+        new_len_ = len(new_samples["amp"])
+        new_samples["phase"] = pm.pad(
+            self.phase,
+            (0, new_len_ - len(self.phase)),
+            mode="edge",
+        )
+        new_samples["_centered_phase"] = pm.pad(
+            self.centered_phase,
+            (0, new_len_ - len(self.centered_phase)),
+            mode="edge",
         )
         for key in new_samples:
             new_samples[key] = new_samples[key].astype(float)[

--- a/pulser-core/pulser/sequence/_schedule.py
+++ b/pulser-core/pulser/sequence/_schedule.py
@@ -434,11 +434,14 @@ class _Schedule(Dict[str, _ChannelSchedule]):
                     # last pulse from the phase_jump_time and adds the
                     # fall_time to let the last pulse ramp down
                     ch_obj = self[channel].channel_obj
+                    in_eom_mode = self[channel].in_eom_mode()
                     phase_jump_buffer = (
-                        ch_obj.phase_jump_time
-                        + last_pulse.fall_time(
-                            ch_obj, in_eom_mode=self[channel].in_eom_mode()
+                        max(
+                            ch_obj.phase_jump_time,
+                            # In EOM mode, we must wait at least 2*rise_time
+                            2 * ch_obj.rise_time * in_eom_mode,
                         )
+                        + last_pulse.fall_time(ch_obj, in_eom_mode=in_eom_mode)
                         - (t0 - last_pulse_slot.tf)
                     )
             except RuntimeError:

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -513,6 +513,7 @@ class TestDevice:
         [
             Rydberg.Global(None, None, min_avg_amp=1),
             Rydberg.Global(None, None, propagation_dir=(1, 0, 0)),
+            Rydberg.Global(None, None, custom_phase_jump_time=0),
             Rydberg.Global(
                 None,
                 None,

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -38,6 +38,7 @@ from pulser.waveforms import BlackmanWaveform, ConstantWaveform
         ("min_avg_amp", -1e-3),
         ("propagation_dir", (0, 0, 0)),
         ("propagation_dir", [1, 0]),
+        ("custom_phase_jump_time", -10),
     ],
 )
 def test_bad_init_global_channel(bad_param, bad_value):
@@ -66,6 +67,7 @@ def test_bad_init_global_channel(bad_param, bad_value):
         ("mod_bandwidth", MODBW_TO_TR * 1e3 + 1),
         ("min_avg_amp", -1e-3),
         ("propagation_dir", (1, 0, 0)),
+        ("custom_phase_jump_time", -0.5),
     ],
 )
 def test_bad_init_local_channel(bad_param, bad_value):

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1729,10 +1729,16 @@ def test_sequence(reg, device, patch_plt_show):
     assert str(seq) == str(seq_)
 
 
+@pytest.mark.parametrize("custom_phase_jump_time", (None, 0))
 @pytest.mark.parametrize("eom", [False, True])
-def test_estimate_added_delay(eom):
+def test_estimate_added_delay(eom, custom_phase_jump_time):
+    ryd_ch_obj = dataclasses.replace(
+        AnalogDevice.channels["rydberg_global"],
+        custom_phase_jump_time=custom_phase_jump_time,
+    )
+    device = dataclasses.replace(AnalogDevice, channel_objects=(ryd_ch_obj,))
     reg = Register.square(2, 5)
-    seq = Sequence(reg, AnalogDevice)
+    seq = Sequence(reg, device)
     pulse_0 = Pulse.ConstantPulse(100, 1, 0, 0)
     pulse_pi_2 = Pulse.ConstantPulse(100, 1, 0, np.pi / 2)
 
@@ -1768,7 +1774,14 @@ def test_estimate_added_delay(eom):
     seq._add(pulse_0, "ising", "min-delay")
     first_pulse = seq._last("ising")
     assert first_pulse.ti == 0
-    delay = pulse_0.fall_time(ising_obj, eom) + ising_obj.phase_jump_time
+    phase_jump_time = (
+        custom_phase_jump_time
+        if custom_phase_jump_time is not None and not eom
+        else 2 * ising_obj.rise_time
+    )
+    if not eom:
+        assert ising_obj.phase_jump_time == phase_jump_time
+    delay = pulse_0.fall_time(ising_obj, eom) + phase_jump_time
     assert seq.estimate_added_delay(pulse_pi_2, "ising") == delay
     seq._add(pulse_pi_2, "ising", "min-delay")
     second_pulse = seq._last("ising")
@@ -2001,7 +2014,7 @@ def test_draw_slm_mask_in_ising(
             seq1.draw(
                 draw_qubit_det=True, draw_interp_pts=False, mode="output"
             )  # Drawing Sequence with only a DMM
-        assert len(record) == 9
+        assert len(record) == 5
         assert np.all(
             str(record[i].message).startswith(
                 "No modulation bandwidth defined"
@@ -2497,6 +2510,7 @@ def test_multiple_index_targets(reg):
     assert built_seq._last("ch0").targets == {"q2", "q3"}
 
 
+@pytest.mark.parametrize("custom_phase_jump_time", (None, 0))
 @pytest.mark.parametrize("check_wait_for_fall", (True, False))
 @pytest.mark.parametrize("correct_phase_drift", (True, False))
 @pytest.mark.parametrize("custom_buffer_time", (None, 400))
@@ -2506,6 +2520,7 @@ def test_eom_mode(
     custom_buffer_time,
     correct_phase_drift,
     check_wait_for_fall,
+    custom_phase_jump_time,
     patch_plt_show,
 ):
     # Setting custom_buffer_time
@@ -2515,7 +2530,9 @@ def test_eom_mode(
         custom_buffer_time=custom_buffer_time,
     )
     channels["rydberg_global"] = dataclasses.replace(
-        channels["rydberg_global"], eom_config=eom_config
+        channels["rydberg_global"],
+        eom_config=eom_config,
+        custom_phase_jump_time=custom_phase_jump_time,
     )
     dev_ = dataclasses.replace(
         mod_device, channel_ids=None, channel_objects=tuple(channels.values())
@@ -2583,8 +2600,7 @@ def test_eom_mode(
     )
     second_pulse_slot = seq._schedule["ch0"].last_pulse_slot()
     phase_buffer = (
-        eom_pulse.fall_time(ch0_obj, in_eom_mode=True)
-        + seq.declared_channels["ch0"].phase_jump_time
+        eom_pulse.fall_time(ch0_obj, in_eom_mode=True) + 2 * ch0_obj.rise_time
     )
     assert second_pulse_slot.ti == first_pulse_slot.tf + phase_buffer
     # Corrects the phase acquired during the phase buffer

--- a/tests/test_sequence_sampler.py
+++ b/tests/test_sequence_sampler.py
@@ -437,7 +437,15 @@ def test_extend_duration(seq_rydberg, with_custom_centered_phase):
     assert extended_short.slots == short.slots
 
 
-def test_phase_sampling(mod_device):
+@pytest.mark.parametrize("custom_phase_jump_time", [None, 0, 100])
+def test_phase_sampling(mod_device, custom_phase_jump_time):
+    ryd_ch_obj = replace(
+        mod_device.channels["rydberg_global"],
+        custom_phase_jump_time=custom_phase_jump_time,
+    )
+    mod_device = replace(
+        mod_device, channel_objects=(ryd_ch_obj,), channel_ids=None
+    )
     reg = pulser.Register.from_coordinates(np.array([[0.0, 0.0]]), prefix="q")
     seq = pulser.Sequence(reg, mod_device)
     seq.declare_channel("ch0", "rydberg_global")
@@ -462,7 +470,10 @@ def test_phase_sampling(mod_device):
     assert end_of_detuned_delay == full_duration - dt
 
     ph_jump_time = seq.declared_channels["ch0"].phase_jump_time
-    assert ph_jump_time > 0
+    if custom_phase_jump_time is not None:
+        assert ph_jump_time == custom_phase_jump_time
+    else:
+        assert ph_jump_time > 0
     expected_phase = np.zeros(full_duration)
     expected_phase[:dt] = 1.0
     transition2_3 = pulse3_start - ph_jump_time
@@ -473,12 +484,21 @@ def test_phase_sampling(mod_device):
     expected_phase[transition2_3:transition3_4] = 3.0
     expected_phase[transition3_4:] = 4.0
 
-    got_phase = (ch_samples_ := sample(seq).channel_samples["ch0"]).phase
-    np.testing.assert_array_equal(expected_phase, got_phase.as_array())
+    ch_samples = sample(seq).channel_samples["ch0"]
+    ch_samples_mod = sample(seq, modulation=True).channel_samples["ch0"]
+
+    np.testing.assert_array_equal(expected_phase, ch_samples.phase.as_array())
+    # No difference when modulated, just longer
+    np.testing.assert_array_equal(
+        expected_phase, ch_samples_mod.phase.as_array()[:full_duration]
+    )
 
     # Test centered phase
     expected_phase[expected_phase > np.pi] -= 2 * np.pi
-    np.testing.assert_array_equal(expected_phase, ch_samples_.centered_phase)
+    np.testing.assert_array_equal(expected_phase, ch_samples.centered_phase)
+    np.testing.assert_array_equal(
+        expected_phase, ch_samples_mod.centered_phase[:full_duration]
+    )
 
 
 @pytest.mark.parametrize("with_diff", [False, True])
@@ -648,5 +668,4 @@ def mod_seq(mod_device: Device) -> pulser.Sequence:
         Pulse.ConstantDetuning(BlackmanWaveform(1000, np.pi / 2), 1.0, 1.0),
         "ch0",
     )
-    seq.measure()
     return seq


### PR DESCRIPTION
- Adds `Channel.custom_phase_jump_time`
- Suppresses modulation of phase samples as it is not physically accurate

Closes #762.