### PR TITLE
Add global phase shift

### DIFF
--- a/pulser-core/pulser/json/abstract_repr/serializer.py
+++ b/pulser-core/pulser/json/abstract_repr/serializer.py
@@ -169,14 +169,12 @@ def serialize_abstract_sequence(
 
     def unfold_targets(
         target_ids: QubitId | Collection[QubitId],
-    ) -> QubitId | list[QubitId] | None:
+    ) -> QubitId | list[QubitId]:
         if isinstance(target_ids, (int, str)):
             return target_ids
 
         targets = list(cast(Collection, target_ids))
-        if len(targets) == 0:
-            return []
-        return targets if len(targets) > 1 else targets[0]
+        return targets if len(targets) != 1 else targets[0]
 
     def convert_targets(
         target_ids: Union[QubitId, Collection[QubitId]],

--- a/pulser-core/pulser/json/abstract_repr/serializer.py
+++ b/pulser-core/pulser/json/abstract_repr/serializer.py
@@ -169,11 +169,13 @@ def serialize_abstract_sequence(
 
     def unfold_targets(
         target_ids: QubitId | Collection[QubitId],
-    ) -> QubitId | list[QubitId]:
+    ) -> QubitId | list[QubitId] | None:
         if isinstance(target_ids, (int, str)):
             return target_ids
 
         targets = list(cast(Collection, target_ids))
+        if len(targets) == 0:
+            return []
         return targets if len(targets) > 1 else targets[0]
 
     def convert_targets(

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -2172,6 +2172,14 @@ class Sequence(Generic[DeviceType]):
             )
 
         if not specific_targets:
+            warnings.warn(
+                "In version v1.4.0 the behavior of `Sequence.phase_shift` and "
+                "`Sequence.phase_shift_index` changed when called without "
+                "specifying targets. In previous versions calling without "
+                "targets wouldn't add a phase shift to any qubit, whereas in "
+                "versions v1.4.0 and up a phase shift will be added to all "
+                "qubits in the register if no specific targets are given."
+            )
             specific_targets = self._register.qubit_ids
             _index = False
 

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -2178,7 +2178,8 @@ class Sequence(Generic[DeviceType]):
                 "specifying targets. In previous versions calling without "
                 "targets wouldn't add a phase shift to any qubit, whereas in "
                 "versions v1.4.0 and up a phase shift will be added to all "
-                "qubits in the register if no specific targets are given."
+                "qubits in the register if no specific targets are given.",
+                stacklevel=3,
             )
             specific_targets = self._register.qubit_ids
             _index = False

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -1527,7 +1527,10 @@ class Sequence(Generic[DeviceType]):
 
         Args:
             phi: The intended phase shift (in rad).
-            targets: The ids of the qubits to apply the phase shift to.
+            specific_targets: The ids of the qubits to apply the phase shift
+                to. If no specific targets are given, the phase shift will be
+                applied to all qubits in the ``Register`` or
+                ``MappableRegister``.
             basis: The basis (i.e. electronic transition) to associate
                 the phase shift to. Must correspond to the basis of a declared
                 channel.
@@ -1549,10 +1552,12 @@ class Sequence(Generic[DeviceType]):
 
         Args:
             phi: The intended phase shift (in rad).
-            targets: The indices of the qubits to apply the phase shift to.
-                A qubit index is a number between 0 and the number of qubits.
-                It is then converted to a Qubit ID using the order in which
-                they were declared when instantiating the ``Register``
+            specific_targets: The indices of the qubits to apply the phase
+                shift to. A qubit index is a number between 0 and the number
+                of qubits. It is then converted to a Qubit ID using the order
+                in which they were declared when instantiating the ``Register``
+                or ``MappableRegister``. If no specific targets are given, the
+                phase shift will be applied to all qubits in the ``Register``
                 or ``MappableRegister``.
             basis: The basis (i.e. electronic transition) to associate
                 the phase shift to. Must correspond to the basis of a declared

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -1516,7 +1516,7 @@ class Sequence(Generic[DeviceType]):
     def phase_shift(
         self,
         phi: float | Parametrized,
-        *targets: QubitId,
+        *specific_targets: QubitId,
         basis: str = "digital",
     ) -> None:
         r"""Shifts the phase of a qubit's reference by 'phi', on a given basis.
@@ -1532,13 +1532,13 @@ class Sequence(Generic[DeviceType]):
                 the phase shift to. Must correspond to the basis of a declared
                 channel.
         """
-        self._phase_shift(phi, *targets, basis=basis)
+        self._phase_shift(phi, *specific_targets, basis=basis)
 
     @seq_decorators.store
     def phase_shift_index(
         self,
         phi: float | Parametrized,
-        *targets: int | Parametrized,
+        *specific_targets: int | Parametrized,
         basis: str = "digital",
     ) -> None:
         r"""Shifts the phase of a qubit's reference by 'phi', on a given basis.
@@ -1562,7 +1562,7 @@ class Sequence(Generic[DeviceType]):
             Cannot be used on non-parametrized sequences using a mappable
             register.
         """
-        self._phase_shift(phi, *targets, basis=basis, _index=True)
+        self._phase_shift(phi, *specific_targets, basis=basis, _index=True)
 
     @seq_decorators.store
     @seq_decorators.block_if_measured
@@ -2157,7 +2157,7 @@ class Sequence(Generic[DeviceType]):
     def _phase_shift(
         self,
         phi: float | Parametrized,
-        *targets: QubitId | int | Parametrized,
+        *specific_targets: QubitId | int | Parametrized,
         basis: str,
         _index: bool = False,
     ) -> None:
@@ -2165,7 +2165,14 @@ class Sequence(Generic[DeviceType]):
             raise ValueError(
                 f"No declared channel targets the given 'basis' ('{basis}')."
             )
-        target_ids = self._check_qubits_give_ids(*targets, _index=_index)
+
+        if not specific_targets:
+            specific_targets = self._register.qubit_ids
+            _index = False
+
+        target_ids = self._check_qubits_give_ids(
+            *specific_targets, _index=_index
+        )
 
         if not self.is_parametrized():
             phi = float(cast(float, phi))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,3 +91,11 @@ def patch_plt_show(monkeypatch):
     plt.close("all")
     # Closes a figure instead of showing it
     monkeypatch.setattr(plt, "show", plt.close)
+
+
+@pytest.fixture()
+def catch_phase_shift_warning():
+    return pytest.warns(
+        UserWarning,
+        match="In version v1.4.0 the behavior of `Sequence.phase_shift`",
+    )

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -642,7 +642,7 @@ class TestSerialization:
 
         seq.align("digital", "rydberg")
         seq.add(pi_pulse, "rydberg")
-        seq.phase_shift(1.0, "control", "target", basis="ground-rydberg")
+        seq.phase_shift(1.0, basis="ground-rydberg")
         seq.target({"target"}, "rydberg")
         seq.add(two_pi_pulse, "rydberg")
 
@@ -1758,6 +1758,12 @@ class TestDeserialization:
                 "basis": "digital",
             },
             {
+                "op": "phase_shift",
+                "phi": 2,
+                "targets": [],
+                "basis": "digital",
+            },
+            {
                 "op": "pulse",
                 "channel": "global",
                 "phase": 1,
@@ -1978,6 +1984,12 @@ class TestDeserialization:
                 "basis": "ground-rydberg",
             },
             {
+                "op": "phase_shift",
+                "phi": var1,
+                "targets": [],
+                "basis": "ground-rydberg",
+            },
+            {
                 "op": "pulse",
                 "channel": "global",
                 "phase": var1,
@@ -2049,10 +2061,13 @@ class TestDeserialization:
             assert c.name == "phase_shift_index"
             # phi is variable
             assert isinstance(c.args[0], VariableItem)
-            # qubit 1 is fixed
-            assert c.args[1] == 2
-            # qubit 2 is variable
-            assert isinstance(c.args[2], VariableItem)
+            if op["targets"]:
+                # qubit 1 is fixed
+                assert c.args[1] == 2
+                # qubit 2 is variable
+                assert isinstance(c.args[2], VariableItem)
+            else:
+                assert len(c.args) == 1
             # basis is fixed
             assert c.kwargs["basis"] == "ground-rydberg"
         elif "pulse" in op["op"]:

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 from __future__ import annotations
 
+import contextlib
 import json
 import re
-import warnings
 from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import replace
@@ -604,7 +604,7 @@ class TestSerialization:
         return TriangularLatticeLayout(50, 6)
 
     @pytest.fixture(params=[DigitalAnalogDevice, MockDevice])
-    def sequence(self, request):
+    def sequence(self, request, catch_phase_shift_warning):
         qubits = {"control": (-2, 0), "target": (2, 0)}
         reg = Register(qubits)
         device = request.param
@@ -643,10 +643,7 @@ class TestSerialization:
 
         seq.align("digital", "rydberg")
         seq.add(pi_pulse, "rydberg")
-        with pytest.warns(
-            UserWarning,
-            match="In version v1.4.0 the behavior of `Sequence.phase_shift`",
-        ):
+        with catch_phase_shift_warning:
             seq.phase_shift(1.0, basis="ground-rydberg")
         seq.target({"target"}, "rydberg")
         seq.add(two_pi_pulse, "rydberg")
@@ -657,11 +654,8 @@ class TestSerialization:
         return seq
 
     @pytest.fixture
-    def abstract(self, sequence):
-        with pytest.warns(
-            UserWarning,
-            match="In version v1.4.0 the behavior of `Sequence.phase_shift`",
-        ):
+    def abstract(self, sequence, catch_phase_shift_warning):
+        with catch_phase_shift_warning:
             abstract_repr = sequence.to_abstract_repr(
                 target_atom=1,
                 amps=[np.pi, 2 * np.pi],
@@ -1792,16 +1786,17 @@ class TestDeserialization:
         ],
         ids=_get_op,
     )
-    def test_deserialize_non_parametrized_op(self, op):
+    def test_deserialize_non_parametrized_op(
+        self, op, catch_phase_shift_warning
+    ):
         s = _get_serialized_seq(
             operations=[op], device=json.loads(MockDevice.to_abstract_repr())
         )
-        with warnings.catch_warnings():
-            if op["op"] == "phase_shift":
-                warnings.filterwarnings(
-                    "ignore",
-                    "In version v1.4.0 the behavior of `Sequence.phase_shift`",
-                )
+        with (
+            catch_phase_shift_warning
+            if (op["op"] == "phase_shift" and not op["targets"])
+            else contextlib.nullcontext()
+        ):
             _check_roundtrip(s)
             seq = Sequence.from_abstract_repr(json.dumps(s))
 
@@ -2041,7 +2036,7 @@ class TestDeserialization:
         ],
         ids=_get_op,
     )
-    def test_deserialize_parametrized_op(self, op):
+    def test_deserialize_parametrized_op(self, op, catch_phase_shift_warning):
         s = _get_serialized_seq(
             operations=[op],
             variables={
@@ -2049,12 +2044,11 @@ class TestDeserialization:
                 "var2": {"type": "int", "value": [44]},
             },
         )
-        with warnings.catch_warnings():
-            if op["op"] == "phase_shift" and not op["targets"]:
-                warnings.filterwarnings(
-                    "ignore",
-                    "In version v1.4.0 the behavior of `Sequence.phase_shift`",
-                )
+        with (
+            catch_phase_shift_warning
+            if (op["op"] == "phase_shift" and not op["targets"])
+            else contextlib.nullcontext()
+        ):
             _check_roundtrip(s)
             seq = Sequence.from_abstract_repr(json.dumps(s))
 

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -643,11 +643,10 @@ class TestSerialization:
 
         seq.align("digital", "rydberg")
         seq.add(pi_pulse, "rydberg")
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                "In version v1.4.0 the behavior of `Sequence.phase_shift`",
-            )
+        with pytest.warns(
+            UserWarning,
+            match="In version v1.4.0 the behavior of `Sequence.phase_shift`",
+        ):
             seq.phase_shift(1.0, basis="ground-rydberg")
         seq.target({"target"}, "rydberg")
         seq.add(two_pi_pulse, "rydberg")
@@ -659,11 +658,10 @@ class TestSerialization:
 
     @pytest.fixture
     def abstract(self, sequence):
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                "In version v1.4.0 the behavior of `Sequence.phase_shift`",
-            )
+        with pytest.warns(
+            UserWarning,
+            match="In version v1.4.0 the behavior of `Sequence.phase_shift`",
+        ):
             abstract_repr = sequence.to_abstract_repr(
                 target_atom=1,
                 amps=[np.pi, 2 * np.pi],

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -573,6 +573,7 @@ def test_switch_register(
         seq.switch_register(Register(dict(q1=(0, 0), qN=(10, 10))))
 
     seq.declare_channel("ryd", "rydberg_global")
+    seq.phase_shift(3)
     seq.add(pulse, "ryd", protocol="no-delay")
 
     if mappable_reg:
@@ -595,6 +596,11 @@ def test_switch_register(
     assert new_seq.is_register_mappable() == mappable_reg
     assert new_seq._calls[1:] == seq._calls[1:]  # Excludes __init__
     assert new_seq._to_build_calls == seq._to_build_calls
+
+    if not parametrized and not mappable_reg:
+        assert new_seq.current_phase_ref("foo") == 3
+        assert new_seq.current_phase_ref("q0") == 3
+        assert seq.current_phase_ref("q1") == 3
 
     build_kwargs = {}
     if parametrized:

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -18,6 +18,7 @@ import dataclasses
 import itertools
 import json
 import re
+import warnings
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -573,7 +574,11 @@ def test_switch_register(
         seq.switch_register(Register(dict(q1=(0, 0), qN=(10, 10))))
 
     seq.declare_channel("ryd", "rydberg_global")
-    seq.phase_shift(3)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", "In version v1.4.0 the behavior of `Sequence.phase_shift"
+        )
+        seq.phase_shift(3)
     seq.add(pulse, "ryd", protocol="no-delay")
 
     if mappable_reg:
@@ -589,7 +594,12 @@ def test_switch_register(
         context_manager = contextlib.nullcontext()
 
     with context_manager:
-        new_seq = seq.switch_register(new_reg)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                "In version v1.4.0 the behavior of `Sequence.phase_shift`",
+            )
+            new_seq = seq.switch_register(new_reg)
     assert seq.declared_variables or not parametrized
     assert seq.declared_variables == new_seq.declared_variables
     assert new_seq.is_parametrized() == parametrized
@@ -608,7 +618,12 @@ def test_switch_register(
     if mappable_reg:
         build_kwargs["qubits"] = {"q0": 1, "q1": 4}
     if build_kwargs:
-        new_seq = new_seq.build(**build_kwargs)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                "In version v1.4.0 the behavior of `Sequence.phase_shift`",
+            )
+            new_seq = new_seq.build(**build_kwargs)
 
     assert isinstance(
         (raman_pulse_slot := new_seq._schedule["raman"][1]).type, Pulse
@@ -625,7 +640,13 @@ def test_switch_register(
     if config_det_map:
         if with_slm_mask:
             if parametrized:
-                seq = seq.build(**build_kwargs)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore",
+                        "In version v1.4.0 the behavior of "
+                        "`Sequence.phase_shift`",
+                    )
+                    seq = seq.build(**build_kwargs)
             assert np.any(reg.qubits["q0"] != new_reg.qubits["q0"])
             assert "dmm_0" in seq.declared_channels
             prev_qubit_wmap = seq._schedule[
@@ -1464,10 +1485,20 @@ def test_phase(reg, device, det_map):
 
     # Test global phase shift
     seq.declare_channel("ch1", "rydberg_global")
-    seq.phase_shift(1, basis="ground-rydberg")
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            "In version v1.4.0 the behavior of `Sequence.phase_shift`",
+        )
+        seq.phase_shift(1, basis="ground-rydberg")
     for q in seq.qubit_info:
         assert seq.current_phase_ref(q, "ground-rydberg") == 1
-    seq.phase_shift(1)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            "In version v1.4.0 the behavior of `Sequence.phase_shift`",
+        )
+        seq.phase_shift(1)
     assert seq.current_phase_ref("q1", "digital") == 0
     assert seq.current_phase_ref("q10", "digital") == 1
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1456,11 +1456,12 @@ def test_phase(reg, device, det_map):
     with pytest.raises(ValueError, match="ids have to be qubit ids"):
         seq.phase_shift(np.pi, "q1", "q4", "q100")
 
+    # Test global phase shift
     seq.declare_channel("ch1", "rydberg_global")
-    seq.phase_shift(1, *seq._qids, basis="ground-rydberg")
+    seq.phase_shift(1, basis="ground-rydberg")
     for q in seq.qubit_info:
         assert seq.current_phase_ref(q, "ground-rydberg") == 1
-    seq.phase_shift(1, *seq._qids)
+    seq.phase_shift(1)
     assert seq.current_phase_ref("q1", "digital") == 0
     assert seq.current_phase_ref("q10", "digital") == 1
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -18,7 +18,6 @@ import dataclasses
 import itertools
 import json
 import re
-import warnings
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -574,10 +573,10 @@ def test_switch_register(
         seq.switch_register(Register(dict(q1=(0, 0), qN=(10, 10))))
 
     seq.declare_channel("ryd", "rydberg_global")
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore", "In version v1.4.0 the behavior of `Sequence.phase_shift"
-        )
+    with pytest.warns(
+        UserWarning,
+        match="In version v1.4.0 the behavior of `Sequence.phase_shift`",
+    ):
         seq.phase_shift(3)
     seq.add(pulse, "ryd", protocol="no-delay")
 
@@ -594,11 +593,10 @@ def test_switch_register(
         context_manager = contextlib.nullcontext()
 
     with context_manager:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                "In version v1.4.0 the behavior of `Sequence.phase_shift`",
-            )
+        with pytest.warns(
+            UserWarning,
+            match="In version v1.4.0 the behavior of `Sequence.phase_shift`",
+        ):
             new_seq = seq.switch_register(new_reg)
     assert seq.declared_variables or not parametrized
     assert seq.declared_variables == new_seq.declared_variables
@@ -618,11 +616,10 @@ def test_switch_register(
     if mappable_reg:
         build_kwargs["qubits"] = {"q0": 1, "q1": 4}
     if build_kwargs:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                "In version v1.4.0 the behavior of `Sequence.phase_shift`",
-            )
+        with pytest.warns(
+            UserWarning,
+            match="In version v1.4.0 the behavior of `Sequence.phase_shift`",
+        ):
             new_seq = new_seq.build(**build_kwargs)
 
     assert isinstance(
@@ -640,12 +637,11 @@ def test_switch_register(
     if config_det_map:
         if with_slm_mask:
             if parametrized:
-                with warnings.catch_warnings():
-                    warnings.filterwarnings(
-                        "ignore",
-                        "In version v1.4.0 the behavior of "
-                        "`Sequence.phase_shift`",
-                    )
+                with pytest.warns(
+                    UserWarning,
+                    match="In version v1.4.0 the behavior of "
+                    "`Sequence.phase_shift`",
+                ):
                     seq = seq.build(**build_kwargs)
             assert np.any(reg.qubits["q0"] != new_reg.qubits["q0"])
             assert "dmm_0" in seq.declared_channels
@@ -1485,19 +1481,17 @@ def test_phase(reg, device, det_map):
 
     # Test global phase shift
     seq.declare_channel("ch1", "rydberg_global")
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            "In version v1.4.0 the behavior of `Sequence.phase_shift`",
-        )
+    with pytest.warns(
+        UserWarning,
+        match="In version v1.4.0 the behavior of `Sequence.phase_shift`",
+    ):
         seq.phase_shift(1, basis="ground-rydberg")
     for q in seq.qubit_info:
         assert seq.current_phase_ref(q, "ground-rydberg") == 1
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            "In version v1.4.0 the behavior of `Sequence.phase_shift`",
-        )
+    with pytest.warns(
+        UserWarning,
+        match="In version v1.4.0 the behavior of `Sequence.phase_shift`",
+    ):
         seq.phase_shift(1)
     assert seq.current_phase_ref("q1", "digital") == 0
     assert seq.current_phase_ref("q10", "digital") == 1

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -548,7 +548,12 @@ def test_ising_mode(
 @pytest.mark.parametrize("mappable_reg", [False, True])
 @pytest.mark.parametrize("parametrized", [False, True])
 def test_switch_register(
-    reg, mappable_reg, parametrized, starts_mappable, config_det_map
+    reg,
+    mappable_reg,
+    parametrized,
+    starts_mappable,
+    config_det_map,
+    catch_phase_shift_warning,
 ):
     pulse = Pulse.ConstantPulse(1000, 1, -1, 2)
     with_slm_mask = not starts_mappable and not mappable_reg
@@ -573,10 +578,7 @@ def test_switch_register(
         seq.switch_register(Register(dict(q1=(0, 0), qN=(10, 10))))
 
     seq.declare_channel("ryd", "rydberg_global")
-    with pytest.warns(
-        UserWarning,
-        match="In version v1.4.0 the behavior of `Sequence.phase_shift`",
-    ):
+    with catch_phase_shift_warning:
         seq.phase_shift(3)
     seq.add(pulse, "ryd", protocol="no-delay")
 
@@ -593,10 +595,7 @@ def test_switch_register(
         context_manager = contextlib.nullcontext()
 
     with context_manager:
-        with pytest.warns(
-            UserWarning,
-            match="In version v1.4.0 the behavior of `Sequence.phase_shift`",
-        ):
+        with catch_phase_shift_warning:
             new_seq = seq.switch_register(new_reg)
     assert seq.declared_variables or not parametrized
     assert seq.declared_variables == new_seq.declared_variables
@@ -616,10 +615,7 @@ def test_switch_register(
     if mappable_reg:
         build_kwargs["qubits"] = {"q0": 1, "q1": 4}
     if build_kwargs:
-        with pytest.warns(
-            UserWarning,
-            match="In version v1.4.0 the behavior of `Sequence.phase_shift`",
-        ):
+        with catch_phase_shift_warning:
             new_seq = new_seq.build(**build_kwargs)
 
     assert isinstance(
@@ -637,11 +633,7 @@ def test_switch_register(
     if config_det_map:
         if with_slm_mask:
             if parametrized:
-                with pytest.warns(
-                    UserWarning,
-                    match="In version v1.4.0 the behavior of "
-                    "`Sequence.phase_shift`",
-                ):
+                with catch_phase_shift_warning:
                     seq = seq.build(**build_kwargs)
             assert np.any(reg.qubits["q0"] != new_reg.qubits["q0"])
             assert "dmm_0" in seq.declared_channels
@@ -1458,7 +1450,7 @@ def test_delay_min_duration(reg, device):
     )
 
 
-def test_phase(reg, device, det_map):
+def test_phase(reg, device, det_map, catch_phase_shift_warning):
     seq = Sequence(reg, device)
     seq.declare_channel("ch0", "raman_local", initial_target="q0")
     seq.phase_shift(-1, "q0", "q1")
@@ -1481,17 +1473,11 @@ def test_phase(reg, device, det_map):
 
     # Test global phase shift
     seq.declare_channel("ch1", "rydberg_global")
-    with pytest.warns(
-        UserWarning,
-        match="In version v1.4.0 the behavior of `Sequence.phase_shift`",
-    ):
+    with catch_phase_shift_warning:
         seq.phase_shift(1, basis="ground-rydberg")
     for q in seq.qubit_info:
         assert seq.current_phase_ref(q, "ground-rydberg") == 1
-    with pytest.warns(
-        UserWarning,
-        match="In version v1.4.0 the behavior of `Sequence.phase_shift`",
-    ):
+    with catch_phase_shift_warning:
         seq.phase_shift(1)
     assert seq.current_phase_ref("q1", "digital") == 0
     assert seq.current_phase_ref("q10", "digital") == 1


### PR DESCRIPTION
This proposes to change `Sequence.phase_shift` to accept not setting a specific target, so that the phase shift is applied to all qubits in the `Register`.
I noticed that it wouldn't raise an error if no targets were supplied in the current version. Instead, it just wouldn't have any effect as no targets have been selected. This behavior changes if this PR is merged. I don't foresee backwards compatibility issues because of it, because the function shouldn't have been used if no targets were supplied.

This PR Closes #827 
