### PR TITLE
Fix drawing of interpolated waveform on DMM

### DIFF
--- a/pulser-core/pulser/sequence/_seq_drawer.py
+++ b/pulser-core/pulser/sequence/_seq_drawer.py
@@ -1419,14 +1419,22 @@ def draw_sequence(
         if interp_pts:
             data[ch].interp_pts = dict(interp_pts)
 
-    for ch, axes in ch_axes.items():
-        ch_data = data[ch]
-
-        if draw_interp_pts:
+    if draw_interp_pts:
+        for ch, axes in ch_axes.items():
+            ch_data = data[ch]
+            # Construct map between quantity and indices
+            ind_map = {}
+            ax_ind = 0
+            for color_ind, qty in enumerate(CURVES_ORDER):
+                if ch_data.curves_on[qty]:
+                    ind_map[qty] = (ax_ind, color_ind)
+                    ax_ind += 1
             for qty in ("amplitude", "detuning"):
                 if qty in ch_data.interp_pts and ch_data.curves_on[qty]:
-                    ind = CURVES_ORDER.index(qty)
+                    ax_ind, color_ind = ind_map[qty]
                     pts = np.array(ch_data.interp_pts[qty])
-                    axes[ind].scatter(pts[:, 0], pts[:, 1], color=COLORS[ind])
+                    axes[ax_ind].scatter(
+                        pts[:, 0], pts[:, 1], color=COLORS[color_ind]
+                    )
 
     return (fig_reg, fig, fig_qubit, fig_legend)

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -2039,7 +2039,7 @@ def test_draw_slm_mask_in_ising(
         mask_time, 0, -100, 0
     )
     # Possible to modulate dmm_0_1 after slm declaration
-    seq1.add_dmm_detuning(RampWaveform(300, 0, -10), "dmm_0_1")
+    seq1.add_dmm_detuning(InterpolatedWaveform(300, (-10, 0)), "dmm_0_1")
     assert seq1._slm_mask_time == [0, mask_time]
     # Possible to add pulses afterwards,
     seq1.declare_channel("ryd_loc", "rydberg_local", ["q0", "q1"])
@@ -2050,7 +2050,7 @@ def test_draw_slm_mask_in_ising(
             mode,
             draw_qubit_det=draw_qubit_det,
             draw_qubit_amp=draw_qubit_amp,
-            draw_interp_pts=False,
+            draw_interp_pts=True,
             draw_register=draw_register,
             fig_name="local_quantities",
         )


### PR DESCRIPTION
The drawing of the interpolated points on a DMM channel failed because it was assuming the amplitude would always be plotted. This solution may be overkill but at least it does not make any assumptions anymore