### PR TITLE
Fix creation of Hamiltonian from sequence for 3d register

### DIFF
--- a/pulser-simulation/pulser_simulation/hamiltonian.py
+++ b/pulser-simulation/pulser_simulation/hamiltonian.py
@@ -26,7 +26,7 @@ from pulser._hamiltonian_data import HamiltonianData
 from pulser.channels.base_channel import States
 from pulser.devices._device_datacls import BaseDevice
 from pulser.noise_model import NoiseModel
-from pulser.register import QubitId, Register
+from pulser.register import QubitId, Register, Register3D
 from pulser.sampler.samples import SequenceSamples
 
 
@@ -52,8 +52,15 @@ class Hamiltonian:
         config: NoiseModel,
     ) -> None:
         """Instantiates a Hamiltonian object."""
-        register = Register.from_coordinates(
-            list(qdict.values()), labels=list(qdict.keys()), center=False
+
+        coords = list(qdict.values())
+        if device.dimensions == 3 and len(coords[0]) == 3:
+            RegisterClass = Register3D
+        else:
+            RegisterClass = Register
+
+        register = RegisterClass.from_coordinates(
+            coords, labels=list(qdict.keys()), center=False
         )
         self.data = HamiltonianData(samples_obj, register, device, config)
         self._sampling_rate = sampling_rate


### PR DESCRIPTION
Calling `QutipEmulator.from_sequence()` with a 3d register fails because `Hamiltonian.__init__` assumes that the register is 2d. This is a regression in v1.6 as it used to work in v1.5 and below.

Here is a MWE:
```python
import dataclasses
from pulser import Register3D, Sequence, Pulse
from pulser.devices import AnalogDevice
from pulser_simulation import QutipEmulator

device = device = dataclasses.replace(AnalogDevice, dimensions=3)
register = Register3D.cubic(side=2, spacing=6, prefix="q")

seq = Sequence(register, device)
seq.declare_channel("ising", "rydberg_global")
channel = seq.declared_channels["ising"]
cst_pulse = Pulse.ConstantPulse(duration=500, amplitude=2., detuning=1., phase=0.)
seq.add(cst_pulse, "ising")

computation = QutipEmulator.from_sequence(seq)
```
The error message in v1.6 is:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pulser/pulser-simulation/pulser_simulation/simulation.py", line 917, in from_sequence
    return cls(
           ^^^^
  File "pulser/pulser-simulation/pulser_simulation/simulation.py", line 172, in __init__
    self._hamiltonian = Hamiltonian(
                        ^^^^^^^^^^^^
  File "pulser/pulser-simulation/pulser_simulation/hamiltonian.py", line 55, in __init__
    register = Register.from_coordinates(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "pulser/pulser-core/pulser/register/base_register.py", line 205, in from_coordinates
    return cls(qubits, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "pulser/pulser-core/pulser/register/register.py", line 63, in __init__
    raise ValueError(
ValueError: All coordinates must be specified as vectors of size 2.
```