### PR TITLE
Convert hf detuning noise units from Hz to rad/microsec

### DIFF
--- a/pulser-core/pulser/_hamiltonian_data/hamiltonian_data.py
+++ b/pulser-core/pulser/_hamiltonian_data/hamiltonian_data.py
@@ -164,14 +164,13 @@ def _generate_detuning_fluctuations(
     det_hf = np.zeros_like(times)
 
     if noise_model.detuning_hf_psd:
-        t = np.asarray(times) * 1e-9  # ns -> s
-        freqs = np.asarray(noise_model.detuning_hf_freqs)[1:]
+        t = np.asarray(times) * 1e-3  # ns -> microsec
+        freqs = np.asarray(noise_model.detuning_hf_omegas)[1:]
         psd = np.asarray(noise_model.detuning_hf_psd)[1:]
-        df = np.diff(noise_model.detuning_hf_freqs)
+        df = np.diff(noise_model.detuning_hf_omegas)
         amp = np.sqrt(2.0 * df * psd)
         arg = freqs[:, None] * t[None, :] + phases[:, None]
-        det_hf = (amp[:, None] * np.cos(2.0 * np.pi * arg)).sum(axis=0)
-        det_hf *= 2.0 * np.pi * 1e-6  # Hz -> rad/microsec
+        det_hf = (amp[:, None] * np.cos(arg)).sum(axis=0)
     return det_cst_term + det_hf
 
 
@@ -763,9 +762,11 @@ class HamiltonianData:
                 if self.noise_model.detuning_sigma
                 else 0.0
             )
-            if self._noise_model.detuning_hf_freqs:
+            if self._noise_model.detuning_hf_omegas:
                 det_phases[ch] = np.random.uniform(
-                    0.0, 1.0, size=len(self._noise_model.detuning_hf_freqs) - 1
+                    0.0,
+                    2 * np.pi,
+                    size=len(self._noise_model.detuning_hf_omegas) - 1,
                 )
             else:
                 det_phases[ch] = np.array(0.0)

--- a/pulser-core/pulser/json/abstract_repr/deserializer.py
+++ b/pulser-core/pulser/json/abstract_repr/deserializer.py
@@ -460,14 +460,14 @@ def _deserialize_noise_model(noise_model_obj: dict[str, Any]) -> NoiseModel:
     relevant_params -= {"detuning_sigma"}  # Handled separately, optional arg
 
     detuning_hf_psd = []
-    detuning_hf_freqs = []
+    detuning_hf_omegas = []
     if "detuning_hf" in noise_model_obj:
         for psd, freq in noise_model_obj.pop("detuning_hf"):
             detuning_hf_psd.append(psd)
-            detuning_hf_freqs.append(freq)
+            detuning_hf_omegas.append(freq)
     relevant_params -= {  # Handled separately
         "detuning_hf_psd",
-        "detuning_hf_freqs",
+        "detuning_hf_omegas",
     }
 
     noise_model = pulser.NoiseModel(
@@ -476,7 +476,7 @@ def _deserialize_noise_model(noise_model_obj: dict[str, Any]) -> NoiseModel:
         eff_noise_opers=tuple(eff_noise_opers),
         with_leakage=with_leakage,
         detuning_hf_psd=tuple(detuning_hf_psd),
-        detuning_hf_freqs=tuple(detuning_hf_freqs),
+        detuning_hf_omegas=tuple(detuning_hf_omegas),
         detuning_sigma=detuning_sigma,
     )
     assert set(noise_model.noise_types) == set(noise_types)

--- a/pulser-core/pulser/noise_model.py
+++ b/pulser-core/pulser/noise_model.py
@@ -48,7 +48,7 @@ _NOISE_TYPE_PARAMS: dict[NoiseTypes, tuple[str, ...]] = {
     "doppler": ("temperature",),
     "register": ("trap_waist", "trap_depth"),
     "amplitude": ("laser_waist", "amp_sigma"),
-    "detuning": ("detuning_sigma", "detuning_hf_psd", "detuning_hf_freqs"),
+    "detuning": ("detuning_sigma", "detuning_hf_psd", "detuning_hf_omegas"),
     "SPAM": ("p_false_pos", "p_false_neg", "state_prep_error"),
     "dephasing": ("dephasing_rate", "hyperfine_dephasing_rate"),
     "relaxation": ("relaxation_rate",),
@@ -102,7 +102,7 @@ OPTIONAL_IN_ABSTR_REPR = (
     "trap_waist",
     "trap_depth",
     "detuning_hf_psd",
-    "detuning_hf_freqs",
+    "detuning_hf_omegas",
 )
 
 
@@ -154,7 +154,7 @@ class NoiseModel:
       ``detuning_sigma``;
       (2) time-dependent high-frequency fluctuations, defined by the
       power spectral density ``detuning_hf_psd`` over the relevant
-      ``detuning_hf_freqs`` frequencies support.
+      ``detuning_hf_omegas`` frequencies support.
       δ_hf(t) = Σ_k sqrt(2 * Δf_k * psd_k) * cos(2π(f_k * t + φ_k))
       where φ_k ~ U[0, 1) (uniform random phase),
       Δf_k = freqs[k+1] - freqs[k].
@@ -192,16 +192,16 @@ class NoiseModel:
             Defaults to 0.
         trap_depth: The potential energy well depth that confines the atoms
             (in µK). Defaults to None.
-        detuning_hf_psd: Power Spectral Density(PSD) is 1D tuple (in Hz²/Hz)
-            provided together with `detuning_hf_freqs` define high frequency
+        detuning_hf_psd: Power Spectral Density(PSD) is 1D tuple (in rad/µs)
+            provided together with `detuning_hf_omegas` define high frequency
             noise contribution of time dependent detuning (in rad/µs).
             Must either be empty or a tuple with at least two values,
-            matching the length of `detuning_hf_freqs`. Default is ().
-        detuning_hf_freqs: 1D tuple (in Hz) of relevant frequency support
-            for PSD. Along with PSD, it is required to define high frequency
-            noise contribution of time dependent detuning (in rad/µs).
-            Must either be empty or a tuple with at least two values,
-            matching the length of `detuning_hf_psd`. Default is ().
+            matching the length of `detuning_hf_omegas`. Default is ().
+        detuning_hf_omegas: 1D tuple (in rad/µs) of relevant angular frequency
+            support for the PSD. Along with the PSD, it is required to define
+            high frequency noise contribution of time dependent detuning
+            (in rad/µs). Must either be empty or a tuple with at least two
+            values, matching the length of `detuning_hf_psd`. Default is ().
         relaxation_rate: The rate of relaxation from the Rydberg to the
             ground state (in 1/µs). Corresponds to 1/T1. Defaults to 0.
         dephasing_rate: The rate of a dephasing occuring (in 1/µs) in a
@@ -231,7 +231,7 @@ class NoiseModel:
     amp_sigma: float = 0.0
     detuning_sigma: float = 0.0
     detuning_hf_psd: tuple[float, ...] = ()
-    detuning_hf_freqs: tuple[float, ...] = ()
+    detuning_hf_omegas: tuple[float, ...] = ()
     relaxation_rate: float = 0.0
     dephasing_rate: float = 0.0
     # if the trap depth is not None the trap waist should be 0.0
@@ -262,7 +262,7 @@ class NoiseModel:
         param_vals["eff_noise_opers"] = to_tuple(self.eff_noise_opers)
 
         param_vals["detuning_hf_psd"] = to_tuple(self.detuning_hf_psd)
-        param_vals["detuning_hf_freqs"] = to_tuple(self.detuning_hf_freqs)
+        param_vals["detuning_hf_omegas"] = to_tuple(self.detuning_hf_omegas)
 
         # Checking the type of provided positive and probability parameters
         for p_, val in param_vals.items():
@@ -284,7 +284,7 @@ class NoiseModel:
         self._check_leakage_noise(true_noise_types)
         self._check_detuning_hf_noise(
             param_vals["detuning_hf_psd"],
-            param_vals["detuning_hf_freqs"],
+            param_vals["detuning_hf_omegas"],
         )
         self._check_eff_noise(
             cast(tuple, param_vals["eff_noise_rates"]),
@@ -401,8 +401,8 @@ class NoiseModel:
     ) -> None:
         if (psd == ()) ^ (freqs == ()):
             raise ValueError(
-                "`detuning_hf_psd` and `detuning_hf_freqs` must either both be"
-                " empty tuples or both be provided."
+                "`detuning_hf_psd` and `detuning_hf_omegas` must either"
+                " both be empty tuples or both be provided."
             )
 
         if psd == ():
@@ -413,31 +413,31 @@ class NoiseModel:
 
         if psd_a.ndim != 1 or freqs_a.ndim != 1:
             raise ValueError(
-                "`detuning_hf_psd` and `detuning_hf_freqs`"
+                "`detuning_hf_psd` and `detuning_hf_omegas`"
                 " are expected to be 1D tuples."
             )
 
         if psd_a.size != freqs_a.size:
             raise ValueError(
-                "`detuning_hf_psd` and `detuning_hf_freqs`"
+                "`detuning_hf_psd` and `detuning_hf_omegas`"
                 " are expected to have the same length."
             )
 
         if psd_a.size <= 1:
             raise ValueError(
-                "`detuning_hf_psd` and `detuning_hf_freqs`"
+                "`detuning_hf_psd` and `detuning_hf_omegas`"
                 " are expected to have length > 1."
             )
 
         if not (np.all(psd_a > 0) and np.all(freqs_a > 0)):
             raise ValueError(
-                "`detuning_hf_psd` and `detuning_hf_freqs`"
+                "`detuning_hf_psd` and `detuning_hf_omegas`"
                 " are expected to have positive values."
             )
 
         if np.any(np.diff(freqs_a) < 0):
             raise ValueError(
-                "`detuning_hf_freqs` are expected to be monotonously growing."
+                "`detuning_hf_omegas` are expected to be monotonously growing."
             )
 
     @staticmethod
@@ -550,7 +550,7 @@ class NoiseModel:
 
         if "detuning_hf_psd" in all_fields:
             det_hf_psd = all_fields.pop("detuning_hf_psd")
-            det_hf_freqs = all_fields.pop("detuning_hf_freqs")
+            det_hf_freqs = all_fields.pop("detuning_hf_omegas")
             all_fields["detuning_hf"] = list(zip(det_hf_psd, det_hf_freqs))
 
         return all_fields

--- a/pulser-core/pulser/noise_model.py
+++ b/pulser-core/pulser/noise_model.py
@@ -158,8 +158,8 @@ class NoiseModel:
       power spectral density (PSD) ``detuning_hf_psd`` over the relevant
       ``detuning_hf_omegas`` angular frequency support.
       :math:`\delta_{hf}(t) = \sum_k \sqrt(2*\Delta \omega_k*\mathrm{PSD}_k)
-      * \cos(2\pi(\omega_k * t + \phi_k))`
-      where :math:`\phi_k \backsim U[0, 1)` (uniform random phase),
+      * \cos(\omega_k * t + \phi_k)`
+      where :math:`\phi_k \backsim U[0, 2\pi)` (uniform random phase),
       and :math:`\Delta \omega_k = \omega_{k+1} - \omega_k`.
     - **SPAM**: SPAM errors. Parametrized by ``state_prep_error``,
       ``p_false_pos`` and ``p_false_neg``.

--- a/pulser-core/pulser/noise_model.py
+++ b/pulser-core/pulser/noise_model.py
@@ -153,12 +153,12 @@ class NoiseModel:
       (1) constant offset (zero-frequency), parameterized by
       ``detuning_sigma``;
       (2) time-dependent high-frequency fluctuations, defined by the
-      power spectral density ``detuning_hf_psd`` over the relevant
-      ``detuning_hf_omegas`` frequencies support.
-      :math:`\delta_{hf}(t) = \Sigma_k \sqrt(2 * \Delta f_k * psd_k)
-      * \cos(2\pi(f_k * t + \phi_k))`
+      power spectral density (PSD) ``detuning_hf_psd`` over the relevant
+      ``detuning_hf_omegas`` angular frequency support.
+      :math:`\delta_{hf}(t) = \sum_k \sqrt(2*\Delta \omega_k*\mathrm{PSD}_k)
+      * \cos(2\pi(\omega_k * t + \phi_k))`
       where :math:`\phi_k \backsim U[0, 1)` (uniform random phase),
-      and :math:`\Delta f_k = freqs[k+1] - freqs[k]`.
+      and :math:`\Delta \omega_k = \omega_{k+1} - \omega_k`.
     - **SPAM**: SPAM errors. Parametrized by ``state_prep_error``,
       ``p_false_pos`` and ``p_false_neg``.
 
@@ -193,7 +193,7 @@ class NoiseModel:
             Defaults to 0.
         trap_depth: The potential energy well depth that confines the atoms
             (in µK). Defaults to None.
-        detuning_hf_psd: Power Spectral Density(PSD) is 1D tuple (in rad/µs)
+        detuning_hf_psd: Power Spectral Density (PSD) is 1D tuple (in rad/µs)
             provided together with `detuning_hf_omegas` define high frequency
             noise contribution of time dependent detuning (in rad/µs).
             Must either be empty or a tuple with at least two values,

--- a/pulser-core/pulser/noise_model.py
+++ b/pulser-core/pulser/noise_model.py
@@ -155,9 +155,10 @@ class NoiseModel:
       (2) time-dependent high-frequency fluctuations, defined by the
       power spectral density ``detuning_hf_psd`` over the relevant
       ``detuning_hf_omegas`` frequencies support.
-      δ_hf(t) = Σ_k sqrt(2 * Δf_k * psd_k) * cos(2π(f_k * t + φ_k))
-      where φ_k ~ U[0, 1) (uniform random phase),
-      Δf_k = freqs[k+1] - freqs[k].
+      :math:`\delta_{hf}(t) = \Sigma_k \sqrt(2 * \Delta f_k * psd_k)
+      * \cos(2\pi(f_k * t + \phi_k))`
+      where :math:`\phi_k \backsim U[0, 1)` (uniform random phase),
+      and :math:`\Delta f_k = freqs[k+1] - freqs[k]`.
     - **SPAM**: SPAM errors. Parametrized by ``state_prep_error``,
       ``p_false_pos`` and ``p_false_neg``.
 

--- a/pulser-core/pulser/noise_model.py
+++ b/pulser-core/pulser/noise_model.py
@@ -150,8 +150,10 @@ class NoiseModel:
       and ``amp_sigma``.
     - **detuning**: Detuning fluctuations consisting of two
       components:
+
       (1) constant offset (zero-frequency), parameterized by
-      ``detuning_sigma``;
+      ``detuning_sigma``
+
       (2) time-dependent high-frequency fluctuations, defined by the
       power spectral density (PSD) ``detuning_hf_psd`` over the relevant
       ``detuning_hf_omegas`` angular frequency support.

--- a/pulser-core/pulser/noise_model.py
+++ b/pulser-core/pulser/noise_model.py
@@ -138,10 +138,12 @@ class NoiseModel:
     - **register**: Thermal fluctuations in the
       register positions, parametrized by ``temperature``, ``trap_waist``
       and, ``trap_depth``, which must all be defined.
+
       (1) Plane standard deviation fluctuation given by:
       :math:`\sigma^{xy} = \sqrt{\frac{T w²}{4 U_{trap}}}`, where T is
       temperature, w is the trap waist and :math:`U_{trap}` is
       the trap depth.
+
       (2) Off plane standard deviation fluctuation given by:
       :math:`\sigma^z = \frac{\pi}{\lambda}\sqrt{2} w \sigma^{xy}`, where
       :math:`\lambda` is the trap wavelength with a constant value of 0.85 µm.

--- a/pulser-core/pulser/noise_model.py
+++ b/pulser-core/pulser/noise_model.py
@@ -157,7 +157,7 @@ class NoiseModel:
       (2) time-dependent high-frequency fluctuations, defined by the
       power spectral density (PSD) ``detuning_hf_psd`` over the relevant
       ``detuning_hf_omegas`` angular frequency support.
-      :math:`\delta_{hf}(t) = \sum_k \sqrt(2*\Delta \omega_k*\mathrm{PSD}_k)
+      :math:`\delta_{hf}(t) = \sum_k \sqrt{2*\Delta \omega_k*\mathrm{PSD}_k}
       * \cos(\omega_k * t + \phi_k)`
       where :math:`\phi_k \backsim U[0, 2\pi)` (uniform random phase),
       and :math:`\Delta \omega_k = \omega_{k+1} - \omega_k`.

--- a/tests/pulser_simulation/test_simulation.py
+++ b/tests/pulser_simulation/test_simulation.py
@@ -2114,8 +2114,8 @@ def test_detuning_hf_noise(monkeypatch):
     seq.add(pulse1, "ch2", protocol="no-delay")
 
     noise_mod = NoiseModel(
-        detuning_hf_psd=np.array([1e6, 2e6, 3e6]),
-        detuning_hf_freqs=np.array([4e6, 5e6, 6e6]),
+        detuning_hf_psd=2.0 * np.pi * np.array([1, 2, 3]),
+        detuning_hf_omegas=2.0 * np.pi * np.array([4, 5, 6]),
         runs=1,
     )
     sim = QutipEmulator.from_sequence(seq, noise_model=noise_mod)

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -226,13 +226,13 @@ def test_register(reg: Register | Register3D):
         ),
         NoiseModel(
             detuning_hf_psd=(1, 2, 3),
-            detuning_hf_freqs=(4, 5, 6),
+            detuning_hf_omegas=(4, 5, 6),
             runs=1,
         ),
         NoiseModel(
             detuning_sigma=0.1,
             detuning_hf_psd=(1, 2, 3),
-            detuning_hf_freqs=(4, 5, 6),
+            detuning_hf_omegas=(4, 5, 6),
             runs=1,
         ),
         NoiseModel(
@@ -2842,7 +2842,7 @@ def test_noise_optional_params(
         trap_waist=trap_waist,
         trap_depth=trap_depth,
         detuning_hf_psd=det_hf_psd,
-        detuning_hf_freqs=det_hf_freqs,
+        detuning_hf_omegas=det_hf_freqs,
         temperature=temperature,
         with_leakage=True,
         eff_noise_rates=(0.1,),

--- a/tests/test_hamiltonian_data.py
+++ b/tests/test_hamiltonian_data.py
@@ -491,25 +491,21 @@ def test_noise_hf_detuning_generation():
             phases : phase offsets
         """
         hf_detun = np.zeros_like(times)
-        times *= 1e-6  # µsec -> sec
+        times *= 1e-3  # ns -> µs
         for i, s in enumerate(psd[1:]):
             df = freqs[i + 1] - freqs[i]
-            hf_detun += (
-                2.0
-                * np.pi
-                * 1e-6
-                * np.sqrt(2 * df * s)
-                * np.cos(2 * np.pi * (freqs[i + 1] * times + phases[i]))
+            hf_detun += np.sqrt(2 * df * s) * np.cos(
+                freqs[i + 1] * times + phases[i]
             )
         return hf_detun
 
     psd = [1, 2, 3]
     freqs = [3, 4, 5]
     times = np.arange(0, 10, 0.1)
-    phases = np.random.uniform(size=(2,))
+    phases = np.random.uniform(0, 2 * np.pi, size=(2,))
 
     noise_m = pulser.NoiseModel(
-        detuning_hf_psd=psd, detuning_hf_freqs=freqs, runs=1
+        detuning_hf_psd=psd, detuning_hf_omegas=freqs, runs=1
     )
     hf_det = _generate_detuning_fluctuations(noise_m, 0.0, phases, times)
     hd_det_expected = original_formula_gen_noise(psd, freqs, times, phases)

--- a/tests/test_noise_model.py
+++ b/tests/test_noise_model.py
@@ -284,18 +284,18 @@ class TestNoiseModel:
     def test_hf_detuning_noise_validation(self):
         # list - expected format
         noise_mod = NoiseModel(
-            detuning_hf_psd=[1, 4, 2], detuning_hf_freqs=[3, 6, 7], runs=1
+            detuning_hf_psd=[1, 4, 2], detuning_hf_omegas=[3, 6, 7], runs=1
         )
         # np.array - other expected format
         noise_mod = NoiseModel(
             detuning_hf_psd=np.array([1, 4, 2]),
-            detuning_hf_freqs=np.array([3, 6, 7]),
+            detuning_hf_omegas=np.array([3, 6, 7]),
             runs=1,
         )
         # tuple - other expected format
         noise_mod = NoiseModel(
             detuning_hf_psd=(1, 4, 2),
-            detuning_hf_freqs=(3, 6, 7),
+            detuning_hf_omegas=(3, 6, 7),
             runs=1,
         )
 
@@ -303,7 +303,7 @@ class TestNoiseModel:
         noise_mod = NoiseModel()
         assert (
             noise_mod.detuning_hf_psd == ()
-            and noise_mod.detuning_hf_freqs == ()
+            and noise_mod.detuning_hf_omegas == ()
         )
 
         # only psd are provided
@@ -316,39 +316,39 @@ class TestNoiseModel:
         with pytest.raises(
             ValueError, match=("empty tuples or both be provided")
         ):
-            NoiseModel(detuning_hf_freqs=(4, 5, 6))
+            NoiseModel(detuning_hf_omegas=(4, 5, 6))
 
         # psd dim != 1
         with pytest.raises(ValueError, match=("1D tuples")):
             NoiseModel(
-                detuning_hf_psd=[[1, 2, 3]], detuning_hf_freqs=[3, 4, 5]
+                detuning_hf_psd=[[1, 2, 3]], detuning_hf_omegas=[3, 4, 5]
             )
 
         # freqs dim != 1
         with pytest.raises(ValueError, match=("1D tuples")):
             NoiseModel(
-                detuning_hf_psd=[1, 2, 3], detuning_hf_freqs=[[3, 4, 5]]
+                detuning_hf_psd=[1, 2, 3], detuning_hf_omegas=[[3, 4, 5]]
             )
 
         # len psd != len freqs
         with pytest.raises(ValueError, match=("same length")):
-            NoiseModel(detuning_hf_psd=[1, 2], detuning_hf_freqs=[3, 4, 5])
+            NoiseModel(detuning_hf_psd=[1, 2], detuning_hf_omegas=[3, 4, 5])
 
         # psd len <= 1
         with pytest.raises(ValueError, match=("length > 1")):
-            NoiseModel(detuning_hf_psd=[1], detuning_hf_freqs=[3])
+            NoiseModel(detuning_hf_psd=[1], detuning_hf_omegas=[3])
 
         # psd < 0
         with pytest.raises(ValueError, match=("positive values")):
-            NoiseModel(detuning_hf_psd=[-1, 2], detuning_hf_freqs=[3, 4])
+            NoiseModel(detuning_hf_psd=[-1, 2], detuning_hf_omegas=[3, 4])
 
         # freqs < 0
         with pytest.raises(ValueError, match=("positive values")):
-            NoiseModel(detuning_hf_psd=[1, 2], detuning_hf_freqs=[3, -4])
+            NoiseModel(detuning_hf_psd=[1, 2], detuning_hf_omegas=[3, -4])
 
         # freqs should monotonously grow
         with pytest.raises(ValueError, match=("monotonously growing")):
-            NoiseModel(detuning_hf_psd=[1, 2], detuning_hf_freqs=[4, 3])
+            NoiseModel(detuning_hf_psd=[1, 2], detuning_hf_omegas=[4, 3])
 
     @pytest.mark.parametrize("param", ["dephasing_rate", "depolarizing_rate"])
     def test_leakage(self, param):
@@ -466,7 +466,7 @@ class TestNoiseModel:
         ) == {
             "detuning_sigma",
             "detuning_hf_psd",
-            "detuning_hf_freqs",
+            "detuning_hf_omegas",
             "runs",
             "samples_per_run",
         }


### PR DESCRIPTION
All other detuning related quantities are in `rad/microsec` so the choice of `Hz` was inconsistent. In addition, in the new units, all quantities in the power spectral density are of order unity, which makes things easier to sanity check.