### PR TITLE
Include the "pulser_version" in the serialized Sequence

### DIFF
--- a/pulser-core/pulser/json/abstract_repr/serializer.py
+++ b/pulser-core/pulser/json/abstract_repr/serializer.py
@@ -150,6 +150,7 @@ def serialize_abstract_sequence(
         "variables": {},
         "operations": [],
         "measurement": None,
+        "pulser_version": pulser.__version__,
     }
 
     if metadata:

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -810,6 +810,7 @@ class TestSerialization:
                 "channels",
                 "operations",
                 "measurement",
+                "pulser_version",
             ]
         )
         device_name = abstract["device"]["name"]
@@ -1602,6 +1603,7 @@ def _get_serialized_seq(
         "operations": operations,
         "variables": variables,
         "measurement": None,
+        "pulser_version": pulser.__version__,
     }
     seq_dict.update(override_kwargs)
     return seq_dict


### PR DESCRIPTION
This information was already included inside the `"device"` object, but not having it at the serialized sequence level was nonetheless an oversight. 