### PR TITLE
Handle UserWarning raised when casting torch to float

### DIFF
--- a/pulser-core/pulser/math/abstract_array.py
+++ b/pulser-core/pulser/math/abstract_array.py
@@ -166,13 +166,13 @@ class AbstractArray:
         return str(self._array.__repr__())
 
     def __int__(self) -> int:
-        return int(self._array)
+        return int(self.as_array(detach=True))
 
     def __float__(self) -> float:
-        return float(self._array)
+        return float(self.as_array(detach=True))
 
     def __bool__(self) -> bool:
-        return bool(self._array)
+        return bool(self.as_array(detach=True))
 
     # Unary operators
     def __neg__(self) -> AbstractArray:

--- a/pulser-core/pulser/waveforms.py
+++ b/pulser-core/pulser/waveforms.py
@@ -57,7 +57,9 @@ T = TypeVar("T", int, float)
 
 def _cast_check(type_: type[T], value: Any, name: str) -> T:
     try:
-        return type_(value)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            return type_(value)
     except (ValueError, TypeError) as e:
         raise TypeError(
             f"'{name}' needs to be castable to {type_.__name__!s} "


### PR DESCRIPTION
From torch 2.8, torch seems to raise a UserWarning when casting a torch tensor having a gradient to a type not having a gradient (float, int, bool)