### PR TITLE
Resolve inconsistencies in the XY Hamiltonian

### DIFF
--- a/docs/source/conventions.md
+++ b/docs/source/conventions.md
@@ -173,12 +173,14 @@ of $|a\rangle$ and $|b\rangle$.
 
 :::{important}
 **In `pulser-simulation`, this is the case for the `ground-rydberg` basis**, since
+
  $$
  E_r > E_g \rightarrow \ket{r} \equiv \ket{b}, \ket{g} \equiv \ket{a}
  $$
+
 :::
 
-When the basis vectors are defined in desceding energy order, we have
+When the basis vectors are defined in descending energy order, we have
 
 $$
 |b\rangle = (1, 0)^T,~~|a\rangle = (0, 1)^T
@@ -201,16 +203,18 @@ H^D(t) / \hbar = \frac{\Omega(t)}{2} \cos\phi(t) \hat{\sigma}^x
 - \delta(t) \hat{n}
 $$
 
-##### Case 2. Asceding energy order
+##### Case 2. Ascending energy order
 
 :::{important}
 **In `pulser-simulation`, this is the case for the `XY` basis**, since
+
  $$
  E_0 < E_1 \rightarrow \ket{0} \equiv \ket{a}, \ket{1} \equiv \ket{b}
  $$
+
 :::
 
-When the basis vectors are defined in asceding energy order, we have
+When the basis vectors are defined in ascending energy order, we have
 
 $$
 |a\rangle = (1, 0)^T,~~|b\rangle = (0, 1)^T

--- a/docs/source/conventions.md
+++ b/docs/source/conventions.md
@@ -235,6 +235,15 @@ H^D(t) / \hbar = \frac{\Omega(t)}{2} \cos\phi(t) \hat{\sigma}^x
 - \delta(t) \hat{n}
 $$
 
+:::{note}
+This is also the Hamiltonian one should use when trying to reconcile the basis states of the `ground-rydberg` basis
+with the computational-basis state-vector convention, i.e.
+
+$$
+|0\rangle = |g\rangle = |a\rangle = (1, 0)^T,~~|1\rangle = |r\rangle = |b\rangle = (0, 1)^T
+$$
+:::
+
 
 ### Interaction Hamiltonian
 

--- a/docs/source/conventions.md
+++ b/docs/source/conventions.md
@@ -169,10 +169,16 @@ A more conventional representation of the driving Hamiltonian uses Pauli operato
 instead of projectors. However, this form now **depends on the state vector definition**
 of $|a\rangle$ and $|b\rangle$.
 
-##### Pulser's state-vector definition
+##### Case 1. Descending energy order
 
-In Pulser, we consistently define the state vectors according to their relative energy.
-In this way we have, for any given basis, that
+:::{info}
+**In `pulser-simulation`, this is the case for the `ground-rydberg` basis**, since
+ $$
+ E_r > E_g \rightarrow \ket{r} \equiv \ket{b}, \ket{g} \equiv \ket{a}
+ $$
+:::
+
+When the basis vectors are defined in desceding energy order, we have
 
 $$
 |b\rangle = (1, 0)^T,~~|a\rangle = (0, 1)^T
@@ -195,17 +201,22 @@ H^D(t) / \hbar = \frac{\Omega(t)}{2} \cos\phi(t) \hat{\sigma}^x
 - \delta(t) \hat{n}
 $$
 
-##### Alternative state-vector definition
+##### Case 2. Asceding energy order
 
-Outside of Pulser, the alternative definition for the basis state
-vectors might be taken:
+:::{info}
+**In `pulser-simulation`, this is the case for the `XY` basis**, since
+ $$
+ E_0 < E_1 \rightarrow \ket{0} \equiv \ket{a}, \ket{1} \equiv \ket{b}
+ $$
+:::
+
+When the basis vectors are defined in asceding energy order, we have
 
 $$
 |a\rangle = (1, 0)^T,~~|b\rangle = (0, 1)^T
 $$
 
-This changes the operators and Hamiltonian definitions,
-as rewriten below with highlighted differences.
+This changes the operators and Hamiltonian definitions with respect to [Case 1](#case-1-descending-energy-order), as rewriten below with highlighted differences.
 
 $$
 \hat{\sigma}^x = |a\rangle\langle b| + |b\rangle\langle a|, \\
@@ -220,16 +231,6 @@ H^D(t) / \hbar = \frac{\Omega(t)}{2} \cos\phi(t) \hat{\sigma}^x
 - \delta(t) \hat{n}
 $$
 
-:::{note}
-A common case for the use of this alternative definition arises when
-trying to reconcile the basis states of the `ground-rydberg` basis
-(where $|r\rangle$ is the higher energy level) with the
-computational-basis state-vector convention, thus ending up with
-
-$$
-|0\rangle = |g\rangle = |a\rangle = (1, 0)^T,~~|1\rangle = |r\rangle = |b\rangle = (0, 1)^T
-$$
-:::
 
 ### Interaction Hamiltonian
 
@@ -250,15 +251,10 @@ On the other hand, with the two Rydberg states of the `XY`
 basis, the interaction Hamiltonian takes the form
 
 $$
-H^\text{int}_{ij} =  \frac{C_3}{R_{ij}^3} (\hat{\sigma}_i^{+}\hat{\sigma}_j^{-} + \hat{\sigma}_i^{-}\hat{\sigma}_j^{+})
+H^\text{int}_{ij} =  \frac{C_3}{R_{ij}^3} (|1\rangle\langle 0|_i |0\rangle\langle 1|_j + |0\rangle\langle 1|_i |1\rangle\langle 0|_j)
 $$
 
-where $C_3$ is a coefficient that depends on the chosen Ryberg states
-and
-
-$$
-\hat{\sigma}_i^{+} =  |1\rangle\langle 0|_i,~~~\hat{\sigma}_i^{-} =  |0\rangle\langle 1|_i
-$$
+where $C_3$ is a coefficient that depends on the chosen Ryberg states.
 
 :::{note}
 The definitions given for both interaction Hamiltonians are independent of the chosen state vector convention.

--- a/docs/source/conventions.md
+++ b/docs/source/conventions.md
@@ -171,7 +171,7 @@ of $|a\rangle$ and $|b\rangle$.
 
 ##### Case 1. Descending energy order
 
-:::{info}
+:::{important}
 **In `pulser-simulation`, this is the case for the `ground-rydberg` basis**, since
  $$
  E_r > E_g \rightarrow \ket{r} \equiv \ket{b}, \ket{g} \equiv \ket{a}
@@ -203,7 +203,7 @@ $$
 
 ##### Case 2. Asceding energy order
 
-:::{info}
+:::{important}
 **In `pulser-simulation`, this is the case for the `XY` basis**, since
  $$
  E_0 < E_1 \rightarrow \ket{0} \equiv \ket{a}, \ket{1} \equiv \ket{b}

--- a/docs/source/programming.md
+++ b/docs/source/programming.md
@@ -139,10 +139,10 @@ $$
 $$
 <details>
 
-  <summary>Interaction strength and entangling operator</summary>
+  <summary>Interaction strength in the XY Hamiltonian</summary>
 
 - The interaction strength is $\frac{C_3}{R_{ij}^3}$, with $C_3$ a coefficient that depends on the energy levels used to encode $\left|0\right>$ and $\left|1\right>$. 
-- The entangling operator between atom $i$ and $j$ is $\hat{\sigma}_i^{+}\hat{\sigma}_j^{-} + \hat{\sigma}_i^{-}\hat{\sigma}_j^{+} = |1\rangle\langle 0|_i |0\rangle\langle 1|_j + |0\rangle\langle 1|_i |1\rangle\langle 0|_j$. 
+
 
 </details>
 

--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -53,7 +53,7 @@ STATES_RANK = get_args(States)
 EIGENSTATES: dict[str, list[States]] = {
     "ground-rydberg": ["r", "g"],
     "digital": ["g", "h"],
-    "XY": ["u", "d"],
+    "XY": ["u", "d"],  # u -> 0, d -> 1
 }
 
 

--- a/pulser-core/pulser/channels/base_channel.py
+++ b/pulser-core/pulser/channels/base_channel.py
@@ -45,7 +45,7 @@ OPTIONAL_ABSTR_CH_FIELDS = (
     "propagation_dir",
 )
 
-# States ranked in decreasing order of their associated eigenenergy
+# States ordered as they appear in the state-vector representation
 States = Literal["u", "d", "r", "g", "h", "x"]
 
 STATES_RANK = get_args(States)

--- a/pulser-simulation/pulser_simulation/hamiltonian.py
+++ b/pulser-simulation/pulser_simulation/hamiltonian.py
@@ -337,7 +337,7 @@ class Hamiltonian:
             elif basis == "digital":
                 op_ids = ["sigma_hg", "sigma_gg"]
             elif basis == "XY":
-                op_ids = ["sigma_du", "sigma_uu"]
+                op_ids = ["sigma_ud", "sigma_dd"]
 
             terms = []
             if addr == "Global":

--- a/tests/pulser_simulation/test_simulation.py
+++ b/tests/pulser_simulation/test_simulation.py
@@ -1403,13 +1403,25 @@ def test_get_xy_hamiltonian():
         )
         < 1e-10
     )
+
     assert simple_ham[0, 1] == 0.5 * amp
-    # |udd><udd| -> 1 atom in |u>
-    assert simple_ham[3, 3] == -detun
-    # |udd><udd| -> 3 atom in |u>
-    assert simple_ham[0, 0] == -3 * detun
-    # |ddd><ddd| -> no atom in |u>
-    assert simple_ham[7, 7] == 0
+    # The detuning on the diagonal depends on how many qubits are in |d>
+    np.testing.assert_array_equal(
+        np.diag(simple_ham.full()),
+        np.array(
+            [
+                0,  # uuu
+                1,  # uud
+                1,  # udu
+                2,  # udd
+                1,  # duu
+                2,  # dud
+                2,  # ddu
+                3,  # ddd
+            ]
+        )
+        * -detun,
+    )
 
 
 def test_run_xy():
@@ -1446,13 +1458,20 @@ def test_run_xy():
 
 
 res_deph_mcarlo = {"0000": 830, "0001": 21, "0010": 3, "0100": 80, "1000": 66}
-res_eff_mcarlo = {"0000": 860, "0001": 35, "0010": 4, "0100": 28, "1000": 73}
+res_eff_mcarlo = {
+    "0000": 860,
+    "0001": 35,
+    "0010": 4,
+    "0100": 25,
+    "1000": 66,
+    "0011": 10,
+}
 res_leak_mcarlo = res_eff_mcarlo
 res_depol_mcarlo = res_deph_mcarlo
 res_deph_atom1_mcarlo = {
-    "0000": 798,
-    "0001": 101,
-    "0010": 22,
+    "0000": 804,
+    "0001": 105,
+    "0010": 12,
     "0100": 54,
     "0101": 8,
     "1000": 17,
@@ -1471,8 +1490,8 @@ res_eff_meq = {"0000": 845, "0001": 29, "0010": 8, "0100": 57, "1000": 61}
 res_leak_meq = res_eff_meq
 res_depol_meq = {
     "0000": 791,
-    "0001": 28,
-    "0010": 18,
+    "0001": 32,
+    "0010": 14,
     "0100": 72,
     "0101": 12,
     "0110": 2,

--- a/tutorials/quantum_simulation/Spin chain of 3 atoms in XY mode.ipynb
+++ b/tutorials/quantum_simulation/Spin chain of 3 atoms in XY mode.ipynb
@@ -208,7 +208,7 @@
     "An external magnetic field can be added to the experiment, and will modify the hamiltonian. The XY Hamiltonian is then\n",
     "\n",
     "$$\n",
-    "H_{XY} = \\sum_{i=1}^N\\sum_{j<i} \\frac{C_3[1 - 3\\text{cos}^2(\\theta_{ij})]}{R_{ij}^3}(\\sigma^+_i \\sigma^-_j + \\sigma^-_i \\sigma^+_j)\n",
+    "H_{XY} = \\sum_{i=1}^N\\sum_{j<i} \\frac{C_3[1 - 3\\text{cos}^2(\\theta_{ij})]}{R_{ij}^3}(|1\\rangle\\langle 0|_i |0\\rangle\\langle 1|_j + |0\\rangle\\langle 1|_i |1\\rangle\\langle 0|_j)\n",
     "$$\n",
     "\n",
     "where $\\theta_{ij}$ is the angle between the vector of the two atoms and the external field as shown on the figure below.\n",


### PR DESCRIPTION
- **The XY Hamiltonian in `pulser-simulation` is corrected to identify** $\ket{1}$ **as the higher energy state**
- The conventions page is adjusted to solve the contradiction outlined in #1042 

Closes #1042  