### PR TITLE
Avoid inconsistent behavior on operations between numpy arrays and parametrized objects

### DIFF
--- a/pulser-core/pulser/parametrized/variable.py
+++ b/pulser-core/pulser/parametrized/variable.py
@@ -128,8 +128,8 @@ class Variable(Parametrized, OpSupport):
 
         return VariableItem(self, key)
 
-    # NOTE: __len__ cannot be defined because it makes numpy.ufuncs convert a
-    # Variable into an array of VariableItem's
+    def __len__(self) -> int:
+        return self.size
 
     def __iter__(self) -> Iterator[VariableItem]:
         for i in range(self.size):

--- a/tests/test_parametrized.py
+++ b/tests/test_parametrized.py
@@ -342,8 +342,8 @@ def test_numpy_compat(obj):
 
     with pytest.raises(TypeError):
         # Only ufunc.__call__ is supported
-        np.add.reduce(arr, obj)
+        np.add.reduce(obj)
 
     # Unsupported ufuncs fail too
     with pytest.raises(TypeError):
-        np.divmod(arr, obj)
+        np.cbrt(obj)


### PR DESCRIPTION
We have had a long standing issue with binary operations on abstract objects where the order of the arguments influenced the outcomes. 

For example,
```
>>> var = Variable("var", dtype=float, size=2)
>>> arr = np.arange(2)

>>> var + arr   # As expected
<pulser.parametrized.paramobj.ParamObj object at 0x7521dce93df0>

>>> arr + var   # An array of parametrized objects, not what we want
array([<pulser.parametrized.paramobj.ParamObj object at 0x7521dce92e30>,
       <pulser.parametrized.paramobj.ParamObj object at 0x7521dce93cd0>],
      dtype=object)
```

After some digging, it seems this can be avoided by writing a custom `__array_ufunc__` for the right-hand side object, so that's what we do here.


