### PR TITLE
Create `BackendConfig.__repr__()`

### DIFF
--- a/pulser-core/pulser/backend/config.py
+++ b/pulser-core/pulser/backend/config.py
@@ -137,6 +137,12 @@ class BackendConfig:
             "desired changes."
         )
 
+    def __repr__(self) -> str:
+        params = [
+            f"{key}={value!r}" for key, value in self._backend_options.items()
+        ]
+        return f"{self.__class__.__name__}(\n    {',\n    '.join(params)},\n)"
+
 
 class EmulationConfig(BackendConfig, Generic[StateType]):
     """Configures an emulation on a backend.

--- a/pulser-core/pulser/backend/config.py
+++ b/pulser-core/pulser/backend/config.py
@@ -138,10 +138,10 @@ class BackendConfig:
         )
 
     def __repr__(self) -> str:
-        params = [
+        params_str = ",\n    ".join(
             f"{key}={value!r}" for key, value in self._backend_options.items()
-        ]
-        return f"{self.__class__.__name__}(\n    {',\n    '.join(params)},\n)"
+        )
+        return f"{self.__class__.__name__}(\n    {params_str},\n)"
 
 
 class EmulationConfig(BackendConfig, Generic[StateType]):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -536,6 +536,8 @@ def test_backend_config():
     assert config1.default_num_shots is None
     assert config1.with_changes(default_num_shots=1).default_num_shots == 1
 
+    assert repr(config1) == "BackendConfig(\n    default_num_shots=None,\n)"
+
 
 def test_emulation_config():
     with pytest.warns(


### PR DESCRIPTION
Creates a simple `__repr__()` for all `BackendConfig` classes. 

Here are a couple examples:

```
>>> print(pulser.backend.BackendConfig())
BackendConfig(
    default_num_shots=None,
)
```

```
>>> import pulser_simulation
>>> print(pulser_simulation.QutipBackendV2.default_config)
QutipConfig(
    callbacks=(),
    observables=(bitstrings:2309590c-1c01-42b5-9553-4fc62619123e, state:cc5f076f-9ad9-4748-b3d7-2199b0776b58),
    default_evaluation_times=array([1.]),
    initial_state=None,
    with_modulation=False,
    interaction_matrix=None,
    prefer_device_noise_model=False,
    noise_model=NoiseModel(noise_types=()),
    n_trajectories=1,
    sampling_rate=1.0,
    solver=<Solver.DEFAULT: 'default'>,
    progress_bar=False,
    default_num_shots=1000,
)
```
