### PR TITLE
Updates to Local Addressability features

### DIFF
--- a/pulser-core/pulser/channels/dmm.py
+++ b/pulser-core/pulser/channels/dmm.py
@@ -189,7 +189,9 @@ class DMM(Channel):
         min_non_zero_weight = np.min(
             # Can't be empty because the WeightMap enforces having at least one
             # non-zero weight
-            np.array(detuning_map.weights)[np.nonzero(detuning_map.weights)]
+            np.array(detuning_map.weights)[
+                np.nonzero(detuning_map.weights)  # type: ignore[arg-type]
+            ]
         )
         if (
             0

--- a/pulser-core/pulser/channels/dmm.py
+++ b/pulser-core/pulser/channels/dmm.py
@@ -25,7 +25,7 @@ from pulser.json.utils import get_dataclass_defaults
 from pulser.pulse import Pulse
 from pulser.register.weight_maps import DetuningMap
 
-OPTIONAL_ABSTR_DMM_FIELDS = ["total_bottom_detuning"]
+OPTIONAL_ABSTR_DMM_FIELDS = ["total_bottom_detuning", "min_avg_abs_detuning"]
 
 
 @dataclass(init=True, frozen=True)
@@ -46,10 +46,13 @@ class DMM(Channel):
         "no-delay".
 
     Args:
-        bottom_detuning: Minimum possible detuning per atom (in rad/µs),
-            must be below zero.
-        total_bottom_detuning: Minimum possible detuning distributed on all
-            atoms (in rad/µs), must be below zero.
+        bottom_detuning: Minimum possible detuning per detuning map spot
+            (in rad/µs); must be below zero.
+        total_bottom_detuning: Minimum possible detuning distributed over all
+            detuning map spots (in rad/µs); must be below zero.
+        min_avg_abs_detuning: The minimum acceptable value for the average
+            detuning (in absolute value and in rad/µs) applied on any detuning
+            map spot (when not 0). Defaults to 0.
         clock_period: The duration of a clock cycle (in ns). The duration of a
             pulse or delay instruction is enforced to be a multiple of the
             clock cycle.
@@ -62,6 +65,7 @@ class DMM(Channel):
 
     bottom_detuning: float | None = None
     total_bottom_detuning: float | None = None
+    min_avg_abs_detuning: float = 0.0
     addressing: Literal["Global"] = field(
         default="Global", init=False, repr=False
     )
@@ -87,18 +91,39 @@ class DMM(Channel):
     def __post_init__(self) -> None:
         super().__post_init__()
         if self.bottom_detuning and self.bottom_detuning > 0:
-            raise ValueError("bottom_detuning must be negative.")
+            raise ValueError(
+                "'bottom_detuning' must be negative (got "
+                f"{self.bottom_detuning})."
+            )
         if self.total_bottom_detuning:
             if self.total_bottom_detuning > 0:
-                raise ValueError("total_bottom_detuning must be negative.")
+                raise ValueError(
+                    "'total_bottom_detuning' must be negative "
+                    f"(got {self.total_bottom_detuning})."
+                )
             if (
                 self.bottom_detuning
                 and self.bottom_detuning < self.total_bottom_detuning
             ):
                 raise ValueError(
-                    "total_bottom_detuning must be lower than"
-                    " bottom_detuning."
+                    f"'total_bottom_detuning' (got "
+                    f"{self.total_bottom_detuning}) must be lower than "
+                    f"'bottom_detuning' (got {self.bottom_detuning})."
                 )
+        if self.min_avg_abs_detuning < 0:
+            raise ValueError(
+                "'min_avg_abs_detuning' must be non-negative "
+                f"(got {self.min_avg_abs_detuning})."
+            )
+        if (
+            self.bottom_detuning
+            and self.min_avg_abs_detuning >= -self.bottom_detuning
+        ):
+            bottom_detuning = self.bottom_detuning
+            raise ValueError(
+                f"'min_avg_abs_detuning' (got {self.min_avg_abs_detuning}) "
+                f"must be lower than or equal to {-bottom_detuning=}."
+            )
 
     @property
     def basis(self) -> Literal["ground-rydberg"]:
@@ -136,24 +161,47 @@ class DMM(Channel):
             raise ValueError("The detuning in a DMM must not be positive.")
         # Check that detuning on each atom is above bottom_detuning
         min_round_detuning = np.min(round_detuning)
+        max_weight = np.max(detuning_map.weights)
         if (
             self.bottom_detuning is not None
-            and np.max(detuning_map.weights) * min_round_detuning
-            < self.bottom_detuning
+            and max_weight * min_round_detuning < self.bottom_detuning
         ):
             raise ValueError(
-                "The detunings on some atoms go below the local bottom "
+                f"For a detuning map with a maximum weight of {max_weight},"
+                f" a DMM pulse with minimum detuning {min_round_detuning} "
+                "rad/µs goes below the local bottom "
                 f"detuning of the DMM ({self.bottom_detuning} rad/µs)."
             )
         # Check that distributed detuning is above total_bottom_detuning
+        sum_weight = np.sum(detuning_map.weights)
         if (
             self.total_bottom_detuning is not None
-            and np.sum(detuning_map.weights) * min_round_detuning
-            < self.total_bottom_detuning
+            and sum_weight * min_round_detuning < self.total_bottom_detuning
         ):
             raise ValueError(
-                "The applied detuning goes below the total bottom detuning "
+                "For a detuning map with a total summed weight of "
+                f"{sum_weight}, the total applied detuning from a DMM pulse "
+                f"with minimum detuning {min_round_detuning} rad/µs goes below"
+                " the total bottom detuning "
                 f"of the DMM ({self.total_bottom_detuning} rad/µs)."
+            )
+        avg_abs_detuning = np.average(np.abs(round_detuning))
+        min_non_zero_weight = np.min(
+            # Can't be empty because the WeightMap enforces having at least one
+            # non-zero weight
+            np.array(detuning_map.weights)[np.nonzero(detuning_map.weights)]
+        )
+        if (
+            0
+            < min_non_zero_weight * avg_abs_detuning
+            < self.min_avg_abs_detuning
+        ):
+            raise ValueError(
+                "For a detuning map with a minimum non-zero weight of "
+                f"{min_non_zero_weight}, a DMM pulse with an average "
+                f"absolute detuning of {avg_abs_detuning:.3g} rad/µs does not"
+                " respect the minimum threshold for the average absolute "
+                f"detuning of the DMM ({self.min_avg_abs_detuning} rad/µs)."
             )
 
     def _to_abstract_repr(self, id: str) -> dict[str, Any]:

--- a/pulser-core/pulser/channels/dmm.py
+++ b/pulser-core/pulser/channels/dmm.py
@@ -197,7 +197,9 @@ class DMM(Channel):
         non_zero_weight_inds = np.nonzero(weights_arr)
         # Can't be empty because the WeightMap enforces having at least one
         # non-zero weight
-        assert len(non_zero_weight_inds) == 1 and len(non_zero_weight_inds[0]) > 0
+        assert (
+            len(non_zero_weight_inds) == 1 and len(non_zero_weight_inds[0]) > 0
+        )
         min_non_zero_weight = np.min(weights_arr[non_zero_weight_inds])
         if (
             0

--- a/pulser-core/pulser/channels/dmm.py
+++ b/pulser-core/pulser/channels/dmm.py
@@ -55,7 +55,6 @@ class DMM(Channel):
             clock cycle.
         min_duration: The shortest duration an instruction can take.
         max_duration: The longest duration an instruction can take.
-        min_avg_amp: The minimum average amplitude of a pulse (when not zero).
         mod_bandwidth: The modulation bandwidth (in MHz), following Pulser's
             non-standard definition (2x the -3dB bandwidth, or the frequency at
             75% amplitude attenuation).
@@ -63,12 +62,27 @@ class DMM(Channel):
 
     bottom_detuning: float | None = None
     total_bottom_detuning: float | None = None
-    addressing: Literal["Global"] = field(default="Global", init=False)
-    max_abs_detuning: Optional[float] = field(default=None, init=False)
-    max_amp: float = field(default=0, init=False)
-    min_retarget_interval: Optional[int] = field(default=None, init=False)
-    fixed_retarget_t: Optional[int] = field(default=None, init=False)
-    max_targets: Optional[int] = field(default=None, init=False)
+    addressing: Literal["Global"] = field(
+        default="Global", init=False, repr=False
+    )
+    max_abs_detuning: Optional[float] = field(
+        default=None, init=False, repr=False
+    )
+    max_amp: float = field(default=0, init=False, repr=False)
+    min_retarget_interval: Optional[int] = field(
+        default=None, init=False, repr=False
+    )
+    fixed_retarget_t: Optional[int] = field(
+        default=None, init=False, repr=False
+    )
+    max_targets: Optional[int] = field(default=None, init=False, repr=False)
+    propagation_dir: tuple[float, float, float] | None = field(
+        default=None, init=False, repr=False
+    )
+    min_avg_amp: float = field(default=0, init=False, repr=False)
+    custom_phase_jump_time: int | None = field(
+        default=None, init=False, repr=False
+    )
 
     def __post_init__(self) -> None:
         super().__post_init__()

--- a/pulser-core/pulser/channels/dmm.py
+++ b/pulser-core/pulser/channels/dmm.py
@@ -197,7 +197,7 @@ class DMM(Channel):
         non_zero_weight_inds = np.nonzero(weights_arr)
         # Can't be empty because the WeightMap enforces having at least one
         # non-zero weight
-        assert len(non_zero_weight_inds) > 0
+        assert len(non_zero_weight_inds) == 1 and len(non_zero_weight_inds[0]) > 0
         min_non_zero_weight = np.min(weights_arr[non_zero_weight_inds])
         if (
             0

--- a/pulser-core/pulser/channels/dmm.py
+++ b/pulser-core/pulser/channels/dmm.py
@@ -33,11 +33,13 @@ class DMM(Channel):
     """Defines a Detuning Map Modulator (DMM) Channel.
 
     A Detuning Map Modulator can be used to define `Global` detuning Pulses
-    (of zero amplitude and phase). These Pulses are locally modulated by the
-    weights of a `DetuningMap`, thus providing a local control over the
-    detuning. The detuning of the pulses added to a DMM has to be negative,
-    between 0 and `bottom_detuning`, and the sum of the weights multiplied by
-    that detuning has to be below `total_bottom_detuning`. Channel targeting
+    (of zero amplitude and phase). These detuning Pulses are locally weighted
+    by the weights of a `DetuningMap`, such that qubits experience a detuning
+    map spot i.e. a detuning pulse equal to
+    (detuning map weight on this qubit)*(detuning pulse value). The detuning
+    of the pulses added to a DMM has to be negative, such that each detuning
+    map spot is between 0 and `bottom_detuning`, and that the sum of all the
+    detuning map spots is below `total_bottom_detuning`. This Channel targets
     the transition between the ground and rydberg states, thus encoding the
     'ground-rydberg' basis.
 
@@ -48,10 +50,10 @@ class DMM(Channel):
     Args:
         bottom_detuning: Minimum possible detuning per detuning map spot
             (in rad/µs); must be below zero.
-        total_bottom_detuning: Minimum possible detuning distributed over all
+        total_bottom_detuning: Minimum possible total detuning summed over all
             detuning map spots (in rad/µs); must be below zero.
         min_avg_abs_detuning: The minimum acceptable value for the average
-            detuning (in absolute value and in rad/µs) applied on any detuning
+            absolute detuning (in rad/µs) applied on any detuning
             map spot (when not 0). Defaults to 0.
         clock_period: The duration of a clock cycle (in ns). The duration of a
             pulse or delay instruction is enforced to be a multiple of the
@@ -170,7 +172,9 @@ class DMM(Channel):
                 f"For a detuning map with a maximum weight of {max_weight},"
                 f" a DMM pulse with minimum detuning {min_round_detuning} "
                 "rad/µs goes below the local bottom "
-                f"detuning of the DMM ({self.bottom_detuning} rad/µs)."
+                f"detuning of the DMM ({self.bottom_detuning} rad/µs). "
+                "To respect this constraint, keep the detuning above "
+                f"{self.bottom_detuning/max_weight} rad/µs."
             )
         # Check that distributed detuning is above total_bottom_detuning
         sum_weight = np.sum(detuning_map.weights)
@@ -183,16 +187,18 @@ class DMM(Channel):
                 f"{sum_weight}, the total applied detuning from a DMM pulse "
                 f"with minimum detuning {min_round_detuning} rad/µs goes below"
                 " the total bottom detuning "
-                f"of the DMM ({self.total_bottom_detuning} rad/µs)."
+                f"of the DMM ({self.total_bottom_detuning} rad/µs). "
+                "To respect this constraint, keep the detuning above "
+                f"{self.total_bottom_detuning/sum_weight} rad/µs."
             )
         avg_abs_detuning = np.average(np.abs(round_detuning))
-        min_non_zero_weight = np.min(
-            # Can't be empty because the WeightMap enforces having at least one
-            # non-zero weight
-            np.array(detuning_map.weights)[
-                np.nonzero(detuning_map.weights)  # type: ignore[arg-type]
-            ]
-        )
+
+        weights_arr = np.array(detuning_map.weights)
+        non_zero_weight_inds = np.nonzero(weights_arr)
+        # Can't be empty because the WeightMap enforces having at least one
+        # non-zero weight
+        assert len(non_zero_weight_inds) > 0
+        min_non_zero_weight = np.min(weights_arr[non_zero_weight_inds])
         if (
             0
             < min_non_zero_weight * avg_abs_detuning

--- a/pulser-core/pulser/json/abstract_repr/schemas/device-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/device-schema.json
@@ -70,6 +70,10 @@
           "description": "How many atoms can be locally addressed at once by the same beam.",
           "type": "null"
         },
+        "min_avg_abs_detuning": {
+          "description": "Minimum acceptable value for the average absolute detuning applied on any detuning map spot.",
+          "type": "number"
+        },
         "min_avg_amp": {
           "description": "The minimum average amplitude of a pulse (when not zero).",
           "type": "number"
@@ -2045,6 +2049,10 @@
         "max_targets": {
           "description": "How many atoms can be locally addressed at once by the same beam.",
           "type": "null"
+        },
+        "min_avg_abs_detuning": {
+          "description": "Minimum acceptable value for the average absolute detuning applied on any detuning map spot.",
+          "type": "number"
         },
         "min_avg_amp": {
           "description": "The minimum average amplitude of a pulse (when not zero).",

--- a/pulser-core/pulser/json/abstract_repr/schemas/noise-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/noise-schema.json
@@ -44,6 +44,12 @@
           },
           "type": "array"
         },
+        "detuning_map_spot_waist": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
         "detuning_sigma": {
           "type": "number"
         },
@@ -87,9 +93,6 @@
             "number",
             "null"
           ]
-        },
-        "detuning_map_spot_waist": {
-          "type": "number"
         },
         "noise_types": {
           "items": {

--- a/pulser-core/pulser/json/abstract_repr/schemas/sequence-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/sequence-schema.json
@@ -1034,17 +1034,17 @@
             },
             "metadata": {
               "additionalProperties": false,
-              "description": "Any metadata to attach to the serialized Sequence.",
+              "description": "Metadata related to the serialized Sequence.",
               "properties": {
                 "extra": {
-                  "description": "A place to include any extra metadata.",
+                  "description": "Any extra metadata.",
                   "type": "object"
                 },
                 "package_versions": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "The packages used to generate the sequence and their versions.",
+                  "description": "The packages used to create the sequence and their respective versions.",
                   "type": "object"
                 }
               },
@@ -1156,17 +1156,17 @@
             },
             "metadata": {
               "additionalProperties": false,
-              "description": "Any metadata to attach to the serialized Sequence.",
+              "description": "Metadata related to the serialized Sequence.",
               "properties": {
                 "extra": {
-                  "description": "A place to include any extra metadata.",
+                  "description": "Any extra metadata.",
                   "type": "object"
                 },
                 "package_versions": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "The packages used to generate the sequence and their versions.",
+                  "description": "The packages used to create the sequence and their respective versions.",
                   "type": "object"
                 }
               },
@@ -1278,17 +1278,17 @@
             },
             "metadata": {
               "additionalProperties": false,
-              "description": "Any metadata to attach to the serialized Sequence.",
+              "description": "Metadata related to the serialized Sequence.",
               "properties": {
                 "extra": {
-                  "description": "A place to include any extra metadata.",
+                  "description": "Any extra metadata.",
                   "type": "object"
                 },
                 "package_versions": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "The packages used to generate the sequence and their versions.",
+                  "description": "The packages used to create the sequence and their respective versions.",
                   "type": "object"
                 }
               },

--- a/pulser-core/pulser/register/register_layout.py
+++ b/pulser-core/pulser/register/register_layout.py
@@ -20,7 +20,6 @@ import json
 from collections.abc import Mapping
 from collections.abc import Sequence as abcSequence
 from dataclasses import dataclass
-from operator import itemgetter
 from typing import Any, Optional, cast
 
 import matplotlib.pyplot as plt
@@ -134,7 +133,7 @@ class RegisterLayout(Traps, RegDrawer):
                 f" in [0, {self.number_of_traps-1}]."
             )
         return DetuningMap(
-            itemgetter(*detuning_weights.keys())(self.traps_dict),
+            [self.traps_dict[trap_id] for trap_id in detuning_weights],
             list(detuning_weights.values()),
             slug,
         )

--- a/pulser-core/pulser/register/weight_maps.py
+++ b/pulser-core/pulser/register/weight_maps.py
@@ -34,6 +34,8 @@ if TYPE_CHECKING:
 
 import pulser.math as pm
 
+WEIGHT_PRECISION = 6
+
 
 @dataclass(init=False, repr=False, eq=False, frozen=True)
 class WeightMap(Traps, RegDrawer):
@@ -72,10 +74,14 @@ class WeightMap(Traps, RegDrawer):
         return self._coords_arr.as_array(detach=True)
 
     @property
+    def _rounded_weights(self) -> np.ndarray:
+        return np.round(self.weights, decimals=WEIGHT_PRECISION)
+
+    @property
     def sorted_weights(self) -> np.ndarray:
         """The weights sorted to match the sorted trap coordinates."""
         sorting = self._calc_sorting_order()
-        return cast(np.ndarray, np.array(self.weights)[sorting])
+        return cast(np.ndarray, self._rounded_weights[sorting])
 
     def get_qubit_weight_map(
         self, qubits: Mapping[QubitId, ArrayLike]

--- a/pulser-core/pulser/register/weight_maps.py
+++ b/pulser-core/pulser/register/weight_maps.py
@@ -60,6 +60,10 @@ class WeightMap(Traps, RegDrawer):
             np.all(np.array(weights) >= 0) and np.all(np.array(weights) <= 1)
         ):
             raise ValueError("All weights must be between 0 and 1.")
+        if np.count_nonzero(weights) == 0:
+            raise ValueError(
+                "A WeightMap must have at least one non-zero weight."
+            )
         object.__setattr__(self, "weights", tuple(weights))
 
     @property

--- a/pulser-core/pulser/sequence/sequence.py
+++ b/pulser-core/pulser/sequence/sequence.py
@@ -626,7 +626,7 @@ class Sequence(Generic[DeviceType]):
     def config_detuning_map(
         self,
         detuning_map: DetuningMap,
-        dmm_id: str,
+        dmm_id: str | None = None,
     ) -> None:
         """Declares a new DMM channel to the Sequence.
 
@@ -641,8 +641,20 @@ class Sequence(Generic[DeviceType]):
                 atom receives.
             dmm_id: How the channel is identified in the device.
                 See in ``Sequence.available_channels`` which DMM IDs are still
-                available (start by "dmm" ) and the associated description.
+                available (start by "dmm" ) and the associated description. If
+                not given, takes the first available DMM in the device.
         """
+        if dmm_id is None:
+            for ch_id, ch_obj in self.available_channels.items():
+                if isinstance(ch_obj, DMM):
+                    dmm_id = ch_id
+                    break
+            else:
+                raise ValueError(
+                    "No DMM channel is still available in device "
+                    f"{self.device.name!r}."
+                )
+
         self._config_detuning_map(detuning_map, dmm_id)
 
     def _config_detuning_map(

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -30,7 +30,7 @@ import pytest
 import pulser
 from pulser import Pulse, Register, Register3D, Sequence, devices
 from pulser.abstract_repr import deserialize_device
-from pulser.channels import Rydberg
+from pulser.channels import Rydberg, DMM
 from pulser.channels.eom import RydbergBeam, RydbergEOM
 from pulser.devices import (
     AnalogDevice,
@@ -705,6 +705,16 @@ class TestDevice:
         device = replace(
             MockDevice, channel_objects=(ch_obj,), channel_ids=None
         )
+        dev_str = device.to_abstract_repr()
+        assert device == deserialize_device(dev_str)
+        assert device == VirtualDevice.from_abstract_repr(dev_str)
+
+    @pytest.mark.parametrize(
+        "dmm_ch_obj",
+        [DMM(total_bottom_detuning=-10), DMM(min_avg_abs_detuning=0.1)],
+    )
+    def test_optional_DMM_fields(self, dmm_ch_obj):
+        device = replace(MockDevice, dmm_objects=(dmm_ch_obj,))
         dev_str = device.to_abstract_repr()
         assert device == deserialize_device(dev_str)
         assert device == VirtualDevice.from_abstract_repr(dev_str)

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -30,7 +30,7 @@ import pytest
 import pulser
 from pulser import Pulse, Register, Register3D, Sequence, devices
 from pulser.abstract_repr import deserialize_device
-from pulser.channels import Rydberg, DMM
+from pulser.channels import DMM, Rydberg
 from pulser.channels.eom import RydbergBeam, RydbergEOM
 from pulser.devices import (
     AnalogDevice,

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -65,7 +65,7 @@ class TestDetuningMap:
     ) -> DetuningMap:
         return layout.define_detuning_map(slm_dict)
 
-    @pytest.mark.parametrize("bad_key", [{1: 1.0}, {"4": 1.0}])
+    @pytest.mark.parametrize("bad_key", [{4: 1.0}, {"4": 1.0}])
     def test_define_detuning_map(
         self,
         layout: RegisterLayout,
@@ -74,13 +74,6 @@ class TestDetuningMap:
         bad_key: dict,
     ):
         for reg in (layout, map_reg):
-            if type(list(bad_key.keys())[0]) == int:
-                with pytest.raises(
-                    ValueError,
-                    match="'trap_coordinates' must be an array or list",
-                ):
-                    reg.define_detuning_map(bad_key)
-                continue
             with pytest.raises(
                 ValueError,
                 match=re.escape(
@@ -185,12 +178,18 @@ class TestDetuningMap:
             bad_weights: dict[int | str, float]
             if reg == register:
                 bad_weights = {"0": -1.0, "1": 1.0, "2": 1.0}
+                zero_weights = {"0": 0.0}
             else:
                 bad_weights = {0: -1.0, 1: 1.0, 2: 1.0}
+                zero_weights = {0: 0.0}
             with pytest.raises(
                 ValueError, match="All weights must be between 0 and 1."
             ):
                 reg.define_detuning_map(bad_weights)  # type: ignore
+            with pytest.raises(
+                ValueError, match="must have at least one non-zero weight"
+            ):
+                reg.define_detuning_map(zero_weights)
 
     def test_init(
         self,
@@ -267,6 +266,7 @@ class TestDMM:
         return DMM(
             bottom_detuning=-1,
             total_bottom_detuning=-10,
+            min_avg_abs_detuning=0.1,
             clock_period=1,
             min_duration=1,
             max_duration=1e6,
@@ -290,17 +290,41 @@ class TestDMM:
         ):
             assert value is None
         with pytest.raises(
-            ValueError, match="bottom_detuning must be negative."
+            ValueError,
+            match=re.escape("'bottom_detuning' must be negative (got 1)."),
         ):
             DMM(bottom_detuning=1)
         with pytest.raises(
-            ValueError, match="total_bottom_detuning must be negative."
+            ValueError,
+            match=re.escape(
+                "'total_bottom_detuning' must be negative (got 10)"
+            ),
         ):
             DMM(total_bottom_detuning=10)
         with pytest.raises(
-            ValueError, match="total_bottom_detuning must be lower"
+            ValueError,
+            match=re.escape(
+                "'total_bottom_detuning' (got -1) must be lower than "
+                "'bottom_detuning' (got -10)"
+            ),
         ):
             DMM(total_bottom_detuning=-1, bottom_detuning=-10)
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "'min_avg_abs_detuning' must be non-negative (got -0.5)"
+            ),
+        ):
+            DMM(min_avg_abs_detuning=-0.5)
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "'min_avg_abs_detuning' (got 10.1) must be lower than or equal"
+                " to -bottom_detuning=10."
+            ),
+        ):
+            DMM(min_avg_abs_detuning=10.1, bottom_detuning=-10)
+
         with pytest.raises(
             NotImplementedError,
             match=f"{DMM} cannot be initialized from `Global` method.",
@@ -327,15 +351,15 @@ class TestDMM:
             physical_dmm.validate_pulse(pos_det_pulse)
 
         # Local detuning is given by Pulse.detuning * local_weight
-        too_low_pulse = Pulse.ConstantPulse(
-            100, 0, physical_dmm.bottom_detuning - 0.01, 0
-        )
+        det_value = physical_dmm.bottom_detuning - 0.01
+        too_low_pulse = Pulse.ConstantPulse(100, 0, det_value, 0)
         with pytest.raises(
             ValueError,
             match=re.escape(
-                "The detunings on some atoms go below the local "
-                "bottom detuning of the DMM "
-                f"({physical_dmm.bottom_detuning} rad/µs)"
+                "For a detuning map with a maximum weight of 1.0, a DMM pulse "
+                f"with minimum detuning {det_value} rad/µs "
+                "goes below the local bottom detuning of the DMM "
+                f"({physical_dmm.bottom_detuning} rad/µs)."
             ),
         ):
             # tested with detuning map with weight 1
@@ -348,11 +372,15 @@ class TestDMM:
         det_map = TriangularLatticeLayout(100, 10).define_detuning_map(
             {i: 0.5 if i < 20 else 0.0 for i in range(100)}
         )
+        summed_weight = sum(det_map.weights)
         with pytest.raises(
             ValueError,
             match=re.escape(
-                "The applied detuning goes below the total bottom detuning "
-                f"of the DMM ({physical_dmm.total_bottom_detuning} rad/µs)"
+                "For a detuning map with a total summed weight of "
+                f"{summed_weight}, the total applied detuning from a DMM pulse"
+                f" with minimum detuning {det_value} rad/µs goes below the "
+                "total bottom detuning of the DMM "
+                f"({physical_dmm.total_bottom_detuning} rad/µs)."
             ),
         ):
             # local detunings match bottom_detuning, global don't
@@ -360,3 +388,20 @@ class TestDMM:
 
         # Should be valid in a virtual DMM without total bottom detuning
         virtual_local_dmm.validate_pulse(too_low_pulse, det_map)
+
+        min_weight = 0.05
+        det_map = TriangularLatticeLayout(100, 10).define_detuning_map(
+            {1: min_weight}
+        )
+        assert min_weight * abs(det_value) < physical_dmm.min_avg_abs_detuning
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "For a detuning map with a minimum non-zero weight of "
+                f"{min_weight}, a DMM pulse with an average absolute detuning"
+                f" of {-det_value:.3g} rad/µs does not respect "
+                "the minimum threshold for the average absolute detuning of "
+                f"the DMM ({physical_dmm.min_avg_abs_detuning} rad/µs)."
+            ),
+        ):
+            physical_dmm.validate_pulse(too_low_pulse, det_map)

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -27,7 +27,11 @@ from pulser.register.base_register import BaseRegister
 from pulser.register.mappable_reg import MappableRegister
 from pulser.register.register_layout import RegisterLayout
 from pulser.register.special_layouts import TriangularLatticeLayout
-from pulser.register.weight_maps import DetuningMap, WeightMap
+from pulser.register.weight_maps import (
+    WEIGHT_PRECISION,
+    DetuningMap,
+    WeightMap,
+)
 
 
 class TestDetuningMap:
@@ -135,7 +139,18 @@ class TestDetuningMap:
         assert np.any(det_map.trap_coordinates != det_map2.trap_coordinates)
         assert det_map.weights != det_map2.weights
 
-        # But are equal in sorted content
+        # We can even introduce small deviations (below the WEIGHT_PRECISION)
+        # in the weights and they should stil be equal
+        det_map2 = DetuningMap(
+            trap_coordinates=det_map2.trap_coordinates,
+            weights=np.clip(
+                np.array(det_map2.weights) + 10 ** -(WEIGHT_PRECISION + 1),
+                0.0,
+                1.0,
+            ),
+        )
+
+        # They are equal in sorted and rounded content
         np.testing.assert_equal(det_map.sorted_coords, det_map2.sorted_coords)
         np.testing.assert_equal(
             det_map.sorted_weights, det_map2.sorted_weights

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -176,6 +176,7 @@ class TestDetuningMap:
 
         for reg in (layout, map_reg, register):
             bad_weights: dict[int | str, float]
+            zero_weights: dict[int | str, float]
             if reg == register:
                 bad_weights = {"0": -1.0, "1": 1.0, "2": 1.0}
                 zero_weights = {"0": 0.0}
@@ -189,7 +190,7 @@ class TestDetuningMap:
             with pytest.raises(
                 ValueError, match="must have at least one non-zero weight"
             ):
-                reg.define_detuning_map(zero_weights)
+                reg.define_detuning_map(zero_weights)  # type: ignore
 
     def test_init(
         self,

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -392,7 +392,9 @@ class TestDMM:
                 "For a detuning map with a maximum weight of 1.0, a DMM pulse "
                 f"with minimum detuning {det_value} rad/µs "
                 "goes below the local bottom detuning of the DMM "
-                f"({physical_dmm.bottom_detuning} rad/µs)."
+                f"({physical_dmm.bottom_detuning} rad/µs). "
+                "To respect this constraint, keep the detuning above "
+                f"{float(physical_dmm.bottom_detuning)} rad/µs."
             ),
         ):
             # tested with detuning map with weight 1
@@ -413,7 +415,9 @@ class TestDMM:
                 f"{summed_weight}, the total applied detuning from a DMM pulse"
                 f" with minimum detuning {det_value} rad/µs goes below the "
                 "total bottom detuning of the DMM "
-                f"({physical_dmm.total_bottom_detuning} rad/µs)."
+                f"({physical_dmm.total_bottom_detuning} rad/µs). "
+                "To respect this constraint, keep the detuning above "
+                f"{physical_dmm.total_bottom_detuning/summed_weight} rad/µs."
             ),
         ):
             # local detunings match bottom_detuning, global don't

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -856,10 +856,7 @@ def test_switch_device_down(
         "new device that does not modify the samples of the Sequence. "
         "Here is a list of matchings tested and their associated errors: "
         "{(('global', 'rydberg_global'), ('dmm_0', 'dmm_0'), ('dmm_0_1', "
-        "'dmm_1')): 'The detunings on some atoms go below the local bottom "
-        "detuning of the DMM (-10 rad/µs).', (('global', 'rydberg_global'), "
-        "('dmm_0', 'dmm_1'), ('dmm_0_1', 'dmm_0')): 'The detunings on some "
-        "atoms go below the local bottom detuning of the DMM (-10 rad/µs).'}"
+        "'dmm_1')):"
     )
     with helpers.raises_all(
         [ValueError, SwitchDeviceError], match=re.escape(error_msg)

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -139,13 +139,29 @@ def test_channel_declaration(reg, device):
     assert seq2.get_addressed_states() == ["u", "d"]
 
 
-def test_dmm_declaration(reg, device, det_map):
+@pytest.mark.parametrize("first_dmm_id", ["dmm_0", None])
+def test_dmm_declaration(reg, device, det_map, first_dmm_id):
     seq = Sequence(reg, device)
     available_channels = set(seq.available_channels)
     assert seq.get_addressed_bases() == ()
-    seq.config_detuning_map(det_map, "dmm_0")
+    seq.config_detuning_map(det_map, first_dmm_id)
+    assert list(seq.declared_channels) == ["dmm_0"]
     assert seq.get_addressed_bases() == ("ground-rydberg",)
-    seq.config_detuning_map(det_map, "dmm_1")
+    assert [
+        ch_id
+        for ch_id, ch_obj in seq.available_channels.items()
+        if isinstance(ch_obj, DMM)
+    ] == ["dmm_1"]
+    # Not defining the dmm_id will make it pick the only available one
+    seq.config_detuning_map(det_map)
+    # No DMM is available now
+    assert not [
+        ch_id
+        for ch_id, ch_obj in seq.available_channels.items()
+        if isinstance(ch_obj, DMM)
+    ]
+    # Add dmm_1 is declared
+    assert list(seq.declared_channels) == ["dmm_0", "dmm_1"]
     with pytest.raises(
         ValueError,
         match=r"No DMM called dmm_2 is available in the device\. "
@@ -155,6 +171,8 @@ def test_dmm_declaration(reg, device, det_map):
         seq.config_detuning_map(det_map, "dmm_2")
     with pytest.raises(ValueError, match="DMM dmm_0 is not available"):
         seq.config_detuning_map(det_map, "dmm_0")
+    with pytest.raises(ValueError, match="No DMM channel is still available"):
+        seq.config_detuning_map(det_map)
 
     chs = {"dmm_0", "dmm_1"}
     assert seq._schedule["dmm_0"][-1] == _TimeSlot(
@@ -168,11 +186,11 @@ def test_dmm_declaration(reg, device, det_map):
         "dmm_0": "dmm_0",
         "dmm_0_1": "dmm_0",
     }
-    seq2.config_detuning_map(det_map, "dmm_0")
+    seq2.config_detuning_map(det_map, first_dmm_id)
     # If a DMM was declared but not as an SLM Mask,
     # MW channels are not available
     assert set(seq2.available_channels) == (available_channels - {"mw_global"})
-    seq2.config_detuning_map(det_map, "dmm_0")
+    seq2.config_detuning_map(det_map)  # Will use "dmm_0" again
     assert set(seq2.available_channels) == (available_channels - {"mw_global"})
     assert channel_map.keys() == seq2.declared_channels.keys()
     assert set(


### PR DESCRIPTION
- Hides irrelevant parameters from the `DMM` repr
- Changes `Sequence.config_detuning_map()` to default to choosing the first available DMM channel when `dmm_id` is not given
- Adds `DMM.min_avg_abs_detuning` (Closes #1027 )
- Improves checks on the DMM and DetuningMap
- Add WEIGHT_PRECISION to weights in a WeightMap (Closes #1040 ) 