### PR TITLE
[FIX] Rounding error in `QutipEmulator` causes repetition in evaluation times

### DIFF
--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -738,7 +738,7 @@ class QutipEmulator:
                 self._meas_basis,
                 state,
                 self._meas_basis in self.basis_name,
-                evaluation_time=t / self._tot_duration * 1e3,
+                evaluation_time=t / (self._tot_duration * 1e-3),
             )
             for state, t in zip(result.states, self._eval_times_array)
         ]

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -458,3 +458,28 @@ def test_aggregation():
     # i.e. that the UUIDs were preserved in the aggregation
     for obs_ in (occup, state, bitstrings):
         assert qutip_results.get_result_times(obs_) == [1.0]
+
+
+def test_rounding_error_eval_time_duplication():
+    seq = pulser.Sequence(
+        pulser.Register.square(1, prefix="q"), pulser.AnalogDevice
+    )
+    seq.declare_channel("rydberg_global", "rydberg_global")
+    seq.add(pulser.Pulse.ConstantPulse(1000, 1, 0, 0), "rydberg_global")
+
+    dt = 0.001
+    evaluation_times = np.linspace(0.0, 1.0, int(1 / dt + 1))
+    config = QutipConfig(
+        observables=[
+            BitStrings(evaluation_times=evaluation_times),
+            BitStrings(
+                # This particular rounding error got repeated in the
+                # results due to rounding errors
+                evaluation_times=[0.49299999999999994],
+                tag_suffix="mod",
+            ),
+        ]
+    )
+    # It works because the rounding error was fixed
+    emu_backend = QutipBackendV2(seq, config=config)
+    emu_backend.run()


### PR DESCRIPTION
- Rounding errors in [this line](https://github.com/pasqal-io/Pulser/blob/develop/pulser-simulation/pulser_simulation/simulation.py#L748) sporadically caused a repetition in the evaluation times of the results, resulting in an error from trying to save the same observable twice (see the test introduced in the  first commit)
- This changes the calculation to avoid the rounding error (second commit)

@pasqal-io/emulation-team We could also implement something more robust to make sure we never hit this `RuntimeError` again (e.g. keeping track of what evaluation times have been stored or add a `skip_if_existing` flag somewhere).