### PR TITLE
Isolate EmulationConfig validation in EmulatorBackend.validate_config()

### DIFF
--- a/pulser-core/pulser/backend/abc.py
+++ b/pulser-core/pulser/backend/abc.py
@@ -96,7 +96,19 @@ class EmulatorBackend(Backend):
     ) -> None:
         """Initializes the backend."""
         super().__init__(sequence, mimic_qpu=mimic_qpu)
-        config = config or self.default_config
+        self._config = self.validate_config(config or self.default_config)
+
+    @classmethod
+    def validate_config(cls, config: EmulationConfig) -> EmulationConfig:
+        """Validates a given configuration for this backend.
+
+        Args:
+            config: The configuration to validate.
+
+        Returns:
+            The full configuration that will be used by the backend if
+            the given configuration passes validation.
+        """
         if not isinstance(config, EmulationConfig):
             raise TypeError(
                 "'config' must be an instance of 'EmulationConfig', "
@@ -105,9 +117,9 @@ class EmulatorBackend(Backend):
         # Use all the parameters in config and then fill the rest with the
         # ones of default_config
         # See the BackendConfig definition to see why this works
-        self._config = type(self.default_config)(
+        return type(cls.default_config)(
             **{
-                **self.default_config._backend_options,
+                **cls.default_config._backend_options,
                 **config._backend_options,
             }
         )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 import re
 import typing
 import uuid
@@ -395,22 +396,37 @@ def test_emulator_backend(sequence):
     ):
         ConcreteEmulator(sequence, config=EmulatorConfig)
 
-    emu = ConcreteEmulator(
-        sequence,
-        config=EmulationConfig(
-            observables=(BitStrings(),), default_evaluation_times="Full"
-        ),
+    concrete_config = EmulationConfig(
+        observables=(BitStrings(),),
+        default_evaluation_times="Full",
+        my_param="bar",
     )
-    assert emu._config.default_evaluation_times == "Full"
-    # with_modulation is not True because EmulationConfig has it in the
-    # signature as `with_modulation=False``
-    assert not emu._config.with_modulation
-    # But the parameter that's not in EmulationConfig's signature is still
-    # passed to the config
-    assert emu._config.extra_param == "foo"
+    emu = ConcreteEmulator(sequence, config=concrete_config)
 
-    # Uses the default config
-    assert ConcreteEmulator(sequence)._config.with_modulation
+    # The adopted configuration, as given by validate_config
+    # (we use the abstract representation to compare them)
+    assert (
+        json.loads(emu._config.to_abstract_repr())
+        == json.loads(
+            ConcreteEmulator.validate_config(
+                concrete_config
+            ).to_abstract_repr()
+        )
+        == json.loads(
+            EmulationConfig(
+                # These come from the concrete config
+                observables=(BitStrings(),),
+                default_evaluation_times="Full",
+                my_param="bar",
+                # with_modulation is not True because EmulationConfig has it
+                # in the signature as `with_modulation=False``
+                with_modulation=False,
+                # But the parameter that's not in EmulationConfig's signature
+                # is still passed to the config
+                extra_param="foo",
+            ).to_abstract_repr()
+        )
+    )
 
 
 def test_backend_config():


### PR DESCRIPTION
This permits the validation of an `EmulationConfig` through the target backend class alone (ie. without needing to instantiate it). It should make it easier to perform an early check on a config when only the target backend class is known.