### PR TITLE
Drop Python 3.9, introduce Python 3.14 + mypy==1.18.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.10", "3.14"]
         with-torch: ["with-torch", "no-torch"]
         numpy: ["numpy-v1", "numpy-v2"]
         include:
@@ -77,8 +77,8 @@ jobs:
             with-torch: "with-torch"
             numpy: "numpy-v1"
         exclude:
-          # Numpy v1 does not support Python 3.13
-          - python-version: "3.13"
+          # Numpy v1 does not support Python 3.14
+          - python-version: "3.14"
             numpy: "numpy-v1"
           - numpy: "numpy-v1"
             with-torch: "no-torch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
         if: ${{ matrix.with-torch != 'with-torch'}}
         run: pytest --cov
       - name: Test validation with legacy jsonschema
+        if: ${{ matrix.python-version != '3.14'}}
         run: |
           pip install jsonschema==4.17.3
           pytest tests/test_abstract_repr.py -W ignore::DeprecationWarning

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Check out Pulser
         uses: actions/checkout@v4

--- a/.github/workflows/pulser-setup/action.yml
+++ b/.github/workflows/pulser-setup/action.yml
@@ -4,7 +4,7 @@ inputs:
   python-version:
     description: Python version
     required: false
-    default: "3.9"
+    default: "3.12"
   extra-packages:
     description: Extra packages to install (give to grep)
     required: false

--- a/.github/workflows/pulser-setup/action.yml
+++ b/.github/workflows/pulser-setup/action.yml
@@ -4,7 +4,7 @@ inputs:
   python-version:
     description: Python version
     required: false
-    default: "3.12"
+    default: "3.11"
   extra-packages:
     description: Extra packages to install (give to grep)
     required: false

--- a/.github/workflows/pulser-setup/action.yml
+++ b/.github/workflows/pulser-setup/action.yml
@@ -4,7 +4,7 @@ inputs:
   python-version:
     description: Python version
     required: false
-    default: "3.11"
+    default: "3.12"
   extra-packages:
     description: Extra packages to install (give to grep)
     required: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,15 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         numpy: ["numpy-v1", "numpy-v2"]
         with-torch: ["with-torch", "no-torch"]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
           # Numpy v1 does not support Python 3.13
           - python-version: "3.13"
+            numpy: "numpy-v1"
+          - numpy: "numpy-v1"
+            with-torch: "no-torch"
+          # Numpy v1 does not support Python 3.14
+          - python-version: "3.14"
             numpy: "numpy-v1"
           - numpy: "numpy-v1"
             with-torch: "no-torch"

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -3,7 +3,7 @@ files =
     pulser-core/pulser, 
     pulser-simulation/pulser_simulation,
     tests
-python_version = 3.11
+python_version = 3.12
 warn_return_any = True
 warn_redundant_casts = True
 warn_unused_ignores = True

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For a comprehensive overview of Pulser, check out [Pulser's white paper](https:/
 
 ## Installation
 
-To install the latest release of ``pulser``, have Python 3.9 or higher installed, then use ``pip``:
+To install the latest release of ``pulser``, have Python 3.10 or higher installed, then use ``pip``:
 
 ```bash
 pip install pulser

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,7 +3,7 @@ black[jupyter] ~= 24.3
 flake8
 flake8-docstrings
 isort
-mypy==1.2
+mypy==1.18.2
 pytest
 pytest-cov
 ruff==0.11.1

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ==============
 
-To install the latest release of ``pulser``, have Python 3.9 or higher
+To install the latest release of ``pulser``, have Python 3.10 or higher
 installed, then use ``pip``: ::
 
   pip install pulser

--- a/pulser-core/pulser/parametrized/variable.py
+++ b/pulser-core/pulser/parametrized/variable.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import collections.abc as abc  # To use collections.abc.Sequence
 import dataclasses
-from typing import Any, Iterator, Union
+from typing import Any, Iterator, Union, cast
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -87,7 +87,7 @@ class Variable(Parametrized, OpSupport):
         self.value: pm.AbstractArray | None
         if self.value is None:
             raise ValueError(f"No value assigned to variable '{self.name}'.")
-        return self.value
+        return cast(pm.AbstractArray, self.value)
 
     def _to_dict(self) -> dict[str, Any]:
         d = obj_to_dict(self, _build=False)

--- a/pulser-core/pulser/register/_patterns.py
+++ b/pulser-core/pulser/register/_patterns.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from __future__ import annotations
 
+from typing import cast
+
 import numpy as np
 
 
@@ -29,7 +31,7 @@ def square_rect(rows: int, columns: int) -> np.ndarray:
     points = np.mgrid[:columns, :rows].transpose().reshape(-1, 2)
     # Centering
     points = points - np.ceil([columns / 2, rows / 2]) + 1
-    return points
+    return cast(np.ndarray, points)
 
 
 def triangular_rect(rows: int, columns: int) -> np.ndarray:

--- a/pulser-core/pulser/register/_reg_drawer.py
+++ b/pulser-core/pulser/register/_reg_drawer.py
@@ -329,7 +329,7 @@ class RegDrawer:
                             coords[0],
                             coords[1],
                             coords[2],
-                            q,  # type: ignore[arg-type]
+                            q,
                             fontsize=12,
                             ha="left",
                             va="bottom",
@@ -352,7 +352,7 @@ class RegDrawer:
                         y = radius * np.sin(u) * np.sin(v) + y0
                         z = radius * np.cos(v) + z0
                         # alpha controls opacity
-                        ax.plot_surface(  # type: ignore[attr-defined]
+                        ax.plot_surface(
                             x,
                             y,
                             z,
@@ -366,7 +366,7 @@ class RegDrawer:
 
                 ax.set_xlabel("x (µm)")
                 ax.set_ylabel("y (µm)")
-                ax.set_zlabel("z (µm)")  # type: ignore[attr-defined]
+                ax.set_zlabel("z (µm)")
 
     @staticmethod
     def _register_dims(

--- a/pulser-core/pulser/register/traps.py
+++ b/pulser-core/pulser/register/traps.py
@@ -54,7 +54,7 @@ class Traps(ABC, CoordsCollection):
         except ValueError as e:
             raise array_type_error_msg from e
 
-        shape = coords_arr.shape
+        shape = np.shape(coords_arr)
         if len(shape) != 2:
             raise array_type_error_msg
 

--- a/pulser-core/pulser/sampler/samples.py
+++ b/pulser-core/pulser/sampler/samples.py
@@ -205,10 +205,13 @@ class ChannelSamples:
         The channel is considered empty if all amplitude and detuning
         samples are zero.
         """
-        return (
-            np.count_nonzero(self.amp.as_array(detach=True))
-            + np.count_nonzero(self.det.as_array(detach=True))
-            == 0
+        return cast(
+            bool,
+            (
+                np.count_nonzero(self.amp.as_array(detach=True))
+                + np.count_nonzero(self.det.as_array(detach=True))
+            )
+            == 0,
         )
 
     def _generate_std_samples(self) -> ChannelSamples:
@@ -439,7 +442,7 @@ class ChannelSamples:
             new_samples[key] = new_samples[key].astype(float)[
                 slice(0, max_duration)
             ]
-        return replace(self, **new_samples)
+        return replace(self, **new_samples)  # type: ignore[arg-type]
 
 
 @dataclass

--- a/pulser-core/pulser/sequence/_seq_drawer.py
+++ b/pulser-core/pulser/sequence/_seq_drawer.py
@@ -871,7 +871,7 @@ def _draw_channel_content(
                 )
                 for ax in axes:
                     ax.axvline(t_, **conf)
-                msg = "\u27F2 " + phase_str(delta)
+                msg = "\u27f2 " + phase_str(delta)
                 axes[0].text(
                     t_ - final_t * 8e-3,
                     tgt_txt_ymax,
@@ -1178,16 +1178,20 @@ def _draw_qubit_content(
                 )
                 # Add targets to legend if qubits are defined
                 if plot_index == 0 and qubits:
-                    ax_leg = (
-                        axes_legend
-                        if n_quantities == 1
-                        else cast(list, axes_legend)[subplot_index]
+                    ax_leg = cast(
+                        Axes,
+                        (
+                            axes_legend
+                            if n_quantities == 1
+                            else cast(list, axes_legend)[subplot_index]
+                        ),
                     )
                     targeted_atoms = {t: qubits[t] for t in target}
                     pos = np.array(list(targeted_atoms.values()))
                     if dimensionality_3d:
                         for sub_ax_leg, (ix, iy) in zip(
-                            ax_leg, combinations(np.arange(3), 2)
+                            cast(Iterable, ax_leg),
+                            combinations(np.arange(3), 2),
                         ):
                             Register._draw_2D(
                                 ax=sub_ax_leg,

--- a/pulser-core/pulser/waveforms.py
+++ b/pulser-core/pulser/waveforms.py
@@ -782,12 +782,15 @@ class BlackmanWaveform(Waveform):
         # According to the documentation for numpy.blackman(), "the value one
         # appears only if the number of samples is odd". Hence, the previous
         # even duration can reach a maximal value closer to max_val.
+        _arr_max = float(np.max(wf.samples.as_array(detach=True)))
         if (
             previous_wf is not None
             and duration % 2 == 1
-            and np.max(wf.samples.as_array(detach=True))
-            < np.max(previous_wf.samples.as_array(detach=True))
-            <= max_val
+            and (
+                _arr_max
+                < np.max(previous_wf.samples.as_array(detach=True))
+                <= max_val
+            )
         ):
             wf = previous_wf
 
@@ -936,7 +939,6 @@ class InterpolatedWaveform(Waveform):
         if times is None or isinstance(times, Parametrized):
             return
         try:
-            times = cast(ArrayLike, times)
             times_ = np.array(times, dtype=float)
         except TypeError as e:
             raise TypeError(_err_message("times")) from e
@@ -1266,5 +1268,5 @@ def _copy_func(f: FunctionType) -> FunctionType:
 
 for m in inspect.getmembers(sys.modules[__name__], inspect.isclass):
     if m[1].__module__ == __name__:
-        _new = _copy_func(m[1].__new__)
+        _new = _copy_func(m[1].__new__)  # type: ignore
         m[1].__new__ = functools.update_wrapper(_new, m[1].__init__)

--- a/pulser-core/requirements.txt
+++ b/pulser-core/requirements.txt
@@ -1,10 +1,6 @@
 jsonschema >= 4.17.3, < 5
 referencing  # A dependency of jsonschema we use. We let jsonschema set the version
-matplotlib < 4
-# Matplotlib 3.10 dropped support for python 3.9, we can only do this from python 3.10
-matplotlib >= 3.10.5; python_version >= '3.10'
-# Dependency from matplotlib < 3.10.5 that raises a DeprecationWarning from 11.3
-pillow < 11.3.0; python_version <= '3.9'
+matplotlib >= 3.10.5, < 4
 packaging   # This is already required by matplotlib but we use it too
 # Numpy 1.20 introduces type hints, 1.24.0 breaks matplotlib < 3.6.1
 numpy >= 1.20, != 1.24.0

--- a/pulser-core/setup.py
+++ b/pulser-core/setup.py
@@ -53,7 +53,7 @@ setup(
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     author="Pulser Development Team",
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     license="Apache 2.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/pulser-simulation/pulser_simulation/hamiltonian.py
+++ b/pulser-simulation/pulser_simulation/hamiltonian.py
@@ -85,7 +85,7 @@ class Hamiltonian:
             int(self._sampling_rate * self._duration),
             dtype=int,
         )
-        return cast(np.ndarray, full_array[indices])
+        return full_array[indices]
 
     def _build_collapse_operators(
         self,

--- a/pulser-simulation/pulser_simulation/qutip_op.py
+++ b/pulser-simulation/pulser_simulation/qutip_op.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any, SupportsComplex, Type, TypeVar, cast
+from typing import Any, Type, TypeVar, cast
 
 import qutip
 
@@ -27,7 +27,7 @@ QutipStateType = TypeVar("QutipStateType", bound=QutipState)
 QutipOperatorType = TypeVar("QutipOperatorType", bound="QutipOperator")
 
 
-class QutipOperator(Operator[SupportsComplex, complex, QutipStateType]):
+class QutipOperator(Operator[complex, complex, QutipStateType]):
     """A quantum operator stored as a qutip.Qobj.
 
     Args:
@@ -116,7 +116,7 @@ class QutipOperator(Operator[SupportsComplex, complex, QutipStateType]):
         )
 
     def __rmul__(
-        self: QutipOperatorType, scalar: SupportsComplex
+        self: QutipOperatorType, scalar: complex
     ) -> QutipOperatorType:
         """Scale the operator by a scalar factor.
 
@@ -152,7 +152,7 @@ class QutipOperator(Operator[SupportsComplex, complex, QutipStateType]):
         *,
         eigenstates: Sequence[Eigenstate],
         n_qudits: int,
-        operations: FullOp[SupportsComplex],
+        operations: FullOp[complex],
     ) -> tuple[QutipOperatorType, FullOp[complex]]:
         """Create an operator from the operator representation.
 
@@ -189,7 +189,7 @@ class QutipOperator(Operator[SupportsComplex, complex, QutipStateType]):
         """
         qudit_dim = len(eigenstates)
 
-        def build_qudit_op(qudit_op: QuditOp[SupportsComplex]) -> qutip.Qobj:
+        def build_qudit_op(qudit_op: QuditOp[complex]) -> qutip.Qobj:
             op = qutip.identity(qudit_dim) * 0
             for proj_str, coeff in qudit_op.items():
                 ket = qutip.basis(qudit_dim, eigenstates.index(proj_str[0]))

--- a/pulser-simulation/pulser_simulation/qutip_state.py
+++ b/pulser-simulation/pulser_simulation/qutip_state.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import math
 from collections import Counter, defaultdict
 from collections.abc import Collection, Mapping, Sequence
-from typing import Any, SupportsComplex, Type, TypeVar
+from typing import Any, Type, TypeVar
 
 import numpy as np
 import qutip
@@ -27,12 +27,12 @@ from pulser.math.multinomial import multinomial
 
 QutipStateType = TypeVar("QutipStateType", bound="QutipState")
 
-QuditOp = Mapping[str, SupportsComplex]
+QuditOp = Mapping[str, complex]
 TensorOp = Sequence[tuple[QuditOp, Collection[int]]]
-FullOp = Sequence[tuple[SupportsComplex, TensorOp]]
+FullOp = Sequence[tuple[complex, TensorOp]]
 
 
-class QutipState(State[SupportsComplex, float]):
+class QutipState(State[complex, float]):
     """A quantum state stored as a qutip.Qobj.
 
     Args:
@@ -129,7 +129,15 @@ class QutipState(State[SupportsComplex, float]):
         # Renormalize to make the non-zero probablilites sum to 1.
         probs = probs[non_zero]
         probs = probs / np.sum(probs)
-        return dict(zip(map(self.get_basis_state_from_index, non_zero), probs))
+        return dict(
+            zip(
+                map(
+                    self.get_basis_state_from_index,  # type: ignore[arg-type]
+                    non_zero,
+                ),
+                probs,
+            )
+        )
 
     def bitstring_probabilities(
         self, *, one_state: Eigenstate | None = None, cutoff: float = 1e-12
@@ -213,7 +221,7 @@ class QutipState(State[SupportsComplex, float]):
         *,
         eigenstates: Sequence[Eigenstate],
         n_qudits: int,
-        amplitudes: Mapping[str, SupportsComplex],
+        amplitudes: Mapping[str, complex],
     ) -> tuple[QutipStateType, Mapping[str, complex]]:
         """Construct the state from its basis states' amplitudes.
 

--- a/pulser-simulation/setup.py
+++ b/pulser-simulation/setup.py
@@ -53,7 +53,7 @@ setup(
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     author="Pulser Development Team",
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     license="Apache 2.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     author="Pulser Development Team",
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     license="Apache 2.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -19,7 +19,7 @@ import re
 from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import asdict, replace
-from typing import Any, Type, cast
+from typing import Any, Type
 from unittest.mock import patch
 
 import jsonschema
@@ -369,7 +369,7 @@ class TestDevice:
             with pytest.raises(DeserializeDeviceError) as exc_info:
                 func(obj_str)
 
-            cause = cast(DeserializeDeviceError, exc_info.value).__cause__
+            cause = exc_info.value.__cause__
             assert isinstance(cause, original_err)
             assert re.search(re.escape(err_msg), str(cause)) is not None
             return cause

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -79,7 +79,7 @@ class TestDetuningMap:
                     ValueError,
                     match="'trap_coordinates' must be an array or list",
                 ):
-                    reg.define_detuning_map(bad_key)  # type: ignore
+                    reg.define_detuning_map(bad_key)
                 continue
             with pytest.raises(
                 ValueError,
@@ -88,7 +88,7 @@ class TestDetuningMap:
                     " in [0, 3]."
                 ),
             ):
-                reg.define_detuning_map(bad_key)  # type: ignore
+                reg.define_detuning_map(bad_key)
         with pytest.raises(
             ValueError,
             match=(
@@ -213,9 +213,8 @@ class TestDetuningMap:
                     reg_det_map_dict = cast(
                         dict[Union[int, str], float], detuning_map_dict
                     )
-                detuning_map = cast(
-                    DetuningMap,
-                    reg.define_detuning_map(reg_det_map_dict),  # type: ignore
+                detuning_map = reg.define_detuning_map(
+                    reg_det_map_dict  # type: ignore
                 )
                 assert np.all(
                     [


### PR DESCRIPTION
- Python 3.9 reaches its EOL at the end of October 2025
- Python 3.14 has been officially released, so we should start properly testing against it
- Since CI `mypy` checks now happen with Numpy v2 and type hints needed to be refreshed, also takes the opportunity to upgrade `mypy` to 1.18.2