### PR TITLE
fix: clarify emulation config type errors

### DIFF
--- a/pulser-core/pulser/backend/config.py
+++ b/pulser-core/pulser/backend/config.py
@@ -260,22 +260,25 @@ class EmulationConfig(BackendConfig, Generic[StateType]):
                 " empty.",
                 stacklevel=2,
             )
-        for cb in callbacks:
+        for i, cb in enumerate(callbacks):
             if isinstance(cb, Observable):
                 raise TypeError(
                     "All entries in 'callbacks' must not be instances of "
-                    "Observable, since those go in 'observables'."
+                    "Observable, since those go in 'observables'. "
+                    f"Instead, got {cb!r} at index {i}."
                 )
             if not isinstance(cb, Callback):
                 raise TypeError(
                     "All entries in 'callbacks' must be instances of "
-                    f"Callback. Instead, got instance of type {type(cb)}."
+                    "Callback. Instead, got instance of type "
+                    f"{type(cb)} at index {i}: {cb!r}."
                 )
-        for obs in observables:
+        for i, obs in enumerate(observables):
             if not isinstance(obs, Observable):
                 raise TypeError(
                     "All entries in 'observables' must be instances of "
-                    f"Observable. Instead, got instance of type {type(obs)}."
+                    "Observable. Instead, got instance of type "
+                    f"{type(obs)} at index {i}: {obs!r}."
                 )
             obs_tags.append(obs.tag)
         repeated_tags = [k for k, v in Counter(obs_tags).items() if v > 1]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -571,12 +571,18 @@ def test_emulation_config():
 
     with pytest.raises(
         TypeError,
-        match="All entries in 'observables' must be instances of Observable",
+        match=(
+            "All entries in 'observables' must be instances of Observable"
+            ".*at index 0.*fidelity"
+        ),
     ):
         EmulationConfig(observables=["fidelity"])
     with pytest.raises(
         TypeError,
-        match="All entries in 'callbacks' must not be instances of Observable",
+        match=(
+            "All entries in 'callbacks' must not be instances of Observable"
+            ".*at index 0"
+        ),
     ):
         EmulationConfig(
             callbacks=(BitStrings(),),
@@ -584,7 +590,10 @@ def test_emulation_config():
         )
     with pytest.raises(
         TypeError,
-        match="All entries in 'callbacks' must be instances of Callback",
+        match=(
+            "All entries in 'callbacks' must be instances of Callback"
+            ".*at index 0.*Hello"
+        ),
     ):
         EmulationConfig(
             callbacks=("Hello",),


### PR DESCRIPTION
Closes #1025.

This improves the `EmulationConfig` validation errors for invalid `callbacks` and `observables` entries. The previous errors only reported the failing type, which made it harder to find the bad value in a longer list.

The new messages include the failing index and `repr()` of the value while keeping the existing error prefixes intact. I also tightened the existing tests so they cover the added context for invalid observables, callbacks that are observables, and non-callback callback entries.

Verification:
- `python3 -m compileall -q pulser-core/pulser/backend/config.py tests/test_backend.py`
- `git diff --check`

I could not run the focused pytest locally because this environment is missing optional test/runtime dependencies (`evalcraft`, then `scipy` when disabling that plugin).
