### PR TITLE
[FIX] Enforce consistent dtype in coords

### DIFF
--- a/pulser-core/pulser/register/_coordinates.py
+++ b/pulser-core/pulser/register/_coordinates.py
@@ -42,7 +42,7 @@ class CoordsCollection:
 
     @cached_property
     def _coords_arr(self) -> pm.AbstractArray:
-        return pm.vstack(cast(Sequence, self._coords))
+        return pm.vstack(cast(Sequence, self._coords)).astype(float)
 
     @cached_property
     def _rounded_coords(self) -> pm.AbstractArray:


### PR DESCRIPTION
When running
```
import pulser
import numpy as np
reg = pulser.Register.from_coordinates(coords=[np.array([-2.501571, -0.003283], dtype=np.float32), np.array([2.50157 , 0.003283], dtype=np.float32)])
reg.with_automatic_layout(pulser.AnalogDevice)
```
We get an error `ValueError: The coordinate '[-2.5037005  -0.00256802]' is not a part of the RegisterLayout.`.
This is due to the fact that we are comparing exact coordinates in `get_trap_ids_from_coordinates`, and most likely due to an issue when going from an array to a list in generate_trap_coordinates.

This problem is solved when working with float64 arrays. The suggested fix here is then to make the type of the arrays/AbstractArray obtained through the properties of CoordsCollection consistent, make it be always float64.
