### PR TITLE
Allow general callback in EmulationConfig

### DIFF
--- a/pulser-core/pulser/backend/config.py
+++ b/pulser-core/pulser/backend/config.py
@@ -109,6 +109,7 @@ class EmulationConfig(BackendConfig, Generic[StateType]):
         callbacks: A general callback that is not an observable. Observables
             must be fed into the observables arg, since they all interact
             with the Results, and are subject to additional validation.
+            Unlike observables, these are called at every emulation step.
         default_evaluation_times: The default times at which observables
             are computed. Can be a sequence of unique relative times between 0
             (the start of the sequence) and 1 (the end of the sequence), in

--- a/pulser-core/pulser/backend/config.py
+++ b/pulser-core/pulser/backend/config.py
@@ -106,6 +106,9 @@ class EmulationConfig(BackendConfig, Generic[StateType]):
         observables: A sequence of observables to compute at specific
             evaluation times. The observables without specified evaluation
             times will use this configuration's 'default_evaluation_times'.
+        callbacks: A general callback that is not an observable. Observables
+            must be fed into the observables arg, since they all interact
+            with the Results, and are subject to additional validation.
         default_evaluation_times: The default times at which observables
             are computed. Can be a sequence of unique relative times between 0
             (the start of the sequence) and 1 (the end of the sequence), in
@@ -170,7 +173,7 @@ class EmulationConfig(BackendConfig, Generic[StateType]):
     ) -> None:
         """Initializes the EmulationConfig."""
         obs_tags = []
-        if not observables:
+        if not observables and not callbacks:
             warnings.warn(
                 f"{self.__class__.__name__!r} was initialized without any "
                 "observables. The corresponding emulation results will be"

--- a/pulser-simulation/pulser_simulation/qutip_backend.py
+++ b/pulser-simulation/pulser_simulation/qutip_backend.py
@@ -178,6 +178,14 @@ class QutipBackendV2(EmulatorBackend):
                     ),
                     eigenstates=eigenstates,
                 )
+                for callback in self._config.callbacks:
+                    callback(
+                        config=self._config,
+                        t=t,
+                        state=state,
+                        hamiltonian=ham,
+                        result=res,
+                    )
                 for obs in self._config.observables:
                     obs(
                         config=self._config,
@@ -226,6 +234,14 @@ class QutipBackendV2(EmulatorBackend):
                     ),
                     eigenstates=eigenstates,
                 )
+                for callback in self._config.callbacks:
+                    callback(
+                        config=self._config,
+                        t=t,
+                        state=state,
+                        hamiltonian=ham,
+                        result=res,
+                    )
                 for obs in self._config.observables:
                     obs(
                         config=self._config,

--- a/pulser-simulation/pulser_simulation/qutip_config.py
+++ b/pulser-simulation/pulser_simulation/qutip_config.py
@@ -120,6 +120,8 @@ class QutipConfig(EmulationConfig[QutipState]):
         self, total_duration_ns: int
     ) -> Literal["Full"] | np.ndarray:
         extra_eval_times: set[float] = set()
+        if self.callbacks:
+            return "Full"
         for obs in self.observables:
             extra_eval_times.update(obs.evaluation_times or [])
 

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -32,6 +32,10 @@ from pulser_simulation.simulation import QutipEmulator
 
 class CountCalls(Callback):
     def __init__(self):
+        """
+        Simple callback that counts how often it's been called.
+        The count can be queried after the simulation from self.counter.
+        """
         self.counter = 0
 
     def __call__(self, **kwargs):
@@ -96,7 +100,10 @@ def test_callback():
 
 def test_qutip_backend_v2_energy():
     seq = sequence()
-
+    with pytest.raises(
+        TypeError, match="'config' must be an instance of 'EmulationConfig'"
+    ):
+        QutipBackendV2(seq, config="tralala")
     config = QutipConfig(
         default_evaluation_times="Full",
         observables=[

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -32,8 +32,8 @@ from pulser_simulation.simulation import QutipEmulator
 
 class CountCalls(Callback):
     def __init__(self):
-        """
-        Simple callback that counts how often it's been called.
+        """Simple callback that counts how often it's been called.
+
         The count can be queried after the simulation from self.counter.
         """
         self.counter = 0

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -22,11 +22,20 @@ import qutip
 
 import pulser
 from pulser.backend.default_observables import Energy, Occupation, StateResult
+from pulser.backend.observable import Callback
 from pulser_simulation.qutip_backend import QutipBackendV2
 from pulser_simulation.qutip_config import QutipConfig
 from pulser_simulation.qutip_state import QutipState
 from pulser_simulation.simconfig import SimConfig
 from pulser_simulation.simulation import QutipEmulator
+
+
+class CountCalls(Callback):
+    def __init__(self):
+        self.counter = 0
+
+    def __call__(self, **kwargs):
+        self.counter += 1
 
 
 def sequence(device: pulser.devices.Device | None = None):
@@ -64,12 +73,29 @@ def sequence(device: pulser.devices.Device | None = None):
     return seq
 
 
+def test_callback():
+    seq = sequence()
+
+    config = QutipConfig(
+        callbacks=[CountCalls()],
+    )
+    backend = QutipBackendV2(seq, config=config)
+    backend.run()
+    assert backend._config.callbacks[0].counter == seq.get_duration() + 1
+
+    config = QutipConfig(
+        callbacks=[CountCalls()],
+        noise_model=pulser.NoiseModel(
+            amp_sigma=0.1, runs=1, samples_per_run=1
+        ),
+    )
+    backend = QutipBackendV2(seq, config=config)
+    backend.run()
+    assert backend._config.callbacks[0].counter == seq.get_duration() + 1
+
+
 def test_qutip_backend_v2_energy():
     seq = sequence()
-    with pytest.raises(
-        TypeError, match="'config' must be an instance of 'EmulationConfig'"
-    ):
-        QutipBackendV2(seq, config="tralala")
 
     config = QutipConfig(
         default_evaluation_times="Full",

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -416,7 +416,6 @@ def test_emulation_config():
     ):
         EmulationConfig(
             callbacks=(BitStrings(),),
-            observables=(BitStrings(),),
             default_evaluation_times=[-1e15, 0.0, 0.5, 1.0],
         )
     with pytest.raises(

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -411,6 +411,24 @@ def test_emulation_config():
     ):
         EmulationConfig(observables=["fidelity"])
     with pytest.raises(
+        TypeError,
+        match="All entries in 'callbacks' must not be instances of Observable",
+    ):
+        EmulationConfig(
+            callbacks=(BitStrings(),),
+            observables=(BitStrings(),),
+            default_evaluation_times=[-1e15, 0.0, 0.5, 1.0],
+        )
+    with pytest.raises(
+        TypeError,
+        match="All entries in 'callbacks' must be instances of Callback",
+    ):
+        EmulationConfig(
+            callbacks=("Hello",),
+            observables=(BitStrings(),),
+            default_evaluation_times=[-1e15, 0.0, 0.5, 1.0],
+        )
+    with pytest.raises(
         ValueError,
         match="Some of the provided 'observables' share identical tags",
     ):


### PR DESCRIPTION
Currently, all the type hints say `Observable` and there is an `isinstance` check too. However, all the code will work with `Callback` too, it's just that the logic about checking evaluation times is not valid anymore for a general `Callback`.

I relaxed the typing a bit. There is currently no validation if the passed object is not an `Observable` since for a general `Callback` you cannot say very much about what it'll do.