### PR TITLE
Fix drawing of legends for local qubit quantities

### DIFF
--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -1939,7 +1939,7 @@ class Sequence(Generic[DeviceType]):
             if fig_qubit is not None:
                 fig_qubit.savefig(name + "_per_qubit" + ext, **kwargs_savefig)
                 if fig_legend is not None:
-                    fig_qubit.savefig(
+                    fig_legend.savefig(
                         name + "_per_qubit_legend" + ext, **kwargs_savefig
                     )
 


### PR DESCRIPTION
We used to be saving the quantities per qubit instead of the legend of the qubit quantities in "myfile_per_qubit_legend.png". This is solved with this PR. No need to be a hotfix. 