### PR TITLE
Preserve observables' UUID in (de)serialization and Results.aggregate

### DIFF
--- a/pulser-core/pulser/backend/observable.py
+++ b/pulser-core/pulser/backend/observable.py
@@ -114,6 +114,7 @@ class Observable(Callback):
             "observable": self._base_tag,
             "evaluation_times": self.evaluation_times,
             "tag_suffix": self._tag_suffix,
+            "uuid": str(self._uuid),
         }
 
     @property

--- a/pulser-core/pulser/backend/results.py
+++ b/pulser-core/pulser/backend/results.py
@@ -273,6 +273,13 @@ class Results:
         where the counters are joined.
         StateResult and EnergyVariance are not supported by default.
 
+        Warning:
+            The ability to access a result from an observable instance
+            (e.g. via Results.get_result(obs)) is only preserved if all
+            aggregated results originated from the same observable instance.
+            When that is not the case, the aggregated result can still
+            be accessed via the observable's tag.
+
         Args:
             results_to_aggregate: The list of Results to aggregate
 
@@ -383,7 +390,14 @@ class Results:
                     "incompatible simulations: "
                     f"the times for `{tag}` are not all the same."
                 )
-            uid = uuid.uuid4()
+
+            _uuids = set(res._tagmap[tag] for res in results_to_aggregate)
+            if len(_uuids) == 1:
+                # Preserve the UUID when all results share the same
+                uid = list(_uuids)[0]
+            else:
+                # Otherwise, create a new one
+                uid = uuid.uuid4()
 
             for t in result_0.get_result_times(tag):
                 v = aggregation_function(

--- a/pulser-core/pulser/json/abstract_repr/schemas/config-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/config-schema.json
@@ -235,6 +235,10 @@
                     "string",
                     "null"
                 ]
+            },
+            "uuid": {
+                "description": "The observable's internal UUID",
+                "type": "string"
             }
         },
         "required": [
@@ -276,6 +280,10 @@
                     "string",
                     "null"
                 ]
+            },
+            "uuid": {
+                "description": "The observable's internal UUID",
+                "type": "string"
             }
         },
         "required": [
@@ -307,6 +315,10 @@
                     "string",
                     "null"
                 ]
+            },
+            "uuid": {
+                "description": "The observable's internal UUID",
+                "type": "string"
             }
         },
         "required": [
@@ -341,6 +353,10 @@
                     "string",
                     "null"
                 ]
+            },
+            "uuid": {
+                "description": "The observable's internal UUID",
+                "type": "string"
             }
         },
         "required": [
@@ -375,6 +391,10 @@
                     "string",
                     "null"
                 ]
+            },
+            "uuid": {
+                "description": "The observable's internal UUID",
+                "type": "string"
             }
         },
         "required": [
@@ -402,6 +422,10 @@
                     "string",
                     "null"
                 ]
+            },
+            "uuid": {
+                "description": "The observable's internal UUID",
+                "type": "string"
             }
         },
         "required": [
@@ -428,6 +452,10 @@
                     "string",
                     "null"
                 ]
+            },
+            "uuid": {
+                "description": "The observable's internal UUID",
+                "type": "string"
             }
         },
         "required": [
@@ -454,6 +482,10 @@
                     "string",
                     "null"
                 ]
+            },
+            "uuid": {
+                "description": "The observable's internal UUID",
+                "type": "string"
             }
         },
         "required": [

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -435,7 +435,7 @@ def test_aggregation():
         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
     ]
     assert np.allclose(
-        qutip_results.final_state._state.full(), expected_state, atol=1e-4
+        qutip_results.final_state.to_qobj().full(), expected_state, atol=1e-4
     )
     assert np.allclose(
         qutip_results.occupation[-1], np.array([0.6, 0.6, 0.8]), atol=1e-4
@@ -446,3 +446,8 @@ def test_aggregation():
         "110": 1000,
     }
     assert "energy_variance" not in qutip_results.get_result_tags()
+
+    # Check that the results are accessible via the original observables
+    # i.e. that the UUIDs were preserved in the aggregation
+    for obs_ in (occup, state, bitstrings):
+        assert qutip_results.get_result_times(obs_) == [1.0]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -480,7 +480,7 @@ def test_emulator_backend(sequence):
         == json.loads(
             EmulationConfig(
                 # These come from the concrete config
-                observables=(BitStrings(),),
+                observables=concrete_config.observables,
                 default_evaluation_times="Full",
                 my_param="bar",
                 # with_modulation is not True because EmulationConfig has it

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -740,7 +740,8 @@ def test_emulation_config():
     np.testing.assert_equal(conf.default_evaluation_times, times)
 
 
-def test_results_aggregation():
+@pytest.mark.parametrize("matching_uuids", [True, False])
+def test_results_aggregation(matching_uuids):
     results1 = Results(atom_order=[0, 1], total_duration=100)
     results2 = Results(atom_order=[0, 1], total_duration=100)
     uids = [uuid.uuid4() for _ in range(4)]
@@ -767,14 +768,14 @@ def test_results_aggregation():
         aggregation_method=AggregationMethod.SKIP,
     )
     results2._store_raw(
-        uuid=uids[2],
+        uuid=uids[0] if matching_uuids else uids[2],
         tag="dummy_result",
         time=0.1,
         value=3.0,
         aggregation_method=agg_type,
     )
     results2._store_raw(
-        uuid=uids[2],
+        uuid=uids[0] if matching_uuids else uids[2],
         tag="dummy_result",
         time=0.2,
         value=4.0,
@@ -804,8 +805,10 @@ def test_results_aggregation():
     )  # twice in agg, twice in agg2, once each for the 2 results added above.
     for ag in [agg, agg2]:
         ag_uuid = ag._find_uuid("dummy_result")
-        for uid in uids:
-            assert ag_uuid != uid
+        if matching_uuids:
+            assert ag_uuid == uids[0]
+        else:
+            assert all(ag_uuid != uid for uid in uids)
         assert ag._aggregation_methods[ag_uuid] == agg_type
         assert ag.dummy_result == [2.0, 3.0]
 

--- a/tests/test_backend_abstract_repr.py
+++ b/tests/test_backend_abstract_repr.py
@@ -41,6 +41,7 @@ class TestObservableRepr:
         operations=[(0.3, [({"rr": 0.2j}, [0, 2])])],
     )
 
+    @mark.parametrize("with_uuid", [True, False])
     @mark.parametrize(
         "observable, arg, expected_kwargs",
         [
@@ -96,17 +97,29 @@ class TestObservableRepr:
             ),
         ],
     )
-    def test_observable_repr(self, observable, arg, expected_kwargs):
+    def test_observable_repr(
+        self, observable, arg, expected_kwargs, with_uuid
+    ):
         obs = observable(*arg, **expected_kwargs)
+        old_uuid = obs._uuid
 
         # serialized repr
         obs_repr = json.loads(json.dumps(obs, cls=AbstractReprEncoder))
+
+        if not with_uuid:
+            # Remove uuid from the repr
+            obs_repr.pop("uuid")
 
         # deserialized repr
         deserialized_obs = _deserialize_observable(
             obs_repr, StateRepr, OperatorRepr
         )
         deserialized_obs_repr = deserialized_obs._to_abstract_repr()
+
+        if with_uuid:
+            assert deserialized_obs._uuid == old_uuid
+        else:
+            assert deserialized_obs._uuid != old_uuid
 
         for repr in [obs_repr, deserialized_obs_repr]:
             # test default values
@@ -135,9 +148,17 @@ class TestObservableRepr:
             )
 
         # Check observable against the schema via config serialization
-        EmulationConfig(observables=[obs]).to_abstract_repr(
-            skip_validation=False
+        ser_config = json.loads(
+            EmulationConfig(observables=[obs]).to_abstract_repr(
+                skip_validation=True
+            )
         )
+        if not with_uuid:
+            # Take out the UUID to check it is not required by the schema
+            ser_config["observables"][0].pop("uuid")
+
+        # This checks the serialized object against the schema
+        EmulationConfig.from_abstract_repr(json.dumps(ser_config))
 
     @mark.parametrize(
         "state_kwargs",


### PR DESCRIPTION
- Updates the observables' JSON schema to support an "uuid" field (not required for backwards compatibility)
- Includes the UUID in the serialization of every observable
- Preserve the UUID in `Results.aggregate` when it is common to all results

Closes #1009 