### PR TITLE
[FIX] Fix definition of InterpolatedWaveform with values as Variable 

### DIFF
--- a/pulser-core/pulser/waveforms.py
+++ b/pulser-core/pulser/waveforms.py
@@ -880,7 +880,7 @@ class InterpolatedWaveform(Waveform):
                 values_ = np.array(values, dtype=float)
             except TypeError as e:
                 raise TypeError(_err_message("values")) from e
-        else: 
+        else:
             values_ = values
         if times is None:
             return

--- a/pulser-core/pulser/waveforms.py
+++ b/pulser-core/pulser/waveforms.py
@@ -880,32 +880,30 @@ class InterpolatedWaveform(Waveform):
                 values_ = np.array(values, dtype=float)
             except TypeError as e:
                 raise TypeError(_err_message("values")) from e
-        else:
-            values_ = values
-        if times is None:
+        if times is None or isinstance(times, Parametrized):
             return
-        if not isinstance(times, Parametrized):
-            try:
-                times = cast(ArrayLike, times)
-                times_ = np.array(times, dtype=float)
-            except TypeError as e:
-                raise TypeError(_err_message("times")) from e
-            if np.any(times_ < 0):
-                raise ValueError(
-                    "All values in `times` must be greater than or equal to 0."
-                )
-            if np.any(times_ > 1):
-                raise ValueError(
-                    "All values in `times` must be less than or equal to 1."
-                )
-            unique_times = np.unique(times)  # Sorted array of unique values
-            if len(times_) != len(unique_times):
-                raise ValueError(
-                    "`times` must be an array of non-repeating values."
-                )
-        else:
-            times_ = times
-        if times_.size != values_.size:
+        try:
+            times = cast(ArrayLike, times)
+            times_ = np.array(times, dtype=float)
+        except TypeError as e:
+            raise TypeError(_err_message("times")) from e
+        if np.any(times_ < 0):
+            raise ValueError(
+                "All values in `times` must be greater than or equal to 0."
+            )
+        if np.any(times_ > 1):
+            raise ValueError(
+                "All values in `times` must be less than or equal to 1."
+            )
+        unique_times = np.unique(times)  # Sorted array of unique values
+        if len(times_) != len(unique_times):
+            raise ValueError(
+                "`times` must be an array of non-repeating values."
+            )
+        if (
+            not isinstance(values, Parametrized)
+            and times_.size != values_.size
+        ):
             raise ValueError(
                 "When specified, the number of time coordinates in `times`"
                 f" ({times_.size}) must match the number of `values` "

--- a/pulser-core/pulser/waveforms.py
+++ b/pulser-core/pulser/waveforms.py
@@ -877,21 +877,19 @@ class InterpolatedWaveform(Waveform):
 
         if not isinstance(values, Parametrized):
             try:
-                _values = np.array(values, dtype=float)
+                values_ = np.array(values, dtype=float)
             except TypeError as e:
                 raise TypeError(_err_message("values")) from e
-        if times is not None and not isinstance(times, Parametrized):
+        else: 
+            values_ = values
+        if times is None:
+            return
+        if not isinstance(times, Parametrized):
             try:
                 times = cast(ArrayLike, times)
                 times_ = np.array(times, dtype=float)
             except TypeError as e:
                 raise TypeError(_err_message("times")) from e
-            if len(times_) != len(_values):
-                raise ValueError(
-                    "When specified, the number of time coordinates in `times`"
-                    f" ({len(times_)}) must match the number of `values` "
-                    f"({len(_values)})."
-                )
             if np.any(times_ < 0):
                 raise ValueError(
                     "All values in `times` must be greater than or equal to 0."
@@ -905,6 +903,14 @@ class InterpolatedWaveform(Waveform):
                 raise ValueError(
                     "`times` must be an array of non-repeating values."
                 )
+        else:
+            times_ = times
+        if times_.size != values_.size:
+            raise ValueError(
+                "When specified, the number of time coordinates in `times`"
+                f" ({times_.size}) must match the number of `values` "
+                f"({values_.size})."
+            )
 
     @property
     def duration(self) -> int:

--- a/tests/test_waveforms.py
+++ b/tests/test_waveforms.py
@@ -301,6 +301,15 @@ def test_interpolated():
         ),
     ):
         InterpolatedWaveform(duration, [0, 0.1, 0.2, 0.3], other_values)
+    times = seq.declare_variable("times", size=6)  # a Variable
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "When specified, the number of time coordinates in `times`"
+            " (6) must match the number of `values` (5)."
+        ),
+    ):
+        InterpolatedWaveform(1000, values, times)
 
 
 def test_kaiser():

--- a/tests/test_waveforms.py
+++ b/tests/test_waveforms.py
@@ -302,6 +302,9 @@ def test_interpolated():
     ):
         InterpolatedWaveform(duration, [0, 0.1, 0.2, 0.3], other_values)
     times = seq.declare_variable("times", size=6)  # a Variable
+    interp_wvf = InterpolatedWaveform(1000, values, times)  # this works
+    times._assign([0, 0.1, 0.2, 0.3, 0.4, 0.5])
+    values._assign([0, 1, 2, 3, 4])
     with pytest.raises(
         ValueError,
         match=re.escape(
@@ -309,7 +312,7 @@ def test_interpolated():
             " (6) must match the number of `values` (5)."
         ),
     ):
-        InterpolatedWaveform(1000, values, times)
+        interp_wvf.build()
 
 
 def test_kaiser():


### PR DESCRIPTION
Currently, defining an InterpolatedWaveform with both values and times as Variable fail, because the variable _values is not instantiated prior to the evaluation len(times) == len(values) in _check_values_times.

This fixes the issue ~and improves the tests: both numpy arrays and Variables have the attribute `size`, so we can actually check that the size of the given times and values are the same, whatever their type.~

It does not improve the tests, it only fixes the issue: taking into account the fact that the given objects can be ParamObj and not only Variable, and since ParamObj doesn't have the attribute `size`, a user can still provide value and times as Variable of different size, whose build will always fail (but at least the initialization is made possible if their size match).  