### PR TITLE
Normalize input state of observables in QutipBackendV2

### DIFF
--- a/pulser-simulation/pulser_simulation/qutip_backend.py
+++ b/pulser-simulation/pulser_simulation/qutip_backend.py
@@ -223,6 +223,7 @@ class QutipBackendV2(EmulatorBackend):
                         state = QutipState(
                             qutip_res.state, eigenstates=eigenstates
                         )
+                        state._state /= state._state.norm()
                         ham = QutipOperator(
                             self._sim_obj._get_noiseless_hamiltonian(
                                 self._config.noise_model.with_leakage

--- a/pulser-simulation/pulser_simulation/qutip_backend.py
+++ b/pulser-simulation/pulser_simulation/qutip_backend.py
@@ -223,7 +223,7 @@ class QutipBackendV2(EmulatorBackend):
                         state = QutipState(
                             qutip_res.state, eigenstates=eigenstates
                         )
-                        state._state /= state._state.norm()
+                        state._state = state._state / state._state.norm()
                         ham = QutipOperator(
                             self._sim_obj._get_noiseless_hamiltonian(
                                 self._config.noise_model.with_leakage

--- a/pulser-simulation/pulser_simulation/qutip_backend.py
+++ b/pulser-simulation/pulser_simulation/qutip_backend.py
@@ -183,7 +183,9 @@ class QutipBackendV2(EmulatorBackend):
 
             for qutip_res in single_res:
                 t = qutip_res.evaluation_time
-                state = QutipState(qutip_res.state, eigenstates=eigenstates)
+                state = QutipState(
+                    qutip_res.state.unit(), eigenstates=eigenstates
+                )
                 ham: QutipOperator = QutipOperator(
                     self._sim_obj._get_noiseless_hamiltonian(
                         self._config.noise_model.with_leakage
@@ -221,9 +223,8 @@ class QutipBackendV2(EmulatorBackend):
                         t = qutip_res.evaluation_time
 
                         state = QutipState(
-                            qutip_res.state, eigenstates=eigenstates
+                            qutip_res.state.unit(), eigenstates=eigenstates
                         )
-                        state._state = state._state / state._state.norm()
                         ham = QutipOperator(
                             self._sim_obj._get_noiseless_hamiltonian(
                                 self._config.noise_model.with_leakage

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -516,7 +516,7 @@ def test_output_state_normalization(amp_sigma):
             ),
             pulser.InterpolatedWaveform(
                 total_duration,
-                U * np.array([-1, 0.0556, 0.332, 1]) * factor,
+                U * np.array([-1, 0.0556, 0.332, 1]),
                 times=interp_pts,
             ),
             0,

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -483,15 +483,15 @@ def test_rounding_error_eval_time_duplication():
     emu_backend.run()
 
 
-def test_output_state_normalization():
-
-    device = pulser.AnalogDevice
+@pytest.mark.parametrize("amp_sigma", [0.0, 0.5])
+def test_output_state_normalization(amp_sigma):
+    factor = 1.2357175818662465 if not amp_sigma else 1.0
 
     # 2. Creating the Register
     R_interatomic = 5  # um
     register = pulser.Register.hexagon(1, R_interatomic, prefix="q")
 
-    seq = pulser.Sequence(register, device)
+    seq = pulser.Sequence(register, pulser.MockDevice)
 
     # 3. Picking the channels
     seq.declare_channel("rydberg_global", "rydberg_global")
@@ -499,7 +499,7 @@ def test_output_state_normalization():
     # 4. Adding the pulses
 
     # Parameters in rad/µs
-    U = device.interaction_coeff / R_interatomic**6
+    U = pulser.AnalogDevice.interaction_coeff / R_interatomic**6
 
     # Time parameters
     total_duration = 4000  # in ns
@@ -509,12 +509,12 @@ def test_output_state_normalization():
         pulser.Pulse(
             pulser.InterpolatedWaveform(
                 total_duration,
-                U * np.array([1e-9, 0.22, 0.2181, 1e-9]),
+                U * np.array([1e-9, 0.22, 0.2181, 1e-9]) * factor,
                 times=interp_pts,
             ),
             pulser.InterpolatedWaveform(
                 total_duration,
-                U * np.array([-1, 0.0556, 0.332, 1]),
+                U * np.array([-1, 0.0556, 0.332, 1]) * factor,
                 times=interp_pts,
             ),
             0,
@@ -526,7 +526,7 @@ def test_output_state_normalization():
     default_config = QutipBackendV2.default_config
     np.random.seed(1234)
     config = default_config.with_changes(
-        noise_model=pulser.NoiseModel(amp_sigma=0.5)
+        noise_model=pulser.NoiseModel(amp_sigma=amp_sigma)
     )
     qutip_bknd_custom = QutipBackendV2(seq, config=config)
     results = qutip_bknd_custom.run()

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -481,3 +481,53 @@ def test_rounding_error_eval_time_duplication():
     # It works because the rounding error was fixed
     emu_backend = QutipBackendV2(seq, config=config)
     emu_backend.run()
+
+
+def test_output_state_normalization():
+
+    device = pulser.AnalogDevice
+
+    # 2. Creating the Register
+    R_interatomic = 5  # um
+    register = pulser.Register.hexagon(1, R_interatomic, prefix="q")
+
+    seq = pulser.Sequence(register, device)
+
+    # 3. Picking the channels
+    seq.declare_channel("rydberg_global", "rydberg_global")
+
+    # 4. Adding the pulses
+
+    # Parameters in rad/µs
+    U = device.interaction_coeff / R_interatomic**6
+
+    # Time parameters
+    total_duration = 4000  # in ns
+    interp_pts = np.linspace(0, 1, 4)  # between 0 and 1
+
+    seq.add(
+        pulser.Pulse(
+            pulser.InterpolatedWaveform(
+                total_duration,
+                U * np.array([1e-9, 0.22, 0.2181, 1e-9]),
+                times=interp_pts,
+            ),
+            pulser.InterpolatedWaveform(
+                total_duration,
+                U * np.array([-1, 0.0556, 0.332, 1]),
+                times=interp_pts,
+            ),
+            0,
+        ),
+        "rydberg_global",
+    )
+
+    # Start from the default_config and add the Fidelity observable
+    default_config = QutipBackendV2.default_config
+    np.random.seed(1234)
+    config = default_config.with_changes(
+        noise_model=pulser.NoiseModel(amp_sigma=0.5)
+    )
+    qutip_bknd_custom = QutipBackendV2(seq, config=config)
+    results = qutip_bknd_custom.run()
+    assert results.final_state._state.norm() < 1 + 1e-8

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -26,6 +26,7 @@ from pulser.backend.default_observables import (
     BitStrings,
     Energy,
     EnergyVariance,
+    Fidelity,
     Occupation,
     StateResult,
 )
@@ -528,14 +529,25 @@ def test_output_state_normalization(amp_sigma):
     )
 
     # Start from the default_config and add any noise
+    noise_model = pulser.NoiseModel(amp_sigma=amp_sigma)
     default_config = QutipBackendV2.default_config
     np.random.seed(1234)
+    config = default_config.with_changes(noise_model=noise_model)
+    qutip_bknd_custom = QutipBackendV2(seq, config=config)
+    results = qutip_bknd_custom.run()
+    final_state = results.final_state
+    assert final_state._state.norm() < 1 + 1e-8
+
+    np.random.seed(1234)
     config = default_config.with_changes(
-        noise_model=pulser.NoiseModel(amp_sigma=amp_sigma)
+        noise_model=noise_model,
+        observables=[
+            Fidelity(final_state)
+        ],  # easiest way to get a fidelity close to 1
     )
     qutip_bknd_custom = QutipBackendV2(seq, config=config)
     results = qutip_bknd_custom.run()
-    assert results.final_state._state.norm() < 1 + 1e-8
+    assert results.fidelity[-1] < 1 + 1e-8
 
 
 def test_run_twice():

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -485,6 +485,8 @@ def test_rounding_error_eval_time_duplication():
 
 @pytest.mark.parametrize("amp_sigma", [0.0, 0.5])
 def test_output_state_normalization(amp_sigma):
+    # The original issue was triggered with amp_sigma=0.5
+    # to test the noiseless path, we manually apply the amplitude fluctuation
     factor = 1.2357175818662465 if not amp_sigma else 1.0
 
     # 2. Creating the Register
@@ -522,7 +524,7 @@ def test_output_state_normalization(amp_sigma):
         "rydberg_global",
     )
 
-    # Start from the default_config and add the Fidelity observable
+    # Start from the default_config and add any noise
     default_config = QutipBackendV2.default_config
     np.random.seed(1234)
     config = default_config.with_changes(

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -488,6 +488,7 @@ def test_rounding_error_eval_time_duplication():
 @pytest.mark.parametrize("amp_sigma", [0.0, 0.5])
 def test_output_state_normalization(amp_sigma):
     # The original issue was triggered with amp_sigma=0.5
+    # In which case the norm of the output state was 1.000012
     # to test the noiseless path, we manually apply the amplitude fluctuation
     factor = 1.2357175818662465 if not amp_sigma else 1.0
 


### PR DESCRIPTION
The ODE solver used by qutip does not preserve state norm analytically. As a result, the norm of the state can be observed to deviate from 1 by as much as 1e-4. Consequently, it is possible to measure `Fidelity` values larger than 1 (see the added unit test). I'm fixing the issue by feeding a normalized copy of the time-evolved state into the observables instead. I'm making a copy rather than normalizing in-place because I don't want the behaviour of the solver to depend on the evaluation times.