### PR TITLE
Fix detection of shot to shot noise

### DIFF
--- a/tests/pulser_simulation/test_simulation.py
+++ b/tests/pulser_simulation/test_simulation.py
@@ -2239,7 +2239,7 @@ def test_noisy_runs(noise):
     old_run = QutipEmulator._run_solver
 
     def mock_run_solver(self, progress_bar: bool = False, **options):
-        nonlocal count, old_run
+        nonlocal count
         count += 1
         return old_run(self, progress_bar, **options)
 
@@ -2260,7 +2260,7 @@ def test_noisy_runs(noise):
     seq.add(pulse1, "ch2", protocol="no-delay")
     nruns = 2
     noise_mod = NoiseModel(runs=nruns, **noise)
-    with patch.object(QutipEmulator, "_run_solver", new=mock_run_solver) as m:
+    with patch.object(QutipEmulator, "_run_solver", new=mock_run_solver):
         sim = QutipEmulator.from_sequence(seq, noise_model=noise_mod)
         result = sim.run()
         assert count == nruns


### PR DESCRIPTION
`QutipEmulator` only does repeated runs if it detects the presence of shot to shot noise, since in its absence, the results of the emulator are deterministically all the same over many runs. The new noise types of `register`, `detuning`, but due to an earlier regression also `doppler` were missing from this list. A version of this check is used in several places, and I've done a small refactor to reuse the same code for all of them. In the unit tests, since mostly `amp_sigma` is present in the noise model, this bug didn't trigger.

The MR is a draft because I still need to add a test that fails without the above code changes.