### PR TITLE
QUBO tutorial: Fix typo when introducing MWIS

### DIFF
--- a/tutorials/applications/QAA to solve a QUBO problem.ipynb
+++ b/tutorials/applications/QAA to solve a QUBO problem.ipynb
@@ -481,7 +481,7 @@
     "**To go further**:\n",
     "\n",
     "- The heuristic we are using here to define the values of $\\Omega$ and $\\delta$ along time works well in this case. You will surely have to adapt these values if you change the matrix $Q$. To tune them automatically, you can use an optimization procedure to find the sequence minimizing your cost function $z^TQz$ (see `get_cost` function above). An example of an optimization procedure is presented in [this tutorial](./optimization.nblink) (for a different cost function).\n",
-    "- If the matrix $Q$ you are trying to solve contains some off-diagonal elements, you need to use local addressability to solve your problem. An example of such a problem and its solution is presented in [this tutorial](./mwis.nblink).\n",
+    "- If the diagonal terms of the matrix $Q$ you are trying to solve are not all equal, you need to use local addressability to solve your problem. An example of such a problem and its solution is presented in [this tutorial](./mwis.nblink).\n",
     "</div>\n"
    ]
   }


### PR DESCRIPTION
Fixing typo in current tutorial when linking with MWIS