### PR TITLE
Improve exceptions in Sequence.switch_device()

### DIFF
--- a/pulser-core/pulser/exceptions/sequence.py
+++ b/pulser-core/pulser/exceptions/sequence.py
@@ -292,3 +292,9 @@ class MaxNumberOfTrapsError(InvalidSequenceError):
             "or equal to the minimum number of layout traps "
             f"({self.device.min_layout_traps})."
         )
+
+
+class SwitchDeviceError(PulserValueError):
+    """Error trying to switch the device of a Sequence."""
+
+    pass


### PR DESCRIPTION
- Fixes issue where the error message was not appearing
- Creates and introduces a custom `SwitchDeviceError`
- Explicitly checks for compatibility of the register with the new device