### PR TITLE
Fix numpy_v1 action

### DIFF
--- a/.github/workflows/pulser-setup/action.yml
+++ b/.github/workflows/pulser-setup/action.yml
@@ -41,7 +41,7 @@ runs:
       if: ${{ inputs.numpy == 'numpy-v1'}}
       shell: bash
       run: |
-        pip install numpy==1.26
+        pip install "numpy>=1.26.4, <2.0.0"
     - name: Install numpy v2
       if: ${{ inputs.numpy == 'numpy-v2'}}
       shell: bash


### PR DESCRIPTION
numpy_v1 pins numpy version to 1.16.0, but scipy 1.17 needs numpy>=1.16.4. Constraining numpy version to >=1.16.14, <2.0.0