### PR TITLE
Deal with deprecation warnings from non-str QubitIDs

### DIFF
--- a/pulser-core/pulser/register/base_register.py
+++ b/pulser-core/pulser/register/base_register.py
@@ -80,7 +80,7 @@ class BaseRegister(ABC, CoordsCollection):
         self._ids: tuple[QubitId, ...] = tuple(qubits.keys())
         if any(not isinstance(id, str) for id in self._ids):
             with warnings.catch_warnings():
-                warnings.filterwarnings("always")
+                warnings.filterwarnings("once")
                 warnings.warn(
                     "Usage of `int`s or any non-`str`types as `QubitId`s will "
                     "be deprecated. Define your `QubitId`s as `str`s, prefer "

--- a/tests/pulser_simulation/test_simresults.py
+++ b/tests/pulser_simulation/test_simresults.py
@@ -409,7 +409,7 @@ def test_results_xy(reg, pi_pulse):
 
 def test_false_positive():
     """Breaks for pulser version < v0.18."""
-    seq = Sequence(Register.square(2, 5), AnalogDevice)
+    seq = Sequence(Register.square(2, 5, prefix="q"), AnalogDevice)
     seq.declare_channel("ryd_glob", "rydberg_global")
     seq.add(
         Pulse.ConstantDetuning(

--- a/tests/pulser_simulation/test_simulation.py
+++ b/tests/pulser_simulation/test_simulation.py
@@ -103,7 +103,9 @@ def test_initialization_and_construction_of_hamiltonian(seq, mod_device):
     with pytest.raises(TypeError, match="sequence has to be a valid"):
         QutipEmulator.from_sequence(fake_sequence)
     with pytest.raises(TypeError, match="sequence has to be a valid"):
-        QutipEmulator(fake_sequence, Register.square(2), mod_device)
+        QutipEmulator(
+            fake_sequence, Register.square(2, prefix="q"), mod_device
+        )
     # Simulation cannot be run on a register not defining "control1"
     with pytest.raises(
         ValueError,
@@ -503,7 +505,7 @@ def test_get_hamiltonian():
 
 
 def test_single_atom_simulation():
-    one_reg = Register.from_coordinates([(0, 0)], "atom")
+    one_reg = Register.from_coordinates([(0, 0)], prefix="atom")
     one_seq = Sequence(one_reg, DigitalAnalogDevice)
     one_seq.declare_channel("ch0", "rydberg_global")
     one_seq.add(
@@ -518,7 +520,7 @@ def test_single_atom_simulation():
 
 
 def test_add_max_step_and_delays():
-    reg = Register.from_coordinates([(0, 0)])
+    reg = Register.from_coordinates([(0, 0)], prefix="q")
     seq = Sequence(reg, DigitalAnalogDevice)
     seq.declare_channel("ch", "rydberg_global")
     seq.delay(1500, "ch")

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -443,7 +443,7 @@ def test_validate_register(helpers, with_diff):
         [ValueError, PulserValueError, InvalidSequenceError, AtomsNumberError],
         match="The number of atoms",
     ):
-        DigitalAnalogDevice.validate_register(Register.square(50))
+        DigitalAnalogDevice.validate_register(Register.square(50, prefix="q"))
 
     with pytest.raises(TypeError):
         DigitalAnalogDevice.validate_register(bad_coords1)
@@ -452,7 +452,7 @@ def test_validate_register(helpers, with_diff):
         match="at most 50 μm away from the center",
     ):
         DigitalAnalogDevice.validate_register(
-            Register.from_coordinates(bad_coords1)
+            Register.from_coordinates(bad_coords1, prefix="q")
         )
 
     with helpers.raises_all(
@@ -466,7 +466,7 @@ def test_validate_register(helpers, with_diff):
         match="at most 2D vectors",
     ):
         DigitalAnalogDevice.validate_register(
-            Register3D(dict(enumerate(bad_coords2)))
+            Register3D.from_coordinates(bad_coords2, prefix="q")
         )
 
     with helpers.raises_all(
@@ -474,7 +474,9 @@ def test_validate_register(helpers, with_diff):
         match="The minimal distance between atoms",
     ):
         DigitalAnalogDevice.validate_register(
-            Register.triangular_lattice(3, 4, spacing=good_spacing // 2)
+            Register.triangular_lattice(
+                3, 4, spacing=good_spacing // 2, prefix="q"
+            )
         )
 
     with helpers.raises_all(
@@ -487,14 +489,16 @@ def test_validate_register(helpers, with_diff):
         )
 
     DigitalAnalogDevice.validate_register(
-        Register.rectangle(5, 10, spacing=good_spacing)
+        Register.rectangle(5, 10, spacing=good_spacing, prefix="q")
     )
 
 
 def test_validate_layout(helpers):
     coords = [(100, 0), (-100, 0)]
     with pytest.raises(TypeError):
-        DigitalAnalogDevice.validate_layout(Register.from_coordinates(coords))
+        DigitalAnalogDevice.validate_layout(
+            Register.from_coordinates(coords, prefix="q")
+        )
     with helpers.raises_all(
         [ValueError, PulserValueError, InvalidSequenceError, RadiusError],
         match="at most 50 μm away from the center",
@@ -542,7 +546,7 @@ def test_validate_layout(helpers):
 
     valid_layout = RegisterLayout(
         Register.square(
-            int(np.sqrt(DigitalAnalogDevice.max_atom_num * 2))
+            int(np.sqrt(DigitalAnalogDevice.max_atom_num * 2)), prefix="q"
         )._coords_arr
     )
     DigitalAnalogDevice.validate_layout(valid_layout)
@@ -632,7 +636,9 @@ def test_layout_filling_fail():
         match="'validate_layout_filling' can only be called for"
         " registers with a register layout.",
     ):
-        DigitalAnalogDevice.validate_layout_filling(Register.square(5))
+        DigitalAnalogDevice.validate_layout_filling(
+            Register.square(5, prefix="q")
+        )
 
 
 def test_calibrated_layouts(helpers):
@@ -677,7 +683,7 @@ def test_calibrated_layouts(helpers):
     assert TestDevice.register_is_from_calibrated_layout(register)
     # Checking a register not built from a layout returns False
     assert not TestDevice.register_is_from_calibrated_layout(
-        Register.triangular_lattice(4, 25, 6.8)
+        Register.triangular_lattice(4, 25, 6.8, prefix="q")
     )
     # Checking Layouts that don't match calibrated layouts returns False
     square_layout = SquareLatticeLayout(10, 10, 6.8)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -168,7 +168,7 @@ def test_mappable_register():
 
 
 def test_rare_cases(patch_plt_show, helpers):
-    reg = Register.square(4)
+    reg = Register.square(4, prefix="q")
     seq = Sequence(reg, DigitalAnalogDevice)
     var = seq.declare_variable("var")
 
@@ -209,7 +209,7 @@ def test_rare_cases(patch_plt_show, helpers):
 
 
 def test_support(helpers):
-    seq = Sequence(Register.square(2), DigitalAnalogDevice)
+    seq = Sequence(Register.square(2, prefix="q"), DigitalAnalogDevice)
     var = seq.declare_variable("var")
 
     obj_dict = BlackmanWaveform.from_max_val(1, var)._to_dict()
@@ -246,7 +246,7 @@ def test_support(helpers):
 
 def test_sequence_module():
     # Check that the sequence module is backwards compatible after refactoring
-    seq = Sequence(Register.square(2), DigitalAnalogDevice)
+    seq = Sequence(Register.square(2, prefix="q"), DigitalAnalogDevice)
 
     obj_dict = json.loads(seq._serialize())
     assert obj_dict["__module__"] == "pulser.sequence"
@@ -263,7 +263,7 @@ def test_sequence_module():
 
 
 def test_type_error():
-    s = Sequence(Register.square(1), MockDevice)._serialize()
+    s = Sequence(Register.square(1, prefix="q"), MockDevice)._serialize()
     with pytest.raises(
         TypeError,
         match=re.escape(
@@ -281,7 +281,7 @@ def test_numpy_types():
 
 
 def test_deprecated_device_args():
-    seq = Sequence(Register.square(1), MockDevice)
+    seq = Sequence(Register.square(1, prefix="q"), MockDevice)
 
     seq_dict = json.loads(seq._serialize())
     dev_dict = seq_dict["__kwargs__"]["device"]

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -37,7 +37,7 @@ def test_creation():
         Register(ids)
 
     with pytest.raises(ValueError, match="vectors of size 2"):
-        Register.from_coordinates([(0, 1, 0, 1)])
+        Register.from_coordinates([(0, 1, 0, 1)], prefix="q")
 
     with pytest.raises(
         NotImplementedError, match="a prefix and a set of labels"
@@ -45,7 +45,7 @@ def test_creation():
         Register.from_coordinates(coords, prefix="a", labels=["a", "b"])
 
     with pytest.raises(ValueError, match="vectors of size 3"):
-        Register3D.from_coordinates([((1, 0),), ((-1, 0),)])
+        Register3D.from_coordinates([((1, 0),), ((-1, 0),)], prefix="q")
 
     reg1 = Register(qubits)
     reg2 = Register.from_coordinates(coords, center=False, prefix="q")
@@ -73,14 +73,14 @@ def test_creation():
     assert np.all(reg3._coords == coords_)
     assert not np.all(coords_ == coords)
 
-    reg4 = Register.rectangle(1, 2, spacing=1)
+    reg4 = Register.rectangle(1, 2, spacing=1, prefix="q")
     assert np.all(reg4._coords == coords_)
 
-    reg5 = Register.square(2, spacing=2)
+    reg5 = Register.square(2, spacing=2, prefix="q")
     coords_ = np.array([(-1, -1), (1, -1), (-1, 1), (1, 1)], dtype=float)
     assert np.all(np.array(reg5._coords) == coords_)
 
-    reg6 = Register.triangular_lattice(2, 2, spacing=4)
+    reg6 = Register.triangular_lattice(2, 2, spacing=4, prefix="q")
     coords_ = np.array(
         [
             (-3, -np.sqrt(3)),
@@ -174,7 +174,7 @@ def test_hexagon():
         Register.hexagon(1, spacing=-1.0)
 
     # Check small hexagon (1 layer)
-    reg = Register.hexagon(1, spacing=1.0)
+    reg = Register.hexagon(1, spacing=1.0, prefix="q")
     assert len(reg.qubits) == 7
     atoms = list(reg.qubits.values())
     crest_y = np.sqrt(3) / 2
@@ -187,7 +187,7 @@ def test_hexagon():
     assert np.all(np.isclose(atoms[6], [-1.0, 0.0]))
 
     # Check a few atoms for a bigger hexagon (2 layers)
-    reg = Register.hexagon(2, spacing=1.0)
+    reg = Register.hexagon(2, spacing=1.0, prefix="q")
     assert len(reg.qubits) == 19
     atoms = list(reg.qubits.values())
     crest_y = np.sqrt(3) / 2.0
@@ -220,10 +220,14 @@ def test_max_connectivity():
         reg = Register.max_connectivity(max_atom_num + 1, device)
 
     # Check spacing
-    reg = Register.max_connectivity(max_atom_num, device, spacing=spacing)
+    reg = Register.max_connectivity(
+        max_atom_num, device, spacing=spacing, prefix="q"
+    )
     with pytest.raises(ValueError, match="Spacing "):
         Register.max_connectivity(max_atom_num, device, spacing=spacing - 1.0)
-    reg = Register.max_connectivity(max_atom_num, MockDevice, spacing=spacing)
+    reg = Register.max_connectivity(
+        max_atom_num, MockDevice, spacing=spacing, prefix="q"
+    )
     with pytest.raises(
         NotImplementedError,
         match="Maximum connectivity layouts are not well defined for a "
@@ -232,7 +236,7 @@ def test_max_connectivity():
         Register.max_connectivity(1e9, MockDevice)
 
     # Check 1 atom
-    reg = Register.max_connectivity(1, device)
+    reg = Register.max_connectivity(1, device, prefix="q")
     assert len(reg.qubits) == 1
     atoms = list(reg.qubits.values())
     assert np.all(np.isclose(atoms[0], [0.0, 0.0]))
@@ -249,10 +253,10 @@ def test_max_connectivity():
                 (-0.5, -crest_y),
             ]
         )
-        reg = Register.max_connectivity(i, device)
+        reg = Register.max_connectivity(i, device, prefix="q")
         device.validate_register(reg)
         reg2 = Register.from_coordinates(
-            spacing * hex_coords[:i], center=False
+            spacing * hex_coords[:i], center=False, prefix="q"
         )
         assert len(reg.qubits) == i
         atoms = list(reg.qubits.values())
@@ -261,7 +265,7 @@ def test_max_connectivity():
             assert np.all(np.isclose(atoms[k], atoms2[k]))
 
     # Check full layers on a small hexagon (1 layer)
-    reg = Register.max_connectivity(7, device)
+    reg = Register.max_connectivity(7, device, prefix="q")
     device.validate_register(reg)
     assert len(reg.qubits) == 7
     atoms = list(reg.qubits.values())
@@ -274,7 +278,7 @@ def test_max_connectivity():
     assert np.all(np.isclose(atoms[6], [-1.0 * spacing, 0.0]))
 
     # Check full layers for a bigger hexagon (2 layers)
-    reg = Register.max_connectivity(19, device)
+    reg = Register.max_connectivity(19, device, prefix="q")
     device.validate_register(reg)
     assert len(reg.qubits) == 19
     atoms = list(reg.qubits.values())
@@ -289,7 +293,7 @@ def test_max_connectivity():
 
     # Check extra atoms (2 full layers + 7 extra atoms)
     # for C3 symmetry, C6 symmetry and offset for next atoms
-    reg = Register.max_connectivity(26, device)
+    reg = Register.max_connectivity(26, device, prefix="q")
     device.validate_register(reg)
     assert len(reg.qubits) == 26
     atoms = list(reg.qubits.values())
@@ -313,7 +317,7 @@ def test_max_connectivity():
 
 
 def test_rotation():
-    reg = Register.square(2, spacing=np.sqrt(2))
+    reg = Register.square(2, spacing=np.sqrt(2), prefix="q")
     rot_reg = reg.rotated(45)
     new_coords_ = np.array([(0, -1), (1, 0), (-1, 0), (0, 1)], dtype=float)
     np.testing.assert_allclose(
@@ -332,21 +336,21 @@ draw_params = [
 @pytest.mark.parametrize("draw_params", draw_params)
 def test_drawing(draw_params, patch_plt_show):
     with pytest.raises(ValueError, match="Blockade radius"):
-        reg = Register.from_coordinates([(1, 0), (0, 1)])
+        reg = Register.from_coordinates([(1, 0), (0, 1)], prefix="q")
         reg.draw(blockade_radius=0.0, draw_half_radius=True, **draw_params)
 
-    reg = Register.from_coordinates([(1, 0), (0, 1)])
+    reg = Register.from_coordinates([(1, 0), (0, 1)], prefix="q")
     reg.draw(blockade_radius=0.1, draw_graph=True, **draw_params)
     with pytest.raises(ValueError, match="The register must have"):
         reg.draw(draw_empty_sites=True)
 
-    reg = Register.triangular_lattice(3, 8)
+    reg = Register.triangular_lattice(3, 8, prefix="q")
     reg.draw(**draw_params)
 
     with patch("matplotlib.pyplot.savefig"):
         reg.draw(fig_name="my_register.pdf")
 
-    reg = Register.rectangle(1, 8)
+    reg = Register.rectangle(1, 8, prefix="q")
     reg.draw(
         blockade_radius=5,
         draw_half_radius=True,
@@ -357,7 +361,7 @@ def test_drawing(draw_params, patch_plt_show):
     with pytest.raises(ValueError, match="'blockade_radius' to draw."):
         reg.draw(draw_half_radius=True, **draw_params)
 
-    reg = Register.square(1)
+    reg = Register.square(1, prefix="q")
     with pytest.raises(NotImplementedError, match="Needs more than one atom"):
         reg.draw(blockade_radius=5, draw_half_radius=True, **draw_params)
 
@@ -370,43 +374,43 @@ def test_drawing(draw_params, patch_plt_show):
 def test_orthorombic():
     # Check rows
     with pytest.raises(ValueError, match="The number of rows"):
-        Register3D.cuboid(0, 2, 2)
+        Register3D.cuboid(0, 2, 2, prefix="q")
 
     # Check columns
     with pytest.raises(ValueError, match="The number of columns"):
-        Register3D.cuboid(2, 0, 2)
+        Register3D.cuboid(2, 0, 2, prefix="q")
 
     # Check layers
     with pytest.raises(ValueError, match="The number of layers"):
-        Register3D.cuboid(2, 2, 0)
+        Register3D.cuboid(2, 2, 0, prefix="q")
 
     # Check spacing
     with pytest.raises(ValueError, match="Spacing"):
-        Register3D.cuboid(2, 2, 2, 0.0)
+        Register3D.cuboid(2, 2, 2, 0.0, prefix="q")
 
 
 def test_cubic():
     # Check side
     with pytest.raises(ValueError, match="The number of atoms per side"):
-        Register3D.cubic(0)
+        Register3D.cubic(0, prefix="q")
 
     # Check spacing
     with pytest.raises(ValueError, match="Spacing"):
-        Register3D.cubic(2, 0.0)
+        Register3D.cubic(2, 0.0, prefix="q")
 
 
 @pytest.mark.parametrize("draw_params", draw_params)
 def test_drawing3D(draw_params, patch_plt_show):
     with pytest.raises(ValueError, match="Blockade radius"):
-        reg = Register3D.from_coordinates([(1, 0, 0), (0, 0, 1)])
+        reg = Register3D.from_coordinates([(1, 0, 0), (0, 0, 1)], prefix="q")
         reg.draw(blockade_radius=0.0, **draw_params)
 
-    reg = Register3D.cubic(3, 8)
+    reg = Register3D.cubic(3, 8, prefix="q")
 
     with patch("matplotlib.pyplot.savefig"):
         reg.draw(fig_name="my_register.pdf", **draw_params)
 
-    reg = Register3D.cuboid(1, 8, 2)
+    reg = Register3D.cuboid(1, 8, 2, prefix="q")
     reg.draw(
         blockade_radius=5,
         draw_half_radius=True,
@@ -417,7 +421,7 @@ def test_drawing3D(draw_params, patch_plt_show):
     with pytest.raises(ValueError, match="'blockade_radius' to draw."):
         reg.draw(draw_half_radius=True, **draw_params)
 
-    reg = Register3D.cuboid(2, 2, 2)
+    reg = Register3D.cuboid(2, 2, 2, prefix="q")
     reg.draw(
         blockade_radius=5,
         draw_half_radius=True,
@@ -435,18 +439,18 @@ def test_drawing3D(draw_params, patch_plt_show):
         **draw_params,
     )
 
-    reg = Register3D.cubic(1)
+    reg = Register3D.cubic(1, prefix="q")
     with pytest.raises(NotImplementedError, match="Needs more than one atom"):
         reg.draw(blockade_radius=5, draw_half_radius=True, **draw_params)
 
 
 def test_to_2D():
-    reg = Register3D.cuboid(2, 2, 2)
+    reg = Register3D.cuboid(2, 2, 2, prefix="q")
     with pytest.raises(ValueError, match="Atoms are not coplanar"):
         reg.to_2D()
     reg.to_2D(tol_width=6)
 
-    reg = Register3D.cuboid(2, 2, 1)
+    reg = Register3D.cuboid(2, 2, 1, prefix="q")
     reg.to_2D()
 
 
@@ -505,17 +509,17 @@ def test_coords_hash():
     assert reg1.coords_hex_hash() == reg2.coords_hex_hash()
 
     # Same coords but in inverse order
-    reg3 = Register.from_coordinates(coords1[::-1])
+    reg3 = Register.from_coordinates(coords1[::-1], prefix="q")
     assert reg1.coords_hex_hash() == reg3.coords_hex_hash()
 
     # Modify a coordinate below precision
     coords1[0][0] += 1e-10
-    reg4 = Register.from_coordinates(coords1)
+    reg4 = Register.from_coordinates(coords1, prefix="q")
     assert reg1.coords_hex_hash() == reg4.coords_hex_hash()
 
     # Modify a coordinate above precision
     coords1[0][1] += 1e-6
-    reg5 = Register.from_coordinates(coords1)
+    reg5 = Register.from_coordinates(coords1, prefix="q")
     assert reg1.coords_hex_hash() != reg5.coords_hex_hash()
 
 
@@ -548,8 +552,10 @@ def test_custom_register_torch(register_type, coords, patch_plt_show):
     assert reg1 == reg2
 
     # Also check that centering keeps the grad
-    reg3 = register_type.from_coordinates([diff_qubit, coords[1]], center=True)
-    assert torch.all(reg3.qubits[0].as_tensor() == diff_qubit / 2)
+    reg3 = register_type.from_coordinates(
+        [diff_qubit, coords[1]], center=True, prefix="q"
+    )
+    assert torch.all(reg3.qubits["q0"].as_tensor() == diff_qubit / 2)
 
     for r in [reg1, reg2, reg3]:
         _assert_reg_requires_grad(r)
@@ -565,7 +571,7 @@ def test_custom_register_torch(register_type, coords, patch_plt_show):
 
     # check that generating with long type works
     reg4 = register_type.from_coordinates(
-        [torch.tensor(coord, dtype=torch.long) for coord in coords]
+        [torch.tensor(coord, dtype=torch.long) for coord in coords], prefix="q"
     )
     assert reg4 == reg3
 
@@ -607,6 +613,7 @@ def test_register_recipes_torch(
     torch = pytest.importorskip("torch")
     kwargs = {
         param_name: torch.tensor(6.0, requires_grad=requires_grad),
+        "prefix": "q",
         **extra_params,
     }
     reg = reg_classmethod(**kwargs)
@@ -625,7 +632,8 @@ def test_register_recipes_torch(
                     np.array([2.50157, 0.003283]),
                     np.array([-2.501571, 5.0]),
                     np.array([2.50157, 5.1]),
-                ]
+                ],
+                prefix="q",
             ),
             8,
         ),
@@ -636,7 +644,8 @@ def test_register_recipes_torch(
                     np.array([2.50157, 0.003283], dtype=np.float32),
                     np.array([-2.501571, 5.0], dtype=np.float32),
                     np.array([2.50157, 5.1], dtype=np.float32),
-                ]
+                ],
+                prefix="q",
             ),
             8,
         ),
@@ -647,7 +656,8 @@ def test_register_recipes_torch(
                     np.array([2.50157, 0.003283], dtype=np.float32),
                     np.array([-2.501571, 5.0], dtype=np.float64),
                     np.array([2.50157, 5.1], dtype=np.float64),
-                ]
+                ],
+                prefix="q",
             ),
             8,
         ),
@@ -734,7 +744,7 @@ def test_automatic_layout(optimal_filling, reg, max_atom_num):
         )
 
     # The Register is larger than max_traps
-    big_reg = Register.square(8, spacing=5)
+    big_reg = Register.square(8, spacing=5, prefix="q")
     min_traps = np.ceil(len(big_reg.qubit_ids) / max_layout_filling)
     with pytest.raises(
         RuntimeError, match="Failed to find a site for 2 traps"
@@ -756,5 +766,5 @@ def test_automatic_layout_diff():
         match="does not support registers with differentiable coordinates",
     ):
         Register.square(
-            2, spacing=torch.tensor(10.0, requires_grad=True)
+            2, spacing=torch.tensor(10.0, requires_grad=True), prefix="q"
         ).with_automatic_layout(AnalogDevice)

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -96,6 +96,12 @@ def test_creation():
     ):
         Register(qubits, spacing=10, layout="square", trap_ids=(0, 1, 3))
 
+    with pytest.warns(
+        DeprecationWarning,
+        match="Usage of `int`s or any non-`str`types as `QubitId`s",
+    ):
+        Register.from_coordinates([(0, 0)])
+
 
 def test_repr():
     assert (

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -148,7 +148,7 @@ def test_static_hash(layout):
 
 def test_eq(layout, layout3d):
     assert RegisterLayout([[0, 0], [1, 0]]) != Register.from_coordinates(
-        [[0, 0], [1, 0]]
+        [[0, 0], [1, 0]], prefix=""
     )
     assert layout != layout3d
     layout1 = RegisterLayout([[0, 0], [1, 0]])

--- a/tests/test_sequence_sampler.py
+++ b/tests/test_sequence_sampler.py
@@ -244,7 +244,7 @@ def test_modulation_local(mod_device):
 
 @pytest.mark.parametrize("disable_eom", [True, False])
 def test_eom_modulation(mod_device, disable_eom):
-    seq = pulser.Sequence(pulser.Register.square(2), mod_device)
+    seq = pulser.Sequence(pulser.Register.square(2, prefix="q"), mod_device)
     seq.declare_channel("ch0", "rydberg_global")
     seq.enable_eom_mode("ch0", amp_on=1, detuning_on=0.0)
     seq.add_eom_pulse("ch0", 100, 0.0)
@@ -321,7 +321,7 @@ def test_seq_with_DMM_and_map_reg():
 
 
 def seq_with_SLM(
-    ch_name: Literal["mw_global", "rydberg_global"]
+    ch_name: Literal["mw_global", "rydberg_global"],
 ) -> pulser.Sequence:
     q_dict = {
         "batman": np.array([-4.0, 0.0]),  # sometimes masked
@@ -517,7 +517,9 @@ def test_phase_modulation(off_center, with_diff):
         pulser.ConstantWaveform(full_phase.duration, 1), full_phase
     )
 
-    seq = pulser.Sequence(pulser.Register.square(1), pulser.MockDevice)
+    seq = pulser.Sequence(
+        pulser.Register.square(1, prefix="q"), pulser.MockDevice
+    )
     seq.declare_channel("rydberg_global", "rydberg_global")
     seq.add(pulse, "rydberg_global")
     seq_samples = sample(seq).channel_samples["rydberg_global"]

--- a/tests/test_waveforms.py
+++ b/tests/test_waveforms.py
@@ -269,7 +269,8 @@ def test_interpolated():
 
     # Init an InterpolatedWaveform that always fails at build fails
     seq = pulser.Sequence(
-        pulser.Register.square(2, 5), device=pulser.DigitalAnalogDevice
+        pulser.Register.square(2, 5, prefix="q"),
+        device=pulser.DigitalAnalogDevice,
     )
 
     values = seq.declare_variable("values", size=5)  # a Variable


### PR DESCRIPTION
- Reduce the warnings filter from `"always"` to once
- Handle all cases where the warning is raised in the unit tests