### PR TITLE
Add constraints on the minimum layout filling fraction

### DIFF
--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -95,8 +95,8 @@ class BaseDevice(ABC):
         max_layout_traps: An optional value for the maximum number of traps a
             layout can have.
         min_layout_filling: The smallest fraction of a layout that must be
-            filled with atoms. Only enforced for layouts with more traps than
-            'min_layout_traps'.
+            filled with atoms. Only enforced when the layout has more traps
+            than 'min_layout_traps'.
         max_layout_filling: The largest fraction of a layout that can be filled
             with atoms.
         optimal_layout_filling: An optional value for the fraction of a layout
@@ -820,8 +820,8 @@ class Device(BaseDevice):
             that are not already calibrated are accepted. Only enforced in
             QPU execution.
         min_layout_filling: The smallest fraction of a layout that must be
-            filled with atoms. Only enforced for layouts with more traps than
-            'min_layout_traps'.
+            filled with atoms. Only enforced when the layout has more traps
+            than 'min_layout_traps'.
         max_layout_filling: The largest fraction of a layout that can be filled
             with atoms.
         optimal_layout_filling: An optional value for the fraction of a layout
@@ -1005,8 +1005,8 @@ class VirtualDevice(BaseDevice):
         requires_layout: Whether the register used in the sequence must be
             created from a register layout. Only enforced in QPU execution.
         min_layout_filling: The smallest fraction of a layout that must be
-            filled with atoms. Only enforced for layouts with more traps than
-            'min_layout_traps'.
+            filled with atoms. Only enforced when the layout has more traps
+            than 'min_layout_traps'.
         max_layout_filling: The largest fraction of a layout that can be filled
             with atoms.
         optimal_layout_filling: An optional value for the fraction of a layout

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -269,7 +269,7 @@ class BaseDevice(ABC):
                 raise PulserValueError(
                     "With the given maximum layout filling and maximum number "
                     f"of traps, a layout supports at most {max_atoms_} atoms, "
-                    "which is less than the maximum number of atoms allowed"
+                    "which is less than the maximum number of atoms allowed "
                     f"({self.max_atom_num})."
                 )
 

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -38,8 +38,10 @@ from pulser.exceptions.sequence import (
     DimensionTooHighError,
     DistanceError,
     MaxNumberOfTrapsError,
+    MaxQubitNumberError,
+    MinimumLayoutFillingError,
+    MinQubitNumberError,
     OptimalLayoutFillingError,
-    QubitsNumberError,
     RadiusError,
     RydbergLevelError,
     TrapsNumberTooHighError,
@@ -70,6 +72,7 @@ OPTIONAL_IN_ABSTR_REPR = tuple(
         "requires_layout",
         "accepts_new_layouts",
         "min_layout_traps",
+        "min_layout_filling",
     ]
 )
 PARAMS_WITH_ABSTR_REPR = ("channel_objects", "channel_ids", "dmm_objects")
@@ -91,6 +94,9 @@ class BaseDevice(ABC):
         min_layout_traps: The minimum number of traps a layout can have.
         max_layout_traps: An optional value for the maximum number of traps a
             layout can have.
+        min_layout_filling: The smallest fraction of a layout that must be
+            filled with atoms. Only enforced for layouts with more traps than
+            'min_layout_traps'.
         max_layout_filling: The largest fraction of a layout that can be filled
             with atoms.
         optimal_layout_filling: An optional value for the fraction of a layout
@@ -129,6 +135,7 @@ class BaseDevice(ABC):
     max_radial_distance: int | None
     interaction_coeff_xy: float | None = None
     supports_slm_mask: bool = False
+    min_layout_filling: float = 0.0
     max_layout_filling: float = 0.5
     optimal_layout_filling: float | None = None
     min_layout_traps: int = 1
@@ -227,8 +234,18 @@ class BaseDevice(ABC):
                 f"not {self.max_layout_filling}."
             )
 
+        if self.min_layout_filling is not None and not (
+            0.0 <= self.min_layout_filling < self.max_layout_filling
+        ):
+            raise MinimumLayoutFillingError(
+                device=self,
+                invalid=self.min_layout_filling,
+            )
+
         if self.optimal_layout_filling is not None and not (
-            0.0 < self.optimal_layout_filling <= self.max_layout_filling
+            self.min_layout_filling
+            <= self.optimal_layout_filling
+            <= self.max_layout_filling
         ):
             raise OptimalLayoutFillingError(
                 device=self,
@@ -474,11 +491,24 @@ class BaseDevice(ABC):
                 " registers with a register layout."
             )
         n_qubits = len(register.qubit_ids)
+        min_qubits = int(
+            np.ceil(register.layout.number_of_traps * self.min_layout_filling)
+        )
+        if (
+            register.layout.number_of_traps > self.min_layout_traps
+            and n_qubits < min_qubits
+        ):
+            raise MinQubitNumberError(
+                device=self,
+                invalid=n_qubits,
+                min=min_qubits,
+            )
+
         max_qubits = int(
             register.layout.number_of_traps * self.max_layout_filling
         )
         if n_qubits > max_qubits:
-            raise QubitsNumberError(
+            raise MaxQubitNumberError(
                 device=self,
                 invalid=n_qubits,
                 max=max_qubits,
@@ -663,6 +693,7 @@ class BaseDevice(ABC):
             self._param_check_none(self.max_layout_traps)(
                 " - Maximal number of traps: {}"
             ),
+            f" - Minimum layout filling fraction: {self.min_layout_filling}",
             f" - Maximum layout filling fraction: {self.max_layout_filling}",
         ]
 
@@ -788,6 +819,9 @@ class Device(BaseDevice):
         accepts_new_layouts: Whether registers built from register layouts
             that are not already calibrated are accepted. Only enforced in
             QPU execution.
+        min_layout_filling: The smallest fraction of a layout that must be
+            filled with atoms. Only enforced for layouts with more traps than
+            'min_layout_traps'.
         max_layout_filling: The largest fraction of a layout that can be filled
             with atoms.
         optimal_layout_filling: An optional value for the fraction of a layout
@@ -970,6 +1004,9 @@ class VirtualDevice(BaseDevice):
         min_atom_distance: The closest together two atoms can be (in μm).
         requires_layout: Whether the register used in the sequence must be
             created from a register layout. Only enforced in QPU execution.
+        min_layout_filling: The smallest fraction of a layout that must be
+            filled with atoms. Only enforced for layouts with more traps than
+            'min_layout_traps'.
         max_layout_filling: The largest fraction of a layout that can be filled
             with atoms.
         optimal_layout_filling: An optional value for the fraction of a layout

--- a/pulser-core/pulser/exceptions/sequence.py
+++ b/pulser-core/pulser/exceptions/sequence.py
@@ -110,7 +110,34 @@ class TrapsNumberTooHighError(TrapsNumberError):
 
 @dataclass
 class QubitsNumberError(InvalidSequenceError):
-    """An error in the number of qubits.
+    """An error in the number of qubits."""
+
+
+@dataclass
+class MinQubitNumberError(QubitsNumberError):
+    """Too few qubits for the layout.
+
+    Attributes:
+        invalid: The invalid number of qubits.
+        min: The minimum number of qubits.
+    """
+
+    invalid: int
+    min: int
+
+    def __str__(self) -> str:
+        return (
+            "Given the number of traps in the layout and the "
+            "device's minimum layout filling fraction, the given"
+            f" register has too few qubits ({self.invalid}). "
+            "On this device, this layout must hold at least "
+            f"{self.min} qubits."
+        )
+
+
+@dataclass
+class MaxQubitNumberError(QubitsNumberError):
+    """Too many qubits for the layout.
 
     Attributes:
         invalid: The invalid number of qubits.
@@ -224,9 +251,28 @@ class OptimalLayoutFillingError(InvalidSequenceError):
     def __str__(self) -> str:
         return (
             "When defined, the optimal layout filling fraction "
-            "must be greater than 0. and less than or equal to "
+            "must be greater than or equal to `min_layout_filling` "
+            f"({self.device.min_layout_filling}) and less than or equal to "
             f"`max_layout_filling` ({self.device.max_layout_filling}), "
             f"not {self.invalid}."
+        )
+
+
+@dataclass
+class MinimumLayoutFillingError(InvalidSequenceError):
+    """Invalid minimum layout filling.
+
+    Attributes:
+        invalid: The invalid value.
+    """
+
+    invalid: float
+
+    def __str__(self) -> str:
+        return (
+            "The minimum layout filling fraction must be greater than "
+            "or equal to 0. and less than `max_layout_filling` "
+            f"({self.device.max_layout_filling}), not {self.invalid}."
         )
 
 

--- a/pulser-core/pulser/json/abstract_repr/schemas/device-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/device-schema.json
@@ -209,6 +209,10 @@
               "description": "The closest together two atoms can be (in μm).",
               "type": "number"
             },
+            "min_layout_filling": {
+              "description": "The smallest fraction of a layout that must be filled with atoms.",
+              "type": "number"
+            },
             "min_layout_traps": {
               "description": "The minimum number of traps a layout can have.",
               "type": "number"
@@ -348,6 +352,10 @@
             },
             "min_atom_distance": {
               "description": "The closest together two atoms can be (in μm).",
+              "type": "number"
+            },
+            "min_layout_filling": {
+              "description": "The smallest fraction of a layout that must be filled with atoms.",
               "type": "number"
             },
             "min_layout_traps": {

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -364,7 +364,8 @@ class Register(BaseRegister, RegDrawer):
 
         max_traps = device.max_layout_traps
         if device.min_layout_filling > 0.0:
-            # This is akin to imposing a max number of traps
+            # This is akin to imposing a max number of traps for a given
+            # minimum filling and number of qubits
             max_allowed_traps = int(
                 len(self.qubit_ids) / device.min_layout_filling
             )

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -363,7 +363,7 @@ class Register(BaseRegister, RegDrawer):
             )
 
         max_traps = device.max_layout_traps
-        if device.min_layout_filling > 0:
+        if device.min_layout_filling > 0.0:
             # This is akin to imposing a max number of traps
             max_allowed_traps = int(
                 len(self.qubit_ids) / device.min_layout_filling

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -362,6 +362,22 @@ class Register(BaseRegister, RegDrawer):
                 "registers with differentiable coordinates."
             )
 
+        max_traps = device.max_layout_traps
+        if device.min_layout_filling > 0:
+            # This is akin to imposing a max number of traps
+            max_allowed_traps = int(
+                len(self.qubit_ids) / device.min_layout_filling
+            )
+            if max_allowed_traps > device.min_layout_traps:
+                # We only enforce min_layout_filling if the maximum number
+                # of traps it allows is greater than the minimum number of
+                # traps required
+                max_traps = min(
+                    max_traps
+                    or max_allowed_traps,  # In case max_traps is None
+                    max_allowed_traps,
+                )
+
         trap_coords = generate_trap_coordinates(
             self.sorted_coords,
             min_trap_dist=device.min_atom_distance,
@@ -369,7 +385,7 @@ class Register(BaseRegister, RegDrawer):
             max_layout_filling=device.max_layout_filling,
             optimal_layout_filling=device.optimal_layout_filling,
             min_traps=device.min_layout_traps,
-            max_traps=device.max_layout_traps,
+            max_traps=max_traps,
         )
         layout = pulser.register.RegisterLayout(trap_coords, slug=layout_slug)
         trap_ids = layout.get_traps_from_coordinates(

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -516,12 +516,7 @@ class TestDevice:
             (MockDevice, "max_sequence_duration", 1000),
             (MockDevice, "max_runs", 100),
             (MockDevice, "optimal_layout_filling", 0.4),
-            pytest.param(
-                AnalogDevice,
-                "min_layout_filling",
-                0.2,
-                marks=pytest.mark.xfail(reason="Not in the schema yet"),
-            ),
+            (AnalogDevice, "min_layout_filling", 0.2),
             (MockDevice, "min_layout_traps", 10),
             (MockDevice, "max_layout_traps", 200),
             (MockDevice, "requires_layout", True),

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -516,6 +516,12 @@ class TestDevice:
             (MockDevice, "max_sequence_duration", 1000),
             (MockDevice, "max_runs", 100),
             (MockDevice, "optimal_layout_filling", 0.4),
+            pytest.param(
+                AnalogDevice,
+                "min_layout_filling",
+                0.2,
+                marks=pytest.mark.xfail(reason="Not in the schema yet"),
+            ),
             (MockDevice, "min_layout_traps", 10),
             (MockDevice, "max_layout_traps", 200),
             (MockDevice, "requires_layout", True),

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -620,7 +620,7 @@ def test_layout_filling_min_traps():
         device.validate_layout_filling(register)
 
     # When the layout has only 'min_layout_traps',
-    # `min_layout_filling` not is enforced
+    # `min_layout_filling` is not enforced
     register = TriangularLatticeLayout(min_traps, 5).hexagonal_register(1)
     assert register.layout.number_of_traps == min_traps
     device.validate_layout_filling(register)

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -626,10 +626,13 @@ def test_automatic_layout(optimal_filling):
             reg.with_automatic_layout(bound_below_dev).layout.number_of_traps
             == bound_below_dev.min_layout_traps
         )
-    elif trap_num < optimal_traps:
+    else:
         assert trap_num > min_traps
         bound_above_dev = dataclasses.replace(
-            device, max_layout_traps=trap_num - 1
+            device,
+            max_layout_traps=trap_num - 1,
+            # So that we can still fit 20 atoms
+            max_layout_filling=device.max_layout_filling + 0.1,
         )
         assert (
             reg.with_automatic_layout(bound_above_dev).layout.number_of_traps
@@ -640,6 +643,7 @@ def test_automatic_layout(optimal_filling):
         bound_above_from_min_filling = dataclasses.replace(
             device, min_layout_filling=optimal_filling
         )
+        assert bound_above_from_min_filling.min_layout_filling > 0.0
         assert (
             reg.with_automatic_layout(
                 bound_above_from_min_filling

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -635,6 +635,30 @@ def test_automatic_layout(optimal_filling):
             reg.with_automatic_layout(bound_above_dev).layout.number_of_traps
             == bound_above_dev.max_layout_traps
         )
+        # If we set min_layout_filling to the optimal filling, we should end
+        # up with the optimal number of traps (because there can't be more)
+        bound_above_from_min_filling = dataclasses.replace(
+            device, min_layout_filling=optimal_filling
+        )
+        assert (
+            reg.with_automatic_layout(
+                bound_above_from_min_filling
+            ).layout.number_of_traps
+            == optimal_traps
+        )
+
+        # However, if the maximum number of traps allowed by min_layout_filling
+        # matches the minimum number of traps allowed the constraint is not
+        # imposed and we end up back to the original trap number
+        not_bound_above_from_min_filling = dataclasses.replace(
+            bound_above_from_min_filling, min_layout_traps=optimal_traps
+        )
+        assert (
+            reg.with_automatic_layout(
+                not_bound_above_from_min_filling
+            ).layout.number_of_traps
+            == trap_num
+        )
 
     with pytest.raises(TypeError, match="must be of type Device"):
         reg.with_automatic_layout(MockDevice)


### PR DESCRIPTION
- [x]  Adds `BaseDevice.min_layout_filling` to define a minimum layout filling fraction
- [x] Updates the abstract repr schema to support this new parameter