### PR TITLE
make results picklable

### DIFF
--- a/pulser-core/pulser/backend/results.py
+++ b/pulser-core/pulser/backend/results.py
@@ -202,6 +202,12 @@ class Results:
         d = json.loads(repr)
         return cls._from_abstract_repr(d)
 
+    def __getstate__(self) -> dict:
+        return self._to_abstract_repr()  # type: ignore[operator]
+
+    def __setstate__(self, d: dict) -> None:
+        self.__dict__ = d
+
 
 ResultsType = TypeVar("ResultsType", bound=Results)
 


### PR DESCRIPTION
This needed so you can do something like

```    
def do_run(run_index):
        config = emu_mps.MPSConfig(
            num_gpus_to_use=0,
            dt=dt,
            precision=precision,
            observables=observables,
            noise_model=noise_model,
            log_file=res_dir
            / f"log_depolarizing_rate={depolarizing_rate}_run={run_index}.log",
        )
        backend = emu_mps.MPSBackend(seq, config=config)
        return backend.run()

processes_count = int(os.environ.get("SLURM_JOB_CPUS_PER_NODE", cpu_count())) - 1

with Pool(processes=processes_count) as pool:
        monte_carlo_results = pool.map(do_run, range(nruns)
```

The critical point is that `pool.map` tries to pickle the `Results` object to send it to the main process.