### PR TITLE
Fix that Hamiltonian does not work with Register3D

### DIFF
--- a/pulser-simulation/pulser_simulation/hamiltonian.py
+++ b/pulser-simulation/pulser_simulation/hamiltonian.py
@@ -21,12 +21,12 @@ from typing import Union, cast
 import numpy as np
 import qutip
 
-import pulser.math as pm
 from pulser._hamiltonian_data import HamiltonianData
 from pulser.channels.base_channel import States
 from pulser.devices._device_datacls import BaseDevice
 from pulser.noise_model import NoiseModel
-from pulser.register import QubitId, Register
+from pulser.register import QubitId
+from pulser.register.base_register import BaseRegister
 from pulser.sampler.samples import SequenceSamples
 
 
@@ -46,15 +46,12 @@ class Hamiltonian:
     def __init__(
         self,
         samples_obj: SequenceSamples,
-        qdict: dict[QubitId, pm.AbstractArray],
+        register: BaseRegister,
         device: BaseDevice,
         sampling_rate: float,
         config: NoiseModel,
     ) -> None:
         """Instantiates a Hamiltonian object."""
-        register = Register.from_coordinates(
-            list(qdict.values()), labels=list(qdict.keys()), center=False
-        )
         self.data = HamiltonianData(samples_obj, register, device, config)
         self._sampling_rate = sampling_rate
 

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -171,7 +171,7 @@ class QutipEmulator:
 
         self._hamiltonian = Hamiltonian(
             self.samples_obj,
-            self._register.qubits,
+            self._register,
             device,
             sampling_rate,
             noise_model or NoiseModel(),
@@ -193,7 +193,7 @@ class QutipEmulator:
     def _noiseless_hamiltonian(self) -> Hamiltonian:
         return Hamiltonian(
             self.samples_obj,
-            self._register.qubits,
+            self._register,
             self._hamiltonian.data._device,
             self._sampling_rate,
             NoiseModel(),

--- a/tests/pulser_simulation/test_hamiltonian.py
+++ b/tests/pulser_simulation/test_hamiltonian.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pytest
+
+from pulser import MockDevice, NoiseModel, Pulse, Sequence
+from pulser.register import Register, Register3D
+from pulser.sampler import sample
+from pulser_simulation.hamiltonian import Hamiltonian
+
+
+@pytest.fixture
+def reg2d():
+    q_dict = {
+        "q0": np.array([-4.0, 0.0]),
+        "q1": np.array([0.0, 4.0]),
+    }
+
+    return Register(q_dict)
+
+
+@pytest.fixture
+def reg3d():
+    q_dict = {
+        "q0": np.array([-4.0, 0.0, 0.0]),
+        "q1": np.array([0.0, 4.0, 0.0]),
+    }
+    return Register3D(q_dict)
+
+
+def test_register_2d(reg2d):
+    # this should not error, see #940
+    sampling_rate = 0.5
+    duration = 10
+    seq = Sequence(reg2d, MockDevice)
+    seq.declare_channel("ch0", "rydberg_global")
+    seq.declare_channel("ch1", "raman_local", initial_target="q0")
+    seq.declare_channel("ch2", "raman_local", initial_target="q1")
+
+    pulse1 = Pulse.ConstantPulse(duration, 0, 0, 0)
+    # Added twice to check the fluctuation doesn't change from pulse to pulse
+    seq.add(pulse1, "ch0")
+    seq.add(pulse1, "ch0")
+    # The two local channels target alternating qubits on the same basis
+    seq.add(pulse1, "ch1", protocol="no-delay")
+    seq.add(pulse1, "ch2", protocol="no-delay")
+
+    Hamiltonian(
+        sample(seq),
+        reg2d,
+        seq.device,
+        sampling_rate,
+        NoiseModel(),
+    )
+
+
+def test_register_3d(reg3d):
+    # this should not error, see #940
+    sampling_rate = 0.5
+    duration = 10
+    seq = Sequence(reg3d, MockDevice)
+    seq.declare_channel("ch0", "rydberg_global")
+    seq.declare_channel("ch1", "raman_local", initial_target="q0")
+    seq.declare_channel("ch2", "raman_local", initial_target="q1")
+
+    pulse1 = Pulse.ConstantPulse(duration, 0, 0, 0)
+    # Added twice to check the fluctuation doesn't change from pulse to pulse
+    seq.add(pulse1, "ch0")
+    seq.add(pulse1, "ch0")
+    # The two local channels target alternating qubits on the same basis
+    seq.add(pulse1, "ch1", protocol="no-delay")
+    seq.add(pulse1, "ch2", protocol="no-delay")
+
+    Hamiltonian(
+        sample(seq),
+        reg3d,
+        seq.device,
+        sampling_rate,
+        NoiseModel(),
+    )


### PR DESCRIPTION
You need to instantiate a `Register` or `Register3D` depending on the length of the position vector. `Hamiltonian` always tried `Register`. Fixed the issue by making `Hamiltonian` take a `BaseRegister` rather than a `qdict`.