### PR TITLE
Handle when Results.atom_order entries are not strings

### DIFF
--- a/pulser-core/pulser/backend/results.py
+++ b/pulser-core/pulser/backend/results.py
@@ -24,6 +24,7 @@ from typing import Any, TypeVar, overload
 from pulser.backend.observable import Observable
 from pulser.json.abstract_repr.serializer import AbstractReprEncoder
 from pulser.json.abstract_repr.validation import validate_abstract_repr
+from pulser.json.utils import stringify_qubit_ids
 
 
 @dataclass
@@ -147,7 +148,7 @@ class Results:
 
     def _to_abstract_repr(self) -> dict:
         d = {
-            "atom_order": self.atom_order,
+            "atom_order": stringify_qubit_ids(self.atom_order),
             "total_duration": self.total_duration,
         }
         d["tagmap"] = {key: str(value) for key, value in self._tagmap.items()}

--- a/pulser-core/pulser/register/base_register.py
+++ b/pulser-core/pulser/register/base_register.py
@@ -79,14 +79,17 @@ class BaseRegister(ABC, CoordsCollection):
         )
         self._ids: tuple[QubitId, ...] = tuple(qubits.keys())
         if any(not isinstance(id, str) for id in self._ids):
-            warnings.warn(
-                "Usage of `int`s or any non-`str`types as `QubitId`s will be "
-                "deprecated. Define your `QubitId`s as `str`s, prefer setting "
-                "`prefix='q'` when using classmethods, as that will become the"
-                " new default once `int` qubit IDs become invalid.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings("always")
+                warnings.warn(
+                    "Usage of `int`s or any non-`str`types as `QubitId`s will "
+                    "be deprecated. Define your `QubitId`s as `str`s, prefer "
+                    "setting `prefix='q'` when using classmethods, as that "
+                    "will become the new default once `int` qubit IDs become "
+                    "invalid.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
         self._layout_info: Optional[_LayoutInfo] = None
         self._init_kwargs(**kwargs)
 

--- a/tests/test_backend_abstract_repr.py
+++ b/tests/test_backend_abstract_repr.py
@@ -576,3 +576,17 @@ def test_result_serialization(test_torch: bool):
             obs
         )
     assert results.get_result_tags() == deserialized.get_result_tags()
+
+
+def test_result_atom_order_serialization():
+    with pytest.warns(UserWarning, match="converts all qubit ID's to strings"):
+        assert Results.from_abstract_repr(
+            Results(
+                atom_order=(0, 1, 2), total_duration=1000
+            ).to_abstract_repr()
+        ) == Results(atom_order=("0", "1", "2"), total_duration=1000)
+
+        with pytest.raises(
+            AbstractReprError, match="Name collisions encountered"
+        ):
+            Results(atom_order=(0, "0"), total_duration=10).to_abstract_repr()


### PR DESCRIPTION
Even though using non-str qubit IDs is deprecated, it is still allowed and we were not handling it properly when serializing `Results`. This fixes that and also makes the `DeprecationWarning` to not use `int`s as qubit IDs louder.