### PR TITLE
Deal with Pillow 11.3 deprecation warning

### DIFF
--- a/pulser-core/requirements.txt
+++ b/pulser-core/requirements.txt
@@ -1,6 +1,10 @@
 jsonschema >= 4.17.3, < 5
-referencing
+referencing  # A dependency of jsonschema we use. We let jsonschema set the version
 matplotlib < 4
+# This is a dependency from matplotlib that raises a DeprecationWarning from 11.3
+# TODO: Remove when matplolib >= 3.10.4 and replace by
+# pillow < 11.3.0; python_version <= '3.9'
+pillow < 11.3.0 
 packaging   # This is already required by matplotlib but we use it too
 # Numpy 1.20 introduces type hints, 1.24.0 breaks matplotlib < 3.6.1
 numpy >= 1.20, != 1.24.0


### PR DESCRIPTION
- This should fix the failing tests from a `DeprecationWarning` raised by Pillow 1.3 due to usage inside `matplotlib`.
- `matplotlib 3.10.4` will handle this but it is not yet released
- It won't be dealt with for Python 3.9 because `matplotlib` stopped supporting it after v3.9