### PR TITLE
Added EmuMPSBackend, MPSBackend & SVBackend to pulser.backends  (#903)

### DIFF
--- a/pulser-core/pulser/backends.py
+++ b/pulser-core/pulser/backends.py
@@ -39,9 +39,10 @@ if TYPE_CHECKING:
     from pulser.backend import QPUBackend as QPUBackend
     from pulser.backend.abc import Backend
     from pulser_simulation import QutipBackendV2 as QutipBackendV2
-    from pulser_pasqal import EmuMPSBackend as EmuMPSBackend
-    from emu_mps import MPSBackend as MPSBackend
-    from emu_sv import SVBackend as SVBackend
+    from pulser_pasqal import EmuFreeBackend as EmuFreeBackend    # type: ignore[import]
+    from pulser_pasqal import EmuMPSBackend as EmuMPSBackend  # type: ignore[import]
+    from emu_mps import MPSBackend as MPSBackend  # type: ignore[import]
+    from emu_sv import SVBackend as SVBackend  # type: ignore[import]
 
 
 _BACKENDS = {

--- a/pulser-core/pulser/backends.py
+++ b/pulser-core/pulser/backends.py
@@ -36,19 +36,18 @@ import importlib
 from typing import TYPE_CHECKING, Type
 
 if TYPE_CHECKING:
-    from emu_mps import MPSBackend  # type: ignore[import]
-    from emu_mps import MPSBackend as MPSBackend
-    from emu_sv import SVBackend  # type: ignore[import]
-    from emu_sv import SVBackend as SVBackend
-    from pulser_pasqal import EmuFreeBackend  # type: ignore[import]
+    from emu_mps import (
+        MPSBackend as MPSBackend,  # type: ignore[import]
+    )
+    from emu_sv import (
+        SVBackend as SVBackend,  # type: ignore[import]
+    )
     from pulser_pasqal import (
         EmuFreeBackend as EmuFreeBackend,  # type: ignore[import]
     )
-    from pulser_pasqal import EmuMPSBackend  # type: ignore[import]
     from pulser_pasqal import (
         EmuMPSBackend as EmuMPSBackend,  # type: ignore[import]
     )
-
     from pulser.backend import QPUBackend as QPUBackend
     from pulser.backend.abc import Backend
     from pulser_simulation import QutipBackendV2 as QutipBackendV2

--- a/pulser-core/pulser/backends.py
+++ b/pulser-core/pulser/backends.py
@@ -39,6 +39,10 @@ if TYPE_CHECKING:
     from pulser.backend import QPUBackend as QPUBackend
     from pulser.backend.abc import Backend
     from pulser_simulation import QutipBackendV2 as QutipBackendV2
+    from pulser_pasqal import EmuMPSBackend as EmuMPSBackend
+    from emu_mps import MPSBackend as MPSBackend
+    from emu_sv import SVBackend as SVBackend
+
 
 _BACKENDS = {
     "QPUBackend": "pulser.backend",
@@ -46,6 +50,9 @@ _BACKENDS = {
     "QutipBackendV2": "pulser_simulation",
     "EmuFreeBackend": "pulser_pasqal",
     "EmuTNBackend": "pulser_pasqal",
+    "EmuMPSBackend": "pulser_pasqal",
+    "MPSBackend": "emu_mps",
+    "SVBackend": "emu_sv",
 }
 
 

--- a/pulser-core/pulser/backends.py
+++ b/pulser-core/pulser/backends.py
@@ -36,13 +36,26 @@ import importlib
 from typing import TYPE_CHECKING, Type
 
 if TYPE_CHECKING:
+    from emu_mps import MPSBackend  # type: ignore[import]
+    from emu_mps import MPSBackend as MPSBackend
+    from emu_sv import SVBackend  # type: ignore[import]
+    from emu_sv import SVBackend as SVBackend
+    from pulser_pasqal import EmuFreeBackend  # type: ignore[import]
+    from pulser_pasqal import (
+        EmuFreeBackend as EmuFreeBackend,  # type: ignore[import]
+    )
+    from pulser_pasqal import EmuMPSBackend  # type: ignore[import]
+    from pulser_pasqal import (
+        EmuMPSBackend as EmuMPSBackend,  # type: ignore[import]
+    )
+
     from pulser.backend import QPUBackend as QPUBackend
     from pulser.backend.abc import Backend
     from pulser_simulation import QutipBackendV2 as QutipBackendV2
-    from pulser_pasqal import EmuFreeBackend as EmuFreeBackend    # type: ignore[import]
-    from pulser_pasqal import EmuMPSBackend as EmuMPSBackend  # type: ignore[import]
-    from emu_mps import MPSBackend as MPSBackend  # type: ignore[import]
-    from emu_sv import SVBackend as SVBackend  # type: ignore[import]
+    from pulser_pasqal import EmuFreeBackend  # type: ignore[import]
+    from pulser_pasqal import EmuMPSBackend  # type: ignore[import]
+    from emu_mps import MPSBackend           # type: ignore[import]
+    from emu_sv import SVBackend             # type: ignore[import]
 
 
 _BACKENDS = {

--- a/pulser-core/pulser/backends.py
+++ b/pulser-core/pulser/backends.py
@@ -51,10 +51,7 @@ if TYPE_CHECKING:
     from pulser.backend import QPUBackend as QPUBackend
     from pulser.backend.abc import Backend
     from pulser_simulation import QutipBackendV2 as QutipBackendV2
-    from pulser_pasqal import EmuFreeBackend  # type: ignore[import]
-    from pulser_pasqal import EmuMPSBackend  # type: ignore[import]
-    from emu_mps import MPSBackend           # type: ignore[import]
-    from emu_sv import SVBackend             # type: ignore[import]
+    
 
 
 _BACKENDS = {


### PR DESCRIPTION
Made `EmuMPSBackend`, `MPSBackend`, and `SVBackend` importable via
  `pulser.backends` (just added them to the _BACKENDS dict).