### PR TITLE
TECH: preload validation jsonschema

### DIFF
--- a/pulser-core/pulser/json/abstract_repr/validation.py
+++ b/pulser-core/pulser/json/abstract_repr/validation.py
@@ -37,6 +37,17 @@ REGISTRY: Registry = Registry(
     ]
 )
 
+# Build one validator per schema at import time so that meta-schema
+# checking and $ref resolution are paid once, not on every call.
+_VALIDATORS: dict[str, jsonschema.Draft7Validator] = (
+    {}
+    if LEGACY_JSONSCHEMA
+    else {
+        name: jsonschema.Draft7Validator(schema, registry=REGISTRY)
+        for name, schema in SCHEMAS.items()
+    }
+)
+
 
 def validate_abstract_repr(
     obj_str: str,
@@ -57,16 +68,18 @@ def validate_abstract_repr(
         name: The type of object to validate (can be "sequence" or "device").
     """
     obj = json.loads(obj_str)
-    validate_args = dict(instance=obj, schema=SCHEMAS[name])
-    if LEGACY_JSONSCHEMA:  # pragma: no cover
-        validate_args["resolver"] = jsonschema.validators.RefResolver(
-            base_uri=f"{SCHEMAS_PATH.resolve().as_uri()}/",
-            referrer=SCHEMAS[name],
-        )
-    else:  # pragma: no cover
-        validate_args["registry"] = REGISTRY
     try:
-        jsonschema.validate(**validate_args)
+        if LEGACY_JSONSCHEMA:  # pragma: no cover
+            jsonschema.validate(
+                instance=obj,
+                schema=SCHEMAS[name],
+                resolver=jsonschema.validators.RefResolver(  # type: ignore[attr-defined] # noqa: E501
+                    base_uri=f"{SCHEMAS_PATH.resolve().as_uri()}/",
+                    referrer=SCHEMAS[name],
+                ),
+            )
+        else:
+            _VALIDATORS[name].validate(obj)
     except Exception as exc:
         try:
             ser_pulser_version = Version(obj.get("pulser_version", "0.0.0"))

--- a/pulser-core/pulser/json/abstract_repr/validation.py
+++ b/pulser-core/pulser/json/abstract_repr/validation.py
@@ -73,7 +73,7 @@ def validate_abstract_repr(
             jsonschema.validate(
                 instance=obj,
                 schema=SCHEMAS[name],
-                resolver=jsonschema.validators.RefResolver(  # type: ignore[attr-defined] # noqa: E501
+                resolver=jsonschema.validators.RefResolver(
                     base_uri=f"{SCHEMAS_PATH.resolve().as_uri()}/",
                     referrer=SCHEMAS[name],
                 ),

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -2894,7 +2894,9 @@ class TestDeserialization:
         extra_params = {}
         if patch_jsonschema:
             std_error = jsonschema.exceptions.ValidationError
-            with patch("jsonschema.validate"):
+            with patch(
+                "pulser.json.abstract_repr.deserializer.validate_abstract_repr"
+            ):
                 with pytest.raises(AbstractReprError, match=msg):
                     Sequence.from_abstract_repr(json.dumps(s))
         else:
@@ -2932,7 +2934,9 @@ class TestDeserialization:
             AbstractReprError,
             match="The object does not encode a known waveform.",
         ):
-            with patch("jsonschema.validate"):
+            with patch(
+                "pulser.json.abstract_repr.deserializer.validate_abstract_repr"
+            ):
                 Sequence.from_abstract_repr(json.dumps(s))
 
     def test_legacy_device(self):


### PR DESCRIPTION
Following this [investigation](https://www.notion.so/pasqal/Investigate-Pulser-deserialize-perfs-33337dbda0b1802d9f55c7edf2f1ba17), pre-loading Draft7Validator instances cuts validation time by 20–55% on real workloads.

Steps done by `jsonschema.validate`:
1. Detect draft (read $schema from the schema).
2. Instantiate a Draft7Validator.
3. Run the meta-schema check — validate the Pulser schema itself against the Draft 7 meta-schema.
4. Resolve external $refs through the Registry.
5. Validate the input payload against the schema.

With preload, we do steps 1-4 only once at import and `validate_abstract_repr` only does step 5.