### PR TITLE
[FEAT] Add fastjsonschema as optional fast-path for JSON validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
             numpy: "numpy-v1"
           - numpy: "numpy-v1"
             with-torch: "no-torch"
+          # Only test fast-validation on no-torch jobs to limit matrix size
+          - with-torch: "with-torch"
+            fast-validation: "with-fast-validation"
     steps:
       - name: Check out Pulser
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,10 @@ jobs:
       - name: Run the unit tests without torch installed
         if: ${{ matrix.with-torch != 'with-torch'}}
         run: pytest --cov
+      - name: Test validation with fast-validation extra
+        run: |
+          pip install -e ./pulser-core[fast-validation]
+          pytest tests/test_abstract_repr.py
       - name: Test validation with legacy jsonschema
         if: ${{ matrix.python-version != '3.14'}}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,12 @@ jobs:
         python-version: ["3.10", "3.14"]
         with-torch: ["with-torch", "no-torch"]
         numpy: ["numpy-v1", "numpy-v2"]
+        fast-validation: ["with-fast-validation", "no-fast-validation"]
         include:
           - python-version: "3.12"
             with-torch: "with-torch"
             numpy: "numpy-v1"
+            fast-validation: "no-fast-validation"
         exclude:
           # Numpy v1 does not support Python 3.14
           - python-version: "3.14"
@@ -92,16 +94,13 @@ jobs:
           extra-packages: pytest
           with-torch: ${{ matrix.with-torch }}
           numpy: ${{ matrix.numpy }}
+          with-fast-validation: ${{ matrix.fast-validation }}
       - name: Run the unit tests & generate coverage report
         if: ${{ matrix.with-torch == 'with-torch'}}
         run: pytest --cov --cov-fail-under=100
       - name: Run the unit tests without torch installed
         if: ${{ matrix.with-torch != 'with-torch'}}
         run: pytest --cov
-      - name: Test validation with fast-validation extra
-        run: |
-          pip install -e ./pulser-core[fast-validation]
-          pytest tests/test_abstract_repr.py
       - name: Test validation with legacy jsonschema
         if: ${{ matrix.python-version != '3.14'}}
         run: |

--- a/.github/workflows/pulser-setup/action.yml
+++ b/.github/workflows/pulser-setup/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: Which version of numpy to install
     required: false
     default: "numpy-v2"
+  with-fast-validation:
+    description: Whether to include fastjsonschema
+    required: false
+    default: "no-fast-validation"
 runs:
   using: "composite"
   steps:
@@ -47,6 +51,11 @@ runs:
       shell: bash
       run: |
         pip install numpy>=2
+    - name: Install fast-validation extra
+      if: ${{ inputs.with-fast-validation == 'with-fast-validation' }}
+      shell: bash
+      run: |
+        make dev-install-fast-validation
     - name: Install extra packages from the dev requirements
       if: "${{ inputs.extra-packages != '' }}"
       shell: bash

--- a/.github/workflows/pulser-setup/action.yml
+++ b/.github/workflows/pulser-setup/action.yml
@@ -55,7 +55,7 @@ runs:
       if: ${{ inputs.with-fast-validation == 'with-fast-validation' }}
       shell: bash
       run: |
-        make dev-install-fast-validation
+        make dev-install-core-fast-validation
     - name: Install extra packages from the dev requirements
       if: "${{ inputs.extra-packages != '' }}"
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         numpy: ["numpy-v1", "numpy-v2"]
         with-torch: ["with-torch", "no-torch"]
+        fast-validation: ["with-fast-validation", "no-fast-validation"]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
           # Numpy v1 does not support Python 3.13
@@ -40,5 +41,6 @@ jobs:
           extra-packages: pytest
           numpy: ${{ matrix.numpy }}
           with-torch: ${{ matrix.with-torch }}
+          with-fast-validation: ${{ matrix.fast-validation }}
       - name: Run the unit tests & generate coverage report
         run: pytest --cov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,13 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         numpy: ["numpy-v1", "numpy-v2"]
         with-torch: ["with-torch", "no-torch"]
-        fast-validation: ["with-fast-validation", "no-fast-validation"]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.12"
+            numpy: "numpy-v2"
+            with-torch: "no-torch"
+            fast-validation: "with-fast-validation"
         exclude:
           # Numpy v1 does not support Python 3.13
           - python-version: "3.13"

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -10,7 +10,7 @@ warn_unused_ignores = True
 disallow_untyped_defs = True
 
 # 3rd-party libs without type hints nor stubs
-[mypy-scipy.*,qutip.*,jsonschema.*,py.*,mpl_toolkits.*]
+[mypy-scipy.*,qutip.*,jsonschema.*,fastjsonschema.*,py.*,mpl_toolkits.*]
 follow_imports = silent
 ignore_missing_imports = True
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ dev-install-core:
 dev-install-core-no-torch:
 	pip install -e ./pulser-core
 
+.PHONY: dev-install-fast-validation
+dev-install-fast-validation:
+	pip install -e ./pulser-core[fast-validation]
+
 .PHONY: dev-install-simulation
 dev-install-simulation:
 	pip install -e ./pulser-simulation

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ dev-install-core:
 dev-install-core-no-torch:
 	pip install -e ./pulser-core
 
-.PHONY: dev-install-fast-validation
-dev-install-fast-validation:
+.PHONY: dev-install-core-fast-validation
+dev-install-core-fast-validation:
 	pip install -e ./pulser-core[fast-validation]
 
 .PHONY: dev-install-simulation

--- a/pulser-core/pulser/json/abstract_repr/__init__.py
+++ b/pulser-core/pulser/json/abstract_repr/__init__.py
@@ -14,19 +14,14 @@
 """Serialization and deserialization tools for the abstract representation."""
 import json
 from pathlib import Path
+from typing import Any, get_args
+
+from pulser.json.utils import ObjectType, get_filename
 
 SCHEMAS_PATH = Path(__file__).parent / "schemas"
-SCHEMAS = {}
-for obj_type in (
-    "device",
-    "sequence",
-    "register",
-    "layout",
-    "noise",
-    "results",
-    "config",
-):
+SCHEMAS: dict[ObjectType, Any] = {}
+for obj_type in get_args(ObjectType):
     with open(
-        SCHEMAS_PATH / f"{obj_type}-schema.json", "r", encoding="utf-8"
+        SCHEMAS_PATH / get_filename(obj_type), "r", encoding="utf-8"
     ) as f:
         SCHEMAS[obj_type] = json.load(f)

--- a/pulser-core/pulser/json/abstract_repr/validation.py
+++ b/pulser-core/pulser/json/abstract_repr/validation.py
@@ -37,13 +37,15 @@ LEGACY_JSONSCHEMA = (
 )
 
 
+# Maps schema filenames to their contents, used as a handler for
+# fastjsonschema's local $ref resolution (the "" URI scheme).
 _SCHEMAS_BY_FILENAME = {
     get_filename(name): schema for name, schema in SCHEMAS.items()
 }
 
 _FAST_VALIDATORS: dict[str, Callable[[Any], Any]] = (
     {
-        name: fastjsonschema.compile(  # type: ignore[misc]
+        name: fastjsonschema.compile(
             schema, handlers={"": _SCHEMAS_BY_FILENAME.__getitem__}
         )
         for name, schema in SCHEMAS.items()
@@ -52,15 +54,11 @@ _FAST_VALIDATORS: dict[str, Callable[[Any], Any]] = (
     else {}
 )
 
+_REGISTRY_NAMES: list[ObjectType] = ["device", "layout", "register", "noise"]
 REGISTRY: Registry = Registry(
     [
         (get_filename(name), Resource.from_contents(SCHEMAS[name]))
-        for name in (
-            "device",
-            "layout",
-            "register",
-            "noise",
-        )
+        for name in _REGISTRY_NAMES
     ]
 )
 
@@ -105,8 +103,8 @@ def validate_abstract_repr(
                 # validation with fast library
                 _FAST_VALIDATORS[name](obj)
             except fastjsonschema.JsonSchemaException:
-                # in case of validation failure, we run validation with jsonschema
-                # to have descriptive error reasons
+                # fastjsonschema errors lack detail
+                # fall back to jsonschema for better diagnostics
                 _validate_with_jsonschema(obj, name)
         else:
             _validate_with_jsonschema(obj, name)

--- a/pulser-core/pulser/json/abstract_repr/validation.py
+++ b/pulser-core/pulser/json/abstract_repr/validation.py
@@ -27,7 +27,7 @@ from pulser.json.abstract_repr import SCHEMAS, SCHEMAS_PATH
 from pulser.json.utils import ObjectType, get_filename
 
 try:
-    import fastjsonschema  # type: ignore[import-untyped]
+    import fastjsonschema
 except ImportError:  # pragma: no cover
     fastjsonschema = None
 

--- a/pulser-core/pulser/json/abstract_repr/validation.py
+++ b/pulser-core/pulser/json/abstract_repr/validation.py
@@ -14,31 +14,56 @@
 """Function for validation of JSON serialization to abstract representation."""
 import json
 from importlib.metadata import version
-from typing import Literal
+from typing import Any, Callable
 
 import jsonschema
+import jsonschema.validators
 from packaging.version import InvalidVersion, Version
 from referencing import Registry, Resource
 
 import pulser
 from pulser.exceptions.serialization import AbstractReprError
 from pulser.json.abstract_repr import SCHEMAS, SCHEMAS_PATH
+from pulser.json.utils import ObjectType, get_filename
+
+try:
+    import fastjsonschema  # type: ignore[import-untyped]
+except ImportError:  # pragma: no cover
+    fastjsonschema = None
+
 
 LEGACY_JSONSCHEMA = (
     Version("4.18") > Version(version("jsonschema")) >= Version("4.17.3")
 )
 
+
+_SCHEMAS_BY_FILENAME = {
+    get_filename(name): schema for name, schema in SCHEMAS.items()
+}
+
+_FAST_VALIDATORS: dict[str, Callable[[Any], Any]] = (
+    {
+        name: fastjsonschema.compile(  # type: ignore[misc]
+            schema, handlers={"": _SCHEMAS_BY_FILENAME.__getitem__}
+        )
+        for name, schema in SCHEMAS.items()
+    }
+    if fastjsonschema is not None
+    else {}
+)
+
 REGISTRY: Registry = Registry(
     [
-        ("device-schema.json", Resource.from_contents(SCHEMAS["device"])),
-        ("layout-schema.json", Resource.from_contents(SCHEMAS["layout"])),
-        ("register-schema.json", Resource.from_contents(SCHEMAS["register"])),
-        ("noise-schema.json", Resource.from_contents(SCHEMAS["noise"])),
+        (get_filename(name), Resource.from_contents(SCHEMAS[name]))
+        for name in (
+            "device",
+            "layout",
+            "register",
+            "noise",
+        )
     ]
 )
 
-# Build one validator per schema at import time so that meta-schema
-# checking and $ref resolution are paid once, not on every call.
 _VALIDATORS: dict[str, jsonschema.Draft7Validator] = (
     {}
     if LEGACY_JSONSCHEMA
@@ -49,37 +74,42 @@ _VALIDATORS: dict[str, jsonschema.Draft7Validator] = (
 )
 
 
+def _validate_with_jsonschema(obj: Any, object_type: ObjectType) -> None:
+    if LEGACY_JSONSCHEMA:  # pragma: no cover
+        jsonschema.validate(
+            instance=obj,
+            schema=SCHEMAS[object_type],
+            resolver=jsonschema.validators.RefResolver(
+                base_uri=f"{SCHEMAS_PATH.resolve().as_uri()}/",
+                referrer=SCHEMAS[object_type],
+            ),
+        )
+    else:
+        _VALIDATORS[object_type].validate(obj)
+
+
 def validate_abstract_repr(
     obj_str: str,
-    name: Literal[
-        "sequence",
-        "device",
-        "layout",
-        "register",
-        "noise",
-        "results",
-        "config",
-    ],
+    name: ObjectType,
 ) -> None:
     """Validate the abstract representation of an object.
 
     Args:
         obj_str: A JSON-formatted string encoding the object.
-        name: The type of object to validate (can be "sequence" or "device").
+        name: The type of object to validate.
     """
     obj = json.loads(obj_str)
     try:
-        if LEGACY_JSONSCHEMA:  # pragma: no cover
-            jsonschema.validate(
-                instance=obj,
-                schema=SCHEMAS[name],
-                resolver=jsonschema.validators.RefResolver(
-                    base_uri=f"{SCHEMAS_PATH.resolve().as_uri()}/",
-                    referrer=SCHEMAS[name],
-                ),
-            )
+        if fastjsonschema is not None:
+            try:
+                # validation with fast library
+                _FAST_VALIDATORS[name](obj)
+            except fastjsonschema.JsonSchemaException:
+                # in case of validation failure, we run validation with jsonschema
+                # to have descriptive error reasons
+                _validate_with_jsonschema(obj, name)
         else:
-            _VALIDATORS[name].validate(obj)
+            _validate_with_jsonschema(obj, name)
     except Exception as exc:
         try:
             ser_pulser_version = Version(obj.get("pulser_version", "0.0.0"))

--- a/pulser-core/pulser/json/abstract_repr/validation.py
+++ b/pulser-core/pulser/json/abstract_repr/validation.py
@@ -54,7 +54,13 @@ _FAST_VALIDATORS: dict[str, Callable[[Any], Any]] = (
     else {}
 )
 
-_REGISTRY_NAMES: list[ObjectType] = ["device", "layout", "register", "noise"]
+_REGISTRY_NAMES: list[ObjectType] = [
+    "device",
+    "layout",
+    "register",
+    "noise",
+    "sequence",
+]
 REGISTRY: Registry = Registry(
     [
         (get_filename(name), Resource.from_contents(SCHEMAS[name]))
@@ -98,13 +104,10 @@ def validate_abstract_repr(
     """
     obj = json.loads(obj_str)
     try:
-        if fastjsonschema is not None:
+        if fastjsonschema is not None:  # pragma: no cover
             try:
-                # validation with fast library
                 _FAST_VALIDATORS[name](obj)
             except fastjsonschema.JsonSchemaException:
-                # fastjsonschema errors lack detail
-                # fall back to jsonschema for better diagnostics
                 _validate_with_jsonschema(obj, name)
         else:
             _validate_with_jsonschema(obj, name)

--- a/pulser-core/pulser/json/utils.py
+++ b/pulser-core/pulser/json/utils.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import json
 import warnings
 from dataclasses import MISSING, Field
-from typing import TYPE_CHECKING, Any, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence
 
 import numpy as np
 
@@ -116,3 +116,18 @@ def stringify_qubit_ids(qubit_ids: Sequence[QubitId]) -> list[str]:
                 f"strings for IDs: {[(id, str(id)) for id in collisions]}"
             )
     return names
+
+
+ObjectType = Literal[
+    "sequence",
+    "device",
+    "layout",
+    "register",
+    "noise",
+    "results",
+    "config",
+]
+
+
+def get_filename(object_type: ObjectType) -> str:
+    return f"{object_type}-schema.json"

--- a/pulser-core/pulser/json/utils.py
+++ b/pulser-core/pulser/json/utils.py
@@ -130,4 +130,5 @@ ObjectType = Literal[
 
 
 def get_filename(object_type: ObjectType) -> str:
+    """Return the schema filename for a given object type."""
     return f"{object_type}-schema.json"

--- a/pulser-core/setup.py
+++ b/pulser-core/setup.py
@@ -45,7 +45,10 @@ setup(
     name=distribution_name,
     version=__version__,
     install_requires=requirements,
-    extras_require={"torch": ["torch ~= 2.6"]},
+    extras_require={
+        "torch": ["torch ~= 2.6"],
+        "fast-validation": ["fastjsonschema ~= 2.21"],
+    },
     packages=find_packages(),
     package_data={package_name: ["py.typed"]},
     include_package_data=True,


### PR DESCRIPTION
Add a new optional library to validate input data. Summary of changes:
- Introduces `fastjsonschema` as an optional dependency (`pulser-core[fast-validation]`) to speed up JSON schema validation of abstract representations
- When installed, validators are compiled at import time and used as the primary validation path; on failure, falls back to the standard `jsonschema` library to provide detailed error diagnostics
- Refactors shared constants (`ObjectType` literal type, `get_filename` helper) into `pulser/json/utils.py` to reduce duplication across `__init__.py` and `validation.py`
- Updates CI matrix (`ci.yml`, `test.yml`) to test both with and without `fastjsonschema` installed