### PR TITLE
Deny empty sequence for mimic_qpu=True

### DIFF
--- a/pulser-core/pulser/backend/abc.py
+++ b/pulser-core/pulser/backend/abc.py
@@ -53,10 +53,10 @@ class Backend(ABC):
         if not mimic_qpu:
             return
 
-        if sequence.is_empty:
+        if sequence.is_empty():
             raise ValueError(
-                "'sequence' should not be empty, please add content to it's "
-                "schedule."
+                "'sequence' should not be empty, please add an instruction "
+                "to a declared channel."
             )
 
         if not isinstance(device := sequence.device, Device):

--- a/pulser-core/pulser/backend/abc.py
+++ b/pulser-core/pulser/backend/abc.py
@@ -53,6 +53,12 @@ class Backend(ABC):
         if not mimic_qpu:
             return
 
+        if sequence.is_empty:
+            raise ValueError(
+                "'sequence' should not be empty, please add content to it's "
+                "schedule."
+            )
+
         if not isinstance(device := sequence.device, Device):
             raise TypeError(
                 "To be sent to a QPU, the device of the sequence "

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -326,7 +326,6 @@ class Sequence(Generic[DeviceType]):
                 )
             }
 
-    @property
     def is_empty(self) -> bool:
         """States whether the sequence is empty.
 

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -327,6 +327,16 @@ class Sequence(Generic[DeviceType]):
             }
 
     @property
+    def is_empty(self) -> bool:
+        """States whether the sequence is empty.
+
+        Note:
+            This is equivalent to testing if the sequence duration is equal to
+            0.
+        """
+        return self.get_duration() == 0
+
+    @property
     def magnetic_field(self) -> np.ndarray:
         """The magnetic field acting on the array of atoms.
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -81,6 +81,14 @@ def test_abc_backend(sequence):
         ConcreteBackend(sequence.to_abstract_repr())
 
 
+def test_abc_backend_validate_sequence_empty():
+    reg = pulser.Register.square(2, spacing=5, prefix="q")
+    seq = pulser.Sequence(reg, MockDevice)
+    seq.declare_channel("rydberg_global", "rydberg_global")
+    with pytest.raises(ValueError, match="should not be empty"):
+        Backend.validate_sequence(seq, mimic_qpu=True)
+
+
 @pytest.mark.parametrize(
     "param, value, msg",
     [

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -2933,7 +2933,8 @@ def test_sequence_is_empty(reg, device, channel):
         if channel == "rydberg_global"
         else sequence._register.qubit_ids[0]
     )
+    assert sequence.is_empty()
     sequence.declare_channel(channel, channel, initial_target=target)
-    assert sequence.is_empty
+    assert sequence.is_empty()
     sequence.delay(84162, channel)
-    assert not sequence.is_empty
+    assert not sequence.is_empty()

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -2923,3 +2923,17 @@ def test_sequence_diff(device, parametrized, with_modulation, with_eom):
         assert not dmm_ch_samples.amp.requires_grad
         assert dmm_ch_samples.det.requires_grad
         assert not dmm_ch_samples.phase.requires_grad
+
+
+@pytest.mark.parametrize("channel", ["rydberg_global", "raman_local"])
+def test_sequence_is_empty(reg, device, channel):
+    sequence = Sequence(reg, device)
+    target = (
+        None
+        if channel == "rydberg_global"
+        else sequence._register.qubit_ids[0]
+    )
+    sequence.declare_channel(channel, channel, initial_target=target)
+    assert sequence.is_empty
+    sequence.delay(84162, channel)
+    assert not sequence.is_empty


### PR DESCRIPTION
As described in #863, our QPUs don't accept empty sequences. Here I've added a check for this in `Backend.validate_sequence`. I've also added the `is_empty` property to conveniently check if the sequence is empty.

Closes #863 