### PR TITLE
Move the mimic-QPU validation to RemoteBackend.run()

### DIFF
--- a/pulser-core/pulser/backend/qpu.py
+++ b/pulser-core/pulser/backend/qpu.py
@@ -64,23 +64,3 @@ class QPUBackend(RemoteBackend):
             job_params or [], self._sequence.device.max_runs
         )
         return super().run(job_params, wait)
-
-    @staticmethod
-    def validate_job_params(
-        job_params: list[JobParams], max_runs: int | None
-    ) -> None:
-        """Validates a list of job parameters prior to submission."""
-        suffix = " when executing a sequence on a real QPU."
-        if not job_params:
-            raise ValueError("'job_params' must be specified" + suffix)
-        RemoteBackend._type_check_job_params(job_params)
-        for j in job_params:
-            if "runs" not in j:
-                raise ValueError(
-                    "All elements of 'job_params' must specify 'runs'" + suffix
-                )
-            if max_runs is not None and j["runs"] > max_runs:
-                raise ValueError(
-                    "All 'runs' must be below the maximum allowed by the "
-                    f"device ({max_runs})" + suffix
-                )

--- a/pulser-core/pulser/backend/qpu.py
+++ b/pulser-core/pulser/backend/qpu.py
@@ -60,7 +60,5 @@ class QPUBackend(RemoteBackend):
             The results, which can be accessed once all sequences have been
             successfully executed.
         """
-        self.validate_job_params(
-            job_params or [], self._sequence.device.max_runs
-        )
+        self.validate_job_params(job_params, self._sequence.device.max_runs)
         return super().run(job_params, wait)

--- a/pulser-core/pulser/backend/remote.py
+++ b/pulser-core/pulser/backend/remote.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import logging
 import typing
 from abc import ABC, abstractmethod
 from enum import Enum, auto
@@ -261,7 +262,14 @@ class RemoteConnection(ABC):
         Returns:
             The Sequence, with the latest version for the targeted Device.
         """
-        available_devices = self.fetch_available_devices()
+        try:
+            available_devices = self.fetch_available_devices()
+        except NotImplementedError:
+            logging.warning(
+                "The selected connection doesn't give access to the latest device specs. "
+                "Execution might fail if the sequence is incompatible with the device."
+            )
+            return sequence
         available_device_names = {
             dev.name: key for key, dev in available_devices.items()
         }

--- a/pulser-core/pulser/backend/remote.py
+++ b/pulser-core/pulser/backend/remote.py
@@ -266,8 +266,9 @@ class RemoteConnection(ABC):
             available_devices = self.fetch_available_devices()
         except NotImplementedError:
             logging.warning(
-                "The selected connection doesn't give access to the latest device specs. "
-                "Execution might fail if the sequence is incompatible with the device."
+                "The selected connection doesn't give access to the latest "
+                "device specs. Execution might fail if the sequence is "
+                "incompatible with the device."
             )
             return sequence
         available_device_names = {

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -174,10 +174,6 @@ class _MockConnection(RemoteConnection):
     def supports_open_batch(self) -> bool:
         return bool(self._support_open_batch)
 
-    def fetch_available_devices(self):
-        device = pulser.AnalogDevice
-        return {device.name: device}
-
 
 @pytest.mark.parametrize("job_ids", [None, ["jobID1"]])
 def test_remote_results(job_ids):
@@ -212,6 +208,11 @@ def test_remote_connection(sequence):
 
     with pytest.raises(NotImplementedError, match="Unable to find job IDs"):
         connection._get_job_ids("abc")
+
+    with pytest.raises(
+        NotImplementedError, match="Unable to fetch the available devices"
+    ):
+        connection.fetch_available_devices()
 
     assert not sequence.is_measured()
     new_seq = connection._add_measurement_to_sequence(sequence)
@@ -317,6 +318,13 @@ def test_qpu_backend(sequence):
         ),
     ):
         qpu_backend.run(job_params=[{"runs": 100000}])
+
+    device = pulser.AnalogDevice
+
+    def fetch_available_devices():
+        return {device.name: device}
+
+    connection.fetch_available_devices = fetch_available_devices
 
     remote_results = qpu_backend.run(job_params=[{"runs": 10}])
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -174,6 +174,10 @@ class _MockConnection(RemoteConnection):
     def supports_open_batch(self) -> bool:
         return bool(self._support_open_batch)
 
+    def fetch_available_devices(self):
+        device = pulser.AnalogDevice
+        return {device.name: device}
+
 
 @pytest.mark.parametrize("job_ids", [None, ["jobID1"]])
 def test_remote_results(job_ids):
@@ -208,11 +212,6 @@ def test_remote_connection(sequence):
 
     with pytest.raises(NotImplementedError, match="Unable to find job IDs"):
         connection._get_job_ids("abc")
-
-    with pytest.raises(
-        NotImplementedError, match="Unable to fetch the available devices"
-    ):
-        connection.fetch_available_devices()
 
     assert not sequence.is_measured()
     new_seq = connection._add_measurement_to_sequence(sequence)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -233,6 +233,9 @@ def test_update_sequence_device(sequence):
     connection = _MockConnection()
     device = pulser.AnalogDevice
 
+    new_sequence = connection.update_sequence_device(sequence)
+    assert new_sequence == sequence
+
     def fetch_available_devices():
         return {device.name: device}
 


### PR DESCRIPTION
Move mimic-qpu validation from PasqalCloud to RemoteBackend

Potential breaking change:

If there are any connections that use mimic-qpu=true but do not implement the `fetch_available_devices` method, this change may cause the run call to fail