### PR TITLE
Add (de)serializer to Results

### DIFF
--- a/pulser-core/pulser/json/abstract_repr/serializer.py
+++ b/pulser-core/pulser/json/abstract_repr/serializer.py
@@ -34,6 +34,13 @@ if TYPE_CHECKING:
     from pulser.sequence import Sequence
     from pulser.sequence._call import _Call
 
+has_torch: bool
+try:
+    import torch
+    has_torch = True
+except ImportError: # pragma: no cover
+    has_torch = False
+
 
 class AbstractReprEncoder(json.JSONEncoder):
     """The custom encoder for abstract representation of Pulser objects."""
@@ -50,6 +57,11 @@ class AbstractReprEncoder(json.JSONEncoder):
             return list(o)
         elif isinstance(o, complex):
             return dict(real=o.real, imag=o.imag)
+        elif has_torch and isinstance(o, torch.Tensor):
+            if len(o.shape) == 0:
+                return o.item()
+            else:
+                return cast(list, o.tolist())
         else:  # pragma: no cover
             return cast(dict, json.JSONEncoder.default(self, o))
 

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -88,6 +88,45 @@ phys_Chadoq2 = replace(
 )
 
 
+@pytest.mark.parametrize(        
+    "test_torch",
+    [
+        True,
+        False
+    ],
+)
+def test_abstract_repr_encoder(test_torch:bool):
+    encoder = AbstractReprEncoder()
+    
+    if not test_torch:
+        class Dummy:
+            def _to_abstract_repr(self):
+                return "_to_abstract_repr"
+
+        result = encoder.default(Dummy())
+        assert result == "_to_abstract_repr"
+
+        result = encoder.default(np.array([1,2,3,4]))
+        assert result == [1,2,3,4]
+
+        result = encoder.default(np.intp(5))
+        assert result == 5
+
+        result = encoder.default({1,2,3,4})
+        assert result == [1,2,3,4]
+
+        result = encoder.default(1. + 2.j)
+        assert result == dict(real=1., imag=2.)
+    else:
+        torch = pytest.importorskip("torch")
+        
+        result = encoder.default(torch.tensor(5.))
+        assert result == 5.
+
+        result = encoder.default(torch.tensor([1,2,3,4]))
+        assert result == [1,2,3,4]
+
+
 @pytest.mark.parametrize(
     "layout",
     [


### PR DESCRIPTION
- Update the AbstractReprEncoder to support `torch.Tensor` if `torch` exists
- add `to_abstract_repr` and `from_abstract_repr` to `Results`
- tests