### PR TITLE
Use new noise trajectories on each QutipBackendV2 run

### DIFF
--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -204,6 +204,7 @@ class QutipEmulator:
         if not noise_model:
             noise_model = NoiseModel()
 
+        self.noise_trajectories_used = False
         self._hamiltonian_data = HamiltonianData(
             self.samples_obj,
             register,
@@ -379,6 +380,7 @@ class QutipEmulator:
         former_dim = self.dim
         former_basis = self.basis
         noise_model = cfg.to_noise_model()
+        self.noise_trajectories_used = False
         self._hamiltonian_data = HamiltonianData(
             self.samples_obj,
             self._register,
@@ -872,6 +874,18 @@ class QutipEmulator:
     ) -> Iterator[tuple[SimulationResults, int]]:
         n_trajectories = self.n_trajectories
         traj_nb = 0
+        # When run is called repeatedly, we want different noise trajectories
+        # to be used each time. After the first time, create new trajectories
+        if self.noise_trajectories_used:
+            noise_model = self._hamiltonian_data.noise_model
+            self._hamiltonian_data = HamiltonianData(
+                self.samples_obj,
+                self._register,
+                self.device,
+                noise_model,
+                self._get_n_trajectories(noise_model, check_value=True),
+            )
+        self.noise_trajectories_used = True
         for ham, reps in self._hamiltonians:
             if print_progress:
                 if reps == 1:

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -204,7 +204,7 @@ class QutipEmulator:
         if not noise_model:
             noise_model = NoiseModel()
 
-        self.noise_trajectories_used = False
+        self._noise_trajectories_used = False
         self._hamiltonian_data = HamiltonianData(
             self.samples_obj,
             register,
@@ -380,7 +380,7 @@ class QutipEmulator:
         former_dim = self.dim
         former_basis = self.basis
         noise_model = cfg.to_noise_model()
-        self.noise_trajectories_used = False
+        self._noise_trajectories_used = False
         self._hamiltonian_data = HamiltonianData(
             self.samples_obj,
             self._register,
@@ -876,7 +876,7 @@ class QutipEmulator:
         traj_nb = 0
         # When run is called repeatedly, we want different noise trajectories
         # to be used each time. After the first time, create new trajectories
-        if self.noise_trajectories_used:
+        if self._noise_trajectories_used:
             noise_model = self._hamiltonian_data.noise_model
             self._hamiltonian_data = HamiltonianData(
                 self.samples_obj,
@@ -885,7 +885,8 @@ class QutipEmulator:
                 noise_model,
                 self._get_n_trajectories(noise_model, check_value=True),
             )
-        self.noise_trajectories_used = True
+        # Ensure the noise trajectories are refreshed next time run is called
+        self._noise_trajectories_used = True
         for ham, reps in self._hamiltonians:
             if print_progress:
                 if reps == 1:

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -481,3 +481,28 @@ def test_rounding_error_eval_time_duplication():
     # It works because the rounding error was fixed
     emu_backend = QutipBackendV2(seq, config=config)
     emu_backend.run()
+
+
+def test_run_twice():
+    seq = sequence()
+    noise_model = pulser.NoiseModel(
+        trap_depth=1.0,
+        trap_waist=1.0,
+        temperature=50.0,
+        disable_doppler=True,
+        detuning_sigma=5.0,
+    )
+
+    eval_times = [1.0]
+    qutip_config = QutipConfig(
+        default_evaluation_times=eval_times,
+        observables=[StateResult(evaluation_times=eval_times)],
+        noise_model=noise_model,
+        n_trajectories=10,
+    )
+    backend = QutipBackendV2(seq, config=qutip_config)
+    results1 = backend.run()
+    results2 = backend.run()
+    s1 = results1.final_state._state
+    s2 = results2.final_state._state
+    assert s1.overlap(s2) / (s1.norm() * s2.norm()) != pytest.approx(1.0)


### PR DESCRIPTION
Currently, the trajectories for noisy runs are computed on the initialization of `QutipEmulator`, which means that for `QutipEmulator`, `QutipBackend` and `QutipBackendV2`, calling run repeatedly on the same object will yield the same result each time. To get different noise trajectories, you have to recreate the backend. I've changed the code so that on subsequent calls to run, new noise trajectories are computed (if needed).