### PR TITLE
Antecipate fixes from 1.6 release

### DIFF
--- a/pulser-core/pulser/backend/results.py
+++ b/pulser-core/pulser/backend/results.py
@@ -24,6 +24,7 @@ from typing import Any, TypeVar, overload
 from pulser.backend.observable import Observable
 from pulser.json.abstract_repr.serializer import AbstractReprEncoder
 from pulser.json.abstract_repr.validation import validate_abstract_repr
+from pulser.json.utils import stringify_qubit_ids
 
 
 @dataclass
@@ -147,7 +148,7 @@ class Results:
 
     def _to_abstract_repr(self) -> dict:
         d = {
-            "atom_order": self.atom_order,
+            "atom_order": stringify_qubit_ids(self.atom_order),
             "total_duration": self.total_duration,
         }
         d["tagmap"] = {key: str(value) for key, value in self._tagmap.items()}

--- a/pulser-core/pulser/backend/results.py
+++ b/pulser-core/pulser/backend/results.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field
 from typing import Any, TypeVar, overload
 
 from pulser.backend.observable import Observable
+from pulser.json.abstract_repr.deserializer import deserialize_complex
 from pulser.json.abstract_repr.serializer import AbstractReprEncoder
 from pulser.json.abstract_repr.validation import validate_abstract_repr
 from pulser.json.utils import stringify_qubit_ids
@@ -167,7 +168,7 @@ class Results:
         for key, value in dict["tagmap"].items():
             results._tagmap[key] = uuid.UUID(value)
         for key, value in dict["results"].items():
-            results._results[uuid.UUID(key)] = value
+            results._results[uuid.UUID(key)] = deserialize_complex(value)
         for key, value in dict["times"].items():
             results._times[uuid.UUID(key)] = value
         return results

--- a/pulser-core/pulser/json/abstract_repr/backend.py
+++ b/pulser-core/pulser/json/abstract_repr/backend.py
@@ -16,8 +16,8 @@ from pulser.backend.default_observables import (
 )
 from pulser.exceptions.serialization import AbstractReprError
 from pulser.json.abstract_repr.deserializer import (
-    _convert_complex,
     _deserialize_noise_model,
+    deserialize_complex,
 )
 
 if TYPE_CHECKING:
@@ -42,7 +42,7 @@ def _deserialize_state(
     """
     return state_type.from_state_amplitudes(
         eigenstates=ser_state["eigenstates"],
-        amplitudes=_convert_complex(ser_state["amplitudes"]),
+        amplitudes=deserialize_complex(ser_state["amplitudes"]),
     )
 
 
@@ -69,7 +69,7 @@ def _deserialize_operator(
     return op_type.from_operator_repr(
         eigenstates=ser_op["eigenstates"],
         n_qudits=ser_op["n_qudits"],
-        operations=_convert_complex(operations),
+        operations=deserialize_complex(operations),
     )
 
 

--- a/pulser-core/pulser/json/abstract_repr/deserializer.py
+++ b/pulser-core/pulser/json/abstract_repr/deserializer.py
@@ -421,16 +421,16 @@ def _deserialize_register3d(
     return cast(pulser.Register3D, reg)
 
 
-def _convert_complex(obj: Any) -> Any:
+def deserialize_complex(obj: Any) -> Any:
     """Searches for serialized complex numbers and converts them."""
     if isinstance(obj, list):
-        return [_convert_complex(e) for e in obj]
+        return [deserialize_complex(e) for e in obj]
     if isinstance(obj, tuple):
-        return tuple(_convert_complex(e) for e in obj)
+        return tuple(deserialize_complex(e) for e in obj)
     if isinstance(obj, dict):
         if obj.keys() == {"real", "imag"}:
             return obj["real"] + 1j * obj["imag"]
-        return {k: _convert_complex(v) for k, v in obj.items()}
+        return {k: deserialize_complex(v) for k, v in obj.items()}
     return obj
 
 
@@ -439,7 +439,7 @@ def _deserialize_noise_model(noise_model_obj: dict[str, Any]) -> NoiseModel:
     eff_noise_opers = []
     for rate, oper in noise_model_obj.pop("eff_noise"):
         eff_noise_rates.append(rate)
-        eff_noise_opers.append(_convert_complex(oper))
+        eff_noise_opers.append(deserialize_complex(oper))
 
     noise_types = noise_model_obj.pop("noise_types")
     with_leakage = "leakage" in noise_types

--- a/pulser-core/pulser/register/base_register.py
+++ b/pulser-core/pulser/register/base_register.py
@@ -79,14 +79,17 @@ class BaseRegister(ABC, CoordsCollection):
         )
         self._ids: tuple[QubitId, ...] = tuple(qubits.keys())
         if any(not isinstance(id, str) for id in self._ids):
-            warnings.warn(
-                "Usage of `int`s or any non-`str`types as `QubitId`s will be "
-                "deprecated. Define your `QubitId`s as `str`s, prefer setting "
-                "`prefix='q'` when using classmethods, as that will become the"
-                " new default once `int` qubit IDs become invalid.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings("always")
+                warnings.warn(
+                    "Usage of `int`s or any non-`str`types as `QubitId`s will "
+                    "be deprecated. Define your `QubitId`s as `str`s, prefer "
+                    "setting `prefix='q'` when using classmethods, as that "
+                    "will become the new default once `int` qubit IDs become "
+                    "invalid.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
         self._layout_info: Optional[_LayoutInfo] = None
         self._init_kwargs(**kwargs)
 

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -417,7 +417,7 @@ class QutipEmulator:
             # Note: if `value` is very small `eval_times` is an empty list:
             eval_times = self._hamiltonian.sampling_times[indices]
         elif isinstance(value, (list, tuple, np.ndarray)):
-            if np.max(value, initial=0) > self._tot_duration / 1000:
+            if np.max(value, initial=0) > self._tot_duration * 1e-3:
                 raise ValueError(
                     "Provided evaluation-time list extends "
                     "further than sequence duration."
@@ -436,7 +436,7 @@ class QutipEmulator:
             )
         # Ensure 0 and final time are included:
         self._eval_times_array = np.union1d(
-            eval_times, [0.0, self._tot_duration / 1000]
+            eval_times, [0.0, self._tot_duration * 1e-3]
         )
         self._eval_times_instruction = value
 

--- a/tests/test_backend_abstract_repr.py
+++ b/tests/test_backend_abstract_repr.py
@@ -576,3 +576,17 @@ def test_result_serialization(test_torch: bool):
             obs
         )
     assert results.get_result_tags() == deserialized.get_result_tags()
+
+
+def test_result_atom_order_serialization():
+    with pytest.warns(UserWarning, match="converts all qubit ID's to strings"):
+        assert Results.from_abstract_repr(
+            Results(
+                atom_order=(0, 1, 2), total_duration=1000
+            ).to_abstract_repr()
+        ) == Results(atom_order=("0", "1", "2"), total_duration=1000)
+
+        with pytest.raises(
+            AbstractReprError, match="Name collisions encountered"
+        ):
+            Results(atom_order=(0, "0"), total_duration=10).to_abstract_repr()


### PR DESCRIPTION
These were non-critical fixes planned for release with Pulser 1.6 but since that is taking a while, we'll release them ahead of time.

- Properly deserialize complex values in Results (#892)
- Handle when Results.atom_order entries are not strings (#891)
- Fix evaluation times rounding error in QutipBackendV2 (#894)