### PR TITLE
[DevEx] Rework (de)serialization exceptions

### DIFF
--- a/pulser-core/pulser/backend/default_observables.py
+++ b/pulser-core/pulser/backend/default_observables.py
@@ -25,7 +25,7 @@ from pulser.backend.config import EmulationConfig
 from pulser.backend.observable import Observable
 from pulser.backend.operator import Operator, OperatorType
 from pulser.backend.state import Eigenstate, State, StateType
-from pulser.json.exceptions import AbstractReprError
+from pulser.exceptions.serialization import AbstractReprError
 
 
 class StateResult(Observable):

--- a/pulser-core/pulser/backend/operator.py
+++ b/pulser-core/pulser/backend/operator.py
@@ -19,7 +19,7 @@ from collections.abc import Collection, Mapping, Sequence
 from typing import Any, Generic, Type, TypeVar
 
 from pulser.backend.state import Eigenstate, State
-from pulser.json.exceptions import AbstractReprError
+from pulser.exceptions.serialization import AbstractReprError
 
 ArgScalarType = TypeVar("ArgScalarType")
 ReturnScalarType = TypeVar("ReturnScalarType")

--- a/pulser-core/pulser/backend/state.py
+++ b/pulser-core/pulser/backend/state.py
@@ -22,7 +22,7 @@ from typing import Any, Generic, Literal, SupportsFloat, Type, TypeVar, Union
 import numpy as np
 
 from pulser.channels.base_channel import States
-from pulser.json.exceptions import AbstractReprError
+from pulser.exceptions.serialization import AbstractReprError
 
 Eigenstate = Union[States, Literal["0", "1"]]
 

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -30,7 +30,8 @@ import pulser.math as pm
 from pulser.channels.base_channel import Channel, States, get_states_from_bases
 from pulser.channels.dmm import DMM
 from pulser.devices.interaction_coefficients import c6_dict
-from pulser.exceptions import (
+from pulser.exceptions.base import PulserValueError
+from pulser.exceptions.sequence import (
     AtomsNumberError,
     DimensionChoiceError,
     DimensionPositionsTooHighError,
@@ -38,7 +39,6 @@ from pulser.exceptions import (
     DistanceError,
     MaxNumberOfTrapsError,
     OptimalLayoutFillingError,
-    PulserValueError,
     QubitsNumberError,
     RadiusError,
     RydbergLevelError,

--- a/pulser-core/pulser/exceptions/__init__.py
+++ b/pulser-core/pulser/exceptions/__init__.py
@@ -1,0 +1,7 @@
+"""Errors raised by Pulser.
+
+Note: As of this writing, the specific error strings for these classes are
+maintained for backwards compatibility. However, they may change in a future
+version, so if you need to catch a specific error, you should rather rely
+upon its class and fields.
+"""

--- a/pulser-core/pulser/exceptions/base.py
+++ b/pulser-core/pulser/exceptions/base.py
@@ -1,0 +1,23 @@
+"""Base exceptions raised by Pulser."""
+
+
+class PulserError(Exception):
+    """Any error raised by Pulser."""
+
+    pass
+
+
+class PulserValueError(ValueError, PulserError):
+    """A ValueError raised by Pulser.
+
+    Usage:
+        As of this writing, most of the errors raised by Pulser are subclasses
+        of PulserValueError, as we rely on them being catchable as ValueError
+        for the sake of backwards compatibility.
+
+        This is *only* for the sake of backwards compatibility. New errors
+        raised by Pulser are expected to be subclasses of `PulserError` and
+        will often *not* be subclasses of `PulserValueError`.
+    """
+
+    pass

--- a/pulser-core/pulser/exceptions/sequence.py
+++ b/pulser-core/pulser/exceptions/sequence.py
@@ -1,10 +1,4 @@
-"""Errors raised by Pulser.
-
-Note: As of this writing, the specific error strings for these classes are
-maintained for backwards compatibility. However, they may change in a future
-version, so if you need to catch a specific error, you should rather rely
-upon its class and fields.
-"""
+"""Errors raised because a sequence is invalid."""
 
 # Avoid circular dependencies due to type hints, part 1.
 from __future__ import annotations
@@ -12,32 +6,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Sequence
 
+from pulser.exceptions.base import PulserValueError
+
 if TYPE_CHECKING:
     # Avoid circular dependencies due to type hints, part 2.
     from pulser.devices._device_datacls import BaseDevice
     from pulser.register.base_register import QubitId, RegisterLayout
-
-
-class PulserError(Exception):
-    """Any error raised by Pulser."""
-
-    pass
-
-
-class PulserValueError(ValueError, PulserError):
-    """A ValueError raised by Pulser.
-
-    Usage:
-        As of this writing, most of the errors raised by Pulser are subclasses
-        of PulserValueError, as we rely on them being catchable as ValueError
-        for the sake of backwards compatibility.
-
-        This is *only* for the sake of backwards compatibility. New errors
-        raised by Pulser are expected to be subclasses of `PulserError` and
-        will often *not* be subclasses of `PulserValueError`.
-    """
-
-    pass
 
 
 @dataclass

--- a/pulser-core/pulser/exceptions/serialization.py
+++ b/pulser-core/pulser/exceptions/serialization.py
@@ -1,0 +1,71 @@
+"""Errors raised when serialization or deserializing values."""
+
+from dataclasses import dataclass
+
+from pulser.exceptions.base import PulserError
+
+
+class SerializationError(PulserError):
+    """Exception raised when sequence serialization fails."""
+
+    pass
+
+
+class SerializationSupportMissing(SerializationError):
+    """Attempting to serialize a class that we don't know how to serialize."""
+
+    pass
+
+
+@dataclass
+class SerializationSupportModuleMissing(SerializationSupportMissing):
+    """Error: we don't know how to serialize values from this module."""
+
+    module: str
+
+    def __str__(self) -> str:
+        return f"No serialization support for module '{self.module}'."
+
+
+@dataclass
+class SerializationSupportAttributeMissing(SerializationSupportMissing):
+    """Error: we don't know how to serialize values from this submodule."""
+
+    module: str
+    submodule: str
+
+    def __str__(self) -> str:
+        return (
+            "No serialization support for attributes of "
+            f"'{self.module}.{self.submodule}'."
+        )
+
+
+@dataclass
+class SerializationSupportClassMissing(SerializationSupportMissing):
+    """Error: we don't know how to serialize values of this class."""
+
+    module: str
+    class_name: str
+
+    def __str__(self) -> str:
+        return (
+            "No serialization support for "
+            f"'{self.module}.{self.class_name}'."
+        )
+
+
+class AbstractReprError(PulserError):
+    """Exception raised for abstract representation errors.
+
+    Raised when an error occurs during the serialization to or deserialization
+    from the abstract representation.
+    """
+
+    pass
+
+
+class DeserializeDeviceError(PulserError):
+    """Exception raised when device deserialization fails."""
+
+    pass

--- a/pulser-core/pulser/json/abstract_repr/deserializer.py
+++ b/pulser-core/pulser/json/abstract_repr/deserializer.py
@@ -32,12 +32,15 @@ from pulser.channels.eom import (
 )
 from pulser.devices import Device, VirtualDevice
 from pulser.devices._device_datacls import PARAMS_WITH_ABSTR_REPR
+from pulser.exceptions.serialization import (
+    AbstractReprError,
+    DeserializeDeviceError,
+)
 from pulser.json.abstract_repr.signatures import (
     BINARY_OPERATORS,
     UNARY_OPERATORS,
 )
 from pulser.json.abstract_repr.validation import validate_abstract_repr
-from pulser.json.exceptions import AbstractReprError, DeserializeDeviceError
 from pulser.json.utils import get_dataclass_defaults
 from pulser.parametrized import ParamObj, Variable
 from pulser.pulse import Pulse

--- a/pulser-core/pulser/json/abstract_repr/serializer.py
+++ b/pulser-core/pulser/json/abstract_repr/serializer.py
@@ -23,9 +23,9 @@ from typing import TYPE_CHECKING, Any, Union, cast
 import numpy as np
 
 import pulser
+from pulser.exceptions.serialization import AbstractReprError
 from pulser.json.abstract_repr.signatures import SIGNATURES
 from pulser.json.abstract_repr.validation import validate_abstract_repr
-from pulser.json.exceptions import AbstractReprError
 from pulser.json.utils import stringify_qubit_ids
 
 if TYPE_CHECKING:

--- a/pulser-core/pulser/json/abstract_repr/validation.py
+++ b/pulser-core/pulser/json/abstract_repr/validation.py
@@ -21,8 +21,8 @@ from packaging.version import InvalidVersion, Version
 from referencing import Registry, Resource
 
 import pulser
+from pulser.exceptions.serialization import AbstractReprError
 from pulser.json.abstract_repr import SCHEMAS, SCHEMAS_PATH
-from pulser.json.exceptions import AbstractReprError
 
 LEGACY_JSONSCHEMA = (
     Version("4.18") > Version(version("jsonschema")) >= Version("4.17.3")

--- a/pulser-core/pulser/json/exceptions.py
+++ b/pulser-core/pulser/json/exceptions.py
@@ -11,26 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Custom exceptions for serialization errors."""
+"""Custom exceptions for serialization errors.
 
+Note: This module has migrated to pulser.exceptions.serialization. Please
+use the new path for any future work.
+"""
 
-class SerializationError(Exception):
-    """Exception raised when sequence serialization fails."""
+import warnings
 
-    pass
+from pulser.exceptions import serialization
 
+warnings.warn(
+    "module pulser.json.exceptions is deprecated, "
+    "please migrate your code to "
+    "use pulser.exceptions.serialization",
+    category=DeprecationWarning,
+    stacklevel=2,
+)
 
-class AbstractReprError(Exception):
-    """Exception raised for abstract representation errors.
-
-    Raised when an error occurs during the serialization to or deserialization
-    from the abstract representation.
-    """
-
-    pass
-
-
-class DeserializeDeviceError(Exception):
-    """Exception raised when device deserialization fails."""
-
-    pass
+# For backwards compatibility, re-export the exceptions
+# from their new module `pulser.exceptions`.
+SerializationError = serialization.SerializationError
+AbstractReprError = serialization.AbstractReprError
+DeserializeDeviceError = serialization.DeserializeDeviceError

--- a/pulser-core/pulser/json/supported.py
+++ b/pulser-core/pulser/json/supported.py
@@ -18,7 +18,11 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 import pulser.devices as devices
-from pulser.json.exceptions import SerializationError
+from pulser.exceptions.serialization import (
+    SerializationSupportAttributeMissing,
+    SerializationSupportClassMissing,
+    SerializationSupportModuleMissing,
+)
 
 SUPPORTED_BUILTINS = ("float", "int", "str", "set")
 
@@ -106,20 +110,17 @@ def validate_serialization(obj_dict: Mapping[str, Any]) -> None:
         raise TypeError("Invalid 'obj_dict'.")
 
     if module_str not in SUPPORTED_MODULES:
-        raise SerializationError(
-            f"No serialization support for module '{module_str}'."
-        )
+        raise SerializationSupportModuleMissing(module=module_str)
 
     if "__submodule__" in obj_dict:
         submodule_str = obj_dict["__submodule__"]
         if submodule_str not in SUPPORTS_SUBMODULE:
-            raise SerializationError(
-                "No serialization support for attributes of "
-                f"'{module_str}.{submodule_str}'."
+            raise SerializationSupportAttributeMissing(
+                module=module_str, submodule=submodule_str
             )
         obj_str = submodule_str
 
     if obj_str not in SUPPORTED_MODULES[module_str]:
-        raise SerializationError(
-            f"No serialization support for '{module_str}.{obj_str}'."
+        raise SerializationSupportClassMissing(
+            module=module_str, class_name=obj_str
         )

--- a/pulser-core/pulser/json/utils.py
+++ b/pulser-core/pulser/json/utils.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, Optional, Sequence
 import numpy as np
 
 import pulser
-from pulser.json.exceptions import AbstractReprError
+from pulser.exceptions.serialization import AbstractReprError
 
 if TYPE_CHECKING:  # pragma: no cover
     from pulser.register import QubitId

--- a/pulser-core/pulser/parametrized/paramobj.py
+++ b/pulser-core/pulser/parametrized/paramobj.py
@@ -26,13 +26,13 @@ import numpy as np
 
 import pulser.math as pm
 import pulser.parametrized
+from pulser.exceptions.serialization import AbstractReprError
 from pulser.json.abstract_repr.serializer import abstract_repr
 from pulser.json.abstract_repr.signatures import (
     BINARY_OPERATORS,
     SIGNATURES,
     UNARY_OPERATORS,
 )
-from pulser.json.exceptions import AbstractReprError
 from pulser.json.utils import obj_to_dict
 from pulser.parametrized import Parametrized
 

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -45,12 +45,12 @@ from pulser.channels.base_channel import Channel, States, get_states_from_bases
 from pulser.channels.dmm import DMM, _dmm_id_from_name, _get_dmm_name
 from pulser.channels.eom import RydbergBeam, RydbergEOM
 from pulser.devices._device_datacls import BaseDevice
+from pulser.exceptions.serialization import AbstractReprError
 from pulser.json.abstract_repr.deserializer import (
     deserialize_abstract_sequence,
 )
 from pulser.json.abstract_repr.serializer import serialize_abstract_sequence
 from pulser.json.coders import PulserDecoder, PulserEncoder
-from pulser.json.exceptions import AbstractReprError
 from pulser.json.utils import obj_to_dict
 from pulser.parametrized import Parametrized, Variable
 from pulser.parametrized.variable import VariableItem

--- a/pulser-core/pulser/waveforms.py
+++ b/pulser-core/pulser/waveforms.py
@@ -32,8 +32,8 @@ from matplotlib.axes import Axes
 from numpy.typing import ArrayLike
 
 import pulser.math as pm
+from pulser.exceptions.serialization import AbstractReprError
 from pulser.json.abstract_repr.serializer import abstract_repr
-from pulser.json.exceptions import AbstractReprError
 from pulser.json.utils import obj_to_dict
 from pulser.parametrized import Parametrized, ParamObj
 from pulser.parametrized.decorators import parametrize

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,7 +160,7 @@ class Helpers:
 
     @staticmethod
     def raises_all(
-        expected: list[type[Exception]], match: str
+        expected: list[type[Exception]], match: Optional[str] = None
     ) -> _RaisesAllContext:
         """Utility: check exceptions raised by a block.
 

--- a/tests/pulser_simulation/test_qutip_state_op.py
+++ b/tests/pulser_simulation/test_qutip_state_op.py
@@ -20,8 +20,8 @@ import numpy as np
 import pytest
 import qutip
 
+from pulser.exceptions.serialization import AbstractReprError
 from pulser.json.abstract_repr.serializer import AbstractReprEncoder
-from pulser.json.exceptions import AbstractReprError
 from pulser_simulation import QutipOperator, QutipState
 
 

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -39,6 +39,10 @@ from pulser.devices import (
     MockDevice,
     VirtualDevice,
 )
+from pulser.exceptions.serialization import (
+    AbstractReprError,
+    DeserializeDeviceError,
+)
 from pulser.json.abstract_repr.deserializer import (
     VARIABLE_TYPE_MAP,
     deserialize_abstract_register,
@@ -48,7 +52,6 @@ from pulser.json.abstract_repr.serializer import (
     abstract_repr,
 )
 from pulser.json.abstract_repr.validation import validate_abstract_repr
-from pulser.json.exceptions import AbstractReprError, DeserializeDeviceError
 from pulser.noise_model import _LEGACY_DEFAULTS, NoiseModel
 from pulser.parametrized.decorators import parametrize
 from pulser.parametrized.paramobj import ParamObj

--- a/tests/test_backend_abstract_repr.py
+++ b/tests/test_backend_abstract_repr.py
@@ -20,8 +20,8 @@ from pulser.backend import (
 )
 from pulser.backend.operator import OperatorRepr
 from pulser.backend.state import StateRepr
+from pulser.exceptions.serialization import AbstractReprError
 from pulser.json.abstract_repr.serializer import AbstractReprEncoder
-from pulser.json.exceptions import AbstractReprError
 from pulser.noise_model import NoiseModel
 
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -29,14 +29,14 @@ from pulser.devices import (
     MockDevice,
     VirtualDevice,
 )
-from pulser.exceptions import (
+from pulser.exceptions.base import PulserValueError
+from pulser.exceptions.sequence import (
     AtomsNumberError,
     DimensionError,
     DimensionPositionsTooHighError,
     DimensionTooHighError,
     DistanceError,
     InvalidSequenceError,
-    PulserValueError,
     QubitsNumberError,
     RadiusError,
     RydbergLevelError,

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,17 @@
+"""Trivial tests on our exceptions."""
+
+import pytest
+
+
+def test_import_old_serialize_exceptions():
+    """Test importing from pulser.json.exceptions.
+
+    This should trigger a warning.
+    """
+    with pytest.warns(
+        expected_warning=DeprecationWarning,
+        match="module pulser.json.exceptions is deprecated",
+    ):
+        from pulser.json.exceptions import SerializationError
+
+        _ = SerializationError


### PR DESCRIPTION
Resolves #831. In #828, we reworked exceptions during the constructions of sequences. Let's now apply this design to (de)serialization.