### PR TITLE
Add Rydberg interaction in XY mode

### DIFF
--- a/pulser-core/pulser/_hamiltonian_data/hamiltonian_data.py
+++ b/pulser-core/pulser/_hamiltonian_data/hamiltonian_data.py
@@ -568,7 +568,12 @@ class HamiltonianData:
 
         Returns:
             The pairwise interaction coefficients, taking into account
-            Device specs and the Sequence type.
+            Device specs and the Sequence type. In XY mode,
+            it has shape (2, N, N), with N the number of qubits.
+            The first array of shape (N, N) is the C3 interaction,
+            the second the C6 interaction.
+            In Rydberg interaction, it has shape (1, N, N)
+            and corresponds to the C6 interaction only.
         """
         # SLM mask is not included, because it's time-dependent
         is_xy = self.basis_data.interaction_type == "XY"
@@ -624,6 +629,7 @@ class HamiltonianData:
         Returns:
             The pairwise interaction coefficients, taking into account
             Device specs, the Sequence type and missing atoms.
+            See the docstring for HamiltonianData._interaction_matrix.
         """
         mask = [False for _ in range(self.n_qudits)]
         for ind, value in enumerate(bad_atoms.values()):

--- a/pulser-core/pulser/_hamiltonian_data/hamiltonian_data.py
+++ b/pulser-core/pulser/_hamiltonian_data/hamiltonian_data.py
@@ -571,9 +571,11 @@ class HamiltonianData:
             Device specs and the Sequence type.
         """
         # SLM mask is not included, because it's time-dependent
+        is_xy = self.basis_data.interaction_type == "XY"
         d = _distances(register)
-        interactions = pm.zeros_like(d)._array
-        if self.basis_data.interaction_type == "XY":
+        interactions = pm.zeros_like(d.reshape((1,) + d.shape))._array
+        if is_xy:
+            interactions = pm.vstack([interactions, interactions])._array
             positions = list(register.qubits.values())
             assert self.samples._magnetic_field is not None
             assert self._device.interaction_coeff_xy is not None
@@ -588,17 +590,18 @@ class HamiltonianData:
                             [diff, pm.AbstractArray(np.array(0.0))]
                         )
                     cosine = pm.dot(diff, mag_arr) / (pm.norm(diff) * mag_norm)
-                    interactions[[i, j], [j, i]] = (
+                    interactions[[0, 0], [i, j], [j, i]] = (
                         self._device.interaction_coeff_xy  # type: ignore
                         * (1 - 3 * cosine._array**2)
                         / d._array[i, j] ** 3
                     )
-        else:
-            for i in range(self.n_qudits):
-                for j in range(i + 1, self.n_qudits):
-                    interactions[[i, j], [j, i]] = (
-                        self._device.interaction_coeff / d._array[i, j] ** 6
-                    )
+
+        for i in range(self.n_qudits):
+            for j in range(i + 1, self.n_qudits):
+                interactions[[-1, -1], [i, j], [j, i]] = (
+                    self._device.interaction_coeff / d._array[i, j] ** 6
+                )
+
         return interactions
 
     @property
@@ -630,13 +633,13 @@ class HamiltonianData:
             arr = np.array(mask)
             mask2 = arr.reshape(1, -1) | arr.reshape(-1, 1)
             mat = imat.copy()
-            mat[mask2] = 0.0
+            mat[:, mask2] = 0.0
             return pm.AbstractArray(mat)
         else:
             ten = pm.torch.tensor(mask, dtype=pm.torch.bool)
             mask3 = ten.reshape(1, -1) | ten.reshape(-1, 1)
             mat2 = imat.clone()
-            mat2[mask3] = 0.0
+            mat2[:, mask3] = 0.0
             return pm.AbstractArray(mat2)
 
     def _build_local_collapse_operators(

--- a/pulser-core/pulser/_hamiltonian_data/noise_trajectory.py
+++ b/pulser-core/pulser/_hamiltonian_data/noise_trajectory.py
@@ -25,7 +25,29 @@ ChannelName = str
 
 @dataclass(frozen=True)
 class NoiseTrajectory:
-    """Defines a noise trajectory."""
+    """Defines a noise trajectory.
+
+    Args:
+        bad_atoms: Whether each atom is present or bad.
+            False means it's present, True means it's bad.
+        doppler_detune: The time-independent doppler detuning error per qubit.
+        amp_fluctuations:
+            The time-independent amplitude fluctuation per channel.
+        det_fluctuations:
+            The time-independent detuning fluctuation per non-DMM channel.
+        det_phases:
+            The random phase for each frequency component in the
+            time-dependent detuning noise. The amplitude for each component
+            is taken from the noise model and is non-random.
+        register: The qubit register positions including noise.
+        interaction_matrix:
+            Packed interaction matrix for the two body term in the
+            Hamiltonian. Should be of shape (2,N,N) for XY,
+            encoding the C3 and C6 term in that order.
+            Should be of shape (1,N,N) otherwise.
+        dmm_det_fluctuation:
+            The time-independent detuning fluctuations per DMM channel.
+    """
 
     bad_atoms: dict[QubitId, bool]
     doppler_detune: dict[QubitId, float]

--- a/pulser-core/pulser/backend/config.py
+++ b/pulser-core/pulser/backend/config.py
@@ -182,11 +182,13 @@ class EmulationConfig(BackendConfig, Generic[StateType]):
             input or the expected output.
         interaction_matrix: An optional interaction matrix to replace the
             interaction terms in the Hamiltonian. For an N-qudit system,
-            must be an NxN symmetric matrix where entry (i, j) dictates
-            the interaction coefficient between qudits i and j, ie it replaces
-            the C_n/r_{ij}^n term. For XY, since there are two interactions
-            the input should be a tensor of shape (2,N,N), respresenting the
+            an interaction matrix is an NxN symmetric matrix,
+            where entry (i, j) dictates the interaction coefficient between
+            qudits i and j, ie it replaces the C_n/r_{ij}^n term.
+            In XY, there are the two interactions C3 and C6 so
+            the input should be a tensor of shape (2,N,N), representing the
             interaction matrix for the XY and the Rydberg term in that order.
+            Otherwise the input should be a tensor of shape (N, N) or (1,N,N).
         prefer_device_noise_model: If True, uses the noise model of the
             sequence's device (if the sequence's device has one), regardless
             of the noise model given with this configuration.

--- a/pulser-core/pulser/backend/config.py
+++ b/pulser-core/pulser/backend/config.py
@@ -184,7 +184,9 @@ class EmulationConfig(BackendConfig, Generic[StateType]):
             interaction terms in the Hamiltonian. For an N-qudit system,
             must be an NxN symmetric matrix where entry (i, j) dictates
             the interaction coefficient between qudits i and j, ie it replaces
-            the C_n/r_{ij}^n term.
+            the C_n/r_{ij}^n term. For XY, since there are two interactions
+            the input should be a tensor of shape (2,N,N), respresenting the
+            interaction matrix for the XY and the Rydberg term in that order.
         prefer_device_noise_model: If True, uses the noise model of the
             sequence's device (if the sequence's device has one), regardless
             of the noise model given with this configuration.
@@ -305,9 +307,12 @@ class EmulationConfig(BackendConfig, Generic[StateType]):
         if interaction_matrix is not None:
             interaction_matrix = pm.AbstractArray(interaction_matrix)
             _shape = interaction_matrix.shape
-            if len(_shape) != 2 or _shape[0] != _shape[1]:
+            if not (len(_shape) == 2 and _shape[0] == _shape[1]) and not (
+                len(_shape) == 3 and _shape[0] <= 2 and _shape[1] == _shape[2]
+            ):
                 raise ValueError(
-                    "'interaction_matrix' must be a square matrix. Instead, "
+                    "'interaction_matrix' must be of shape "
+                    "(N,N) or (1,N,N), or (2,N,N) for XY. Instead, "
                     f"an array of shape {_shape} was given."
                 )
             if (

--- a/pulser-core/pulser/backend/config.py
+++ b/pulser-core/pulser/backend/config.py
@@ -320,19 +320,23 @@ class EmulationConfig(BackendConfig, Generic[StateType]):
                 )
             if (
                 initial_state is not None
-                and _shape[0] != initial_state.n_qudits
+                and _shape[-1] != initial_state.n_qudits
             ):
                 raise ValueError(
                     f"The received interaction matrix of shape {_shape} is "
                     "incompatible with the received initial state of "
                     f"{initial_state.n_qudits} qudits."
                 )
+            if len(_shape) == 2:
+                interaction_matrix = interaction_matrix.reshape((-1,) + _shape)
             matrix_arr = interaction_matrix.as_array(detach=True)
-            if not np.allclose(matrix_arr, matrix_arr.transpose()):
+            if not np.allclose(
+                matrix_arr, np.transpose(matrix_arr, (0, 2, 1))
+            ):
                 raise ValueError(
                     "The received interaction matrix is not symmetric."
                 )
-            if np.any(np.diag(matrix_arr) != 0):
+            if np.any(np.stack([np.diag(x) for x in matrix_arr]) != 0):
                 warnings.warn(
                     "The received interaction matrix has non-zero values in "
                     "its diagonal; keep in mind that these values are "

--- a/pulser-core/pulser/json/abstract_repr/schemas/config-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/config-schema.json
@@ -82,7 +82,10 @@
                         "items": {
                             "type": "array",
                             "items": {
-                                "type": "number"
+                                "type": "array",
+                                "items": {
+                                    "type": "number"
+                                }
                             }
                         }
                     }

--- a/pulser-core/pulser/math/abstract_array.py
+++ b/pulser-core/pulser/math/abstract_array.py
@@ -328,7 +328,8 @@ class AbstractArray:
         See the reshape method of torch.Tensor and numpy.array respectively.
 
         Args:
-            shape: The desired new shape. Must be compatible with the current shape.
+            shape: The desired new shape.
+                Must be compatible with the current shape.
         """
         return AbstractArray(self._array.reshape(shape))
 

--- a/pulser-core/pulser/math/abstract_array.py
+++ b/pulser-core/pulser/math/abstract_array.py
@@ -325,7 +325,7 @@ class AbstractArray:
     def reshape(self, shape: tuple[int, ...]) -> AbstractArray:
         """Returns a new AbstractArray with the new shape.
 
-        See the reshape functions in torch and numpy respectively.
+        See the reshape method of torch.Tensor and numpy.array respectively.
 
         Args:
             shape: The desired new shape. Must be compatible with the old.

--- a/pulser-core/pulser/math/abstract_array.py
+++ b/pulser-core/pulser/math/abstract_array.py
@@ -322,5 +322,15 @@ class AbstractArray:
                 " losing the computational graph information."
             ) from e
 
+    def reshape(self, shape: tuple[int, ...]) -> AbstractArray:
+        """Return a new Abstractarray with the new shape.
+
+        See the reshape functions in torch and numpy respectively.
+
+        Args:
+            shape: The desired new shape. Must be compatible with the old.
+        """
+        return AbstractArray(self._array.reshape(shape))
+
 
 AbstractArrayLike = Union[AbstractArray, ArrayLike]

--- a/pulser-core/pulser/math/abstract_array.py
+++ b/pulser-core/pulser/math/abstract_array.py
@@ -328,7 +328,7 @@ class AbstractArray:
         See the reshape method of torch.Tensor and numpy.array respectively.
 
         Args:
-            shape: The desired new shape. Must be compatible with the old.
+            shape: The desired new shape. Must be compatible with the current shape.
         """
         return AbstractArray(self._array.reshape(shape))
 

--- a/pulser-core/pulser/math/abstract_array.py
+++ b/pulser-core/pulser/math/abstract_array.py
@@ -323,7 +323,7 @@ class AbstractArray:
             ) from e
 
     def reshape(self, shape: tuple[int, ...]) -> AbstractArray:
-        """Return a new Abstractarray with the new shape.
+        """Returns a new AbstractArray with the new shape.
 
         See the reshape functions in torch and numpy respectively.
 

--- a/pulser-simulation/pulser_simulation/hamiltonian.py
+++ b/pulser-simulation/pulser_simulation/hamiltonian.py
@@ -269,7 +269,7 @@ class Hamiltonian:
                 0.5
                 * self.noise_trajectory.interaction_matrix.as_array(
                     detach=True
-                )[self._qid_index[q1], self._qid_index[q2]]
+                )[0, self._qid_index[q1], self._qid_index[q2]]
             )
             return U * self.build_operator([("sigma_rr", [q1, q2])])
 
@@ -282,7 +282,7 @@ class Hamiltonian:
             includes a 1/hbar factor.
             """
             U = self.noise_trajectory.interaction_matrix.as_array(detach=True)[
-                self._qid_index[q1], self._qid_index[q2]
+                0, self._qid_index[q1], self._qid_index[q2]
             ]
             return U * self.build_operator(
                 [("sigma_ud", [q1]), ("sigma_du", [q2])]

--- a/pulser-simulation/pulser_simulation/hamiltonian.py
+++ b/pulser-simulation/pulser_simulation/hamiltonian.py
@@ -269,7 +269,7 @@ class Hamiltonian:
                 0.5
                 * self.noise_trajectory.interaction_matrix.as_array(
                     detach=True
-                )[0, self._qid_index[q1], self._qid_index[q2]]
+                )[-1, self._qid_index[q1], self._qid_index[q2]]
             )
             return U * self.build_operator([("sigma_rr", [q1, q2])])
 

--- a/pulser-simulation/pulser_simulation/hamiltonian.py
+++ b/pulser-simulation/pulser_simulation/hamiltonian.py
@@ -290,7 +290,7 @@ class Hamiltonian:
             return U_xy * self.build_operator(
                 [("sigma_ud", [q1]), ("sigma_du", [q2])]
             ) + 0.5 * U_ryd * self.build_operator(
-                [("sigma_dd", [q1]), ("sigma_dd", [q2])]
+                [("sigma_uu", [q1]), ("sigma_uu", [q2])]
             )
 
         def make_interaction_term(masked: bool = False) -> qutip.Qobj:

--- a/pulser-simulation/pulser_simulation/hamiltonian.py
+++ b/pulser-simulation/pulser_simulation/hamiltonian.py
@@ -281,11 +281,16 @@ class Hamiltonian:
             The units are given so that the coefficient
             includes a 1/hbar factor.
             """
-            U = self.noise_trajectory.interaction_matrix.as_array(detach=True)[
-                0, self._qid_index[q1], self._qid_index[q2]
-            ]
-            return U * self.build_operator(
+            U_xy = self.noise_trajectory.interaction_matrix.as_array(
+                detach=True
+            )[0, self._qid_index[q1], self._qid_index[q2]]
+            U_ryd = self.noise_trajectory.interaction_matrix.as_array(
+                detach=True
+            )[1, self._qid_index[q1], self._qid_index[q2]]
+            return U_xy * self.build_operator(
                 [("sigma_ud", [q1]), ("sigma_du", [q2])]
+            ) + 0.5 * U_ryd * self.build_operator(
+                [("sigma_dd", [q1]), ("sigma_dd", [q2])]
             )
 
         def make_interaction_term(masked: bool = False) -> qutip.Qobj:

--- a/tests/pulser_simulation/test_simulation.py
+++ b/tests/pulser_simulation/test_simulation.py
@@ -1406,7 +1406,7 @@ def test_get_xy_hamiltonian():
 
     assert simple_ham[0, 1] == 0.5 * amp
     # The detuning on the diagonal depends on how many qubits are in |d>
-    np.testing.assert_array_equal(
+    np.testing.assert_array_almost_equal(
         np.diag(simple_ham.full()),
         np.array(
             [
@@ -1420,7 +1420,21 @@ def test_get_xy_hamiltonian():
                 3,  # ddd
             ]
         )
-        * -detun,
+        * -detun
+        + np.array(
+            [
+                0,  # uuu
+                0,  # uud
+                0,  # udu
+                1,  # udd
+                0,  # duu
+                1,  # dud
+                1 / 8,  # ddu
+                2 + 1 / 8,  # ddd
+            ]
+        )
+        * MockDevice.interaction_coeff
+        / 1e6,
     )
 
 
@@ -1460,11 +1474,10 @@ def test_run_xy():
 res_deph_mcarlo = {"0000": 830, "0001": 21, "0010": 3, "0100": 80, "1000": 66}
 res_eff_mcarlo = {
     "0000": 860,
-    "0001": 35,
-    "0010": 4,
+    "0001": 39,
+    "0010": 10,
     "0100": 25,
     "1000": 66,
-    "0011": 10,
 }
 res_leak_mcarlo = res_eff_mcarlo
 res_depol_mcarlo = res_deph_mcarlo
@@ -1490,19 +1503,17 @@ res_eff_meq = {"0000": 845, "0001": 29, "0010": 8, "0100": 57, "1000": 61}
 res_leak_meq = res_eff_meq
 res_depol_meq = {
     "0000": 791,
-    "0001": 32,
-    "0010": 14,
-    "0100": 72,
-    "0101": 12,
+    "0001": 39,
+    "0010": 10,
+    "0100": 81,
     "0110": 2,
-    "1000": 60,
-    "1010": 17,
+    "1000": 67,
+    "1010": 10,
 }
 res_deph_atom1_meq = {
-    "0000": 798,
-    "0001": 101,
-    "0010": 10,
-    "0011": 12,
+    "0000": 804,
+    "0001": 105,
+    "0010": 12,
     "0100": 54,
     "0101": 8,
     "1000": 17,

--- a/tests/pulser_simulation/test_simulation.py
+++ b/tests/pulser_simulation/test_simulation.py
@@ -1423,14 +1423,14 @@ def test_get_xy_hamiltonian():
         * -detun
         + np.array(
             [
-                0,  # uuu
-                0,  # uud
-                0,  # udu
-                1,  # udd
-                0,  # duu
-                1,  # dud
-                1 / 8,  # ddu
-                2 + 1 / 8,  # ddd
+                2 + 1 / 8,  # uuu
+                1 / 8,  # uud
+                1,  # udu
+                0,  # udd
+                1,  # duu
+                0,  # dud
+                0,  # ddu
+                0,  # ddd
             ]
         )
         * MockDevice.interaction_coeff
@@ -1473,8 +1473,8 @@ def test_run_xy():
 
 res_deph_mcarlo = {"0000": 830, "0001": 21, "0010": 3, "0100": 80, "1000": 66}
 res_eff_mcarlo = {
-    "0000": 860,
-    "0001": 39,
+    "0000": 866,
+    "0001": 33,
     "0010": 10,
     "0100": 25,
     "1000": 66,
@@ -1499,11 +1499,11 @@ res_deph_atom2_mcarlo = {
 }
 
 res_deph_meq = res_deph_mcarlo
-res_eff_meq = {"0000": 845, "0001": 29, "0010": 8, "0100": 57, "1000": 61}
+res_eff_meq = {"0000": 851, "0001": 23, "0010": 8, "0100": 57, "1000": 61}
 res_leak_meq = res_eff_meq
 res_depol_meq = {
-    "0000": 791,
-    "0001": 39,
+    "0000": 798,
+    "0001": 32,
     "0010": 10,
     "0100": 81,
     "0110": 2,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -624,7 +624,8 @@ def test_emulation_config():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "'interaction_matrix' must be a square matrix. Instead, an array"
+            "'interaction_matrix' must be of shape "
+            "(N,N) or (1,N,N), or (2,N,N) for XY. Instead, an array"
             " of shape (4, 3) was given"
         ),
     ):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -666,11 +666,30 @@ def test_emulation_config():
             observables=(BitStrings(),),
             interaction_matrix=matrix_,
         )
+    with pytest.raises(
+        ValueError,
+        match="interaction matrix is not symmetric",
+    ):
+        matrix_ = np.ones((2, 4, 4))
+        matrix_[0, 0, 3] += 1e-4
+        EmulationConfig(
+            observables=(BitStrings(),),
+            interaction_matrix=matrix_,
+        )
     with pytest.warns(UserWarning, match="non-zero values in its diagonal"):
         EmulationConfig(
             observables=(BitStrings(),),
             interaction_matrix=np.ones((4, 4)),
         )
+    with pytest.warns(UserWarning, match="non-zero values in its diagonal"):
+        EmulationConfig(
+            observables=(BitStrings(),),
+            interaction_matrix=np.ones((2, 4, 4)),
+        )
+    EmulationConfig(
+        observables=(BitStrings(),),
+        interaction_matrix=np.array([[[0, 1], [1, 0]], [[0, 2], [2, 0]]]),
+    )
     with pytest.raises(TypeError, match="must be a NoiseModel"):
         EmulationConfig(
             observables=(BitStrings(),), noise_model={"p_false_pos": 0.1}

--- a/tests/test_hamiltonian_data.py
+++ b/tests/test_hamiltonian_data.py
@@ -412,12 +412,18 @@ def test_interaction_matrix(channel_type):
             np.array([[0.0, interaction_size], [interaction_size, 0.0]]),
         )
     elif channel_type == "mw_global":
-        interaction_size = ham._device.interaction_coeff_xy / 8**3
+        interaction_size_xy = ham._device.interaction_coeff_xy / 8**3
+        interaction_size_ryd = ham._device.interaction_coeff / 8**6
         assert np.allclose(
             ham._interaction_matrix(
                 ham.noise_trajectories[0].trajectory.register
             ),
-            np.array([[0.0, interaction_size], [interaction_size, 0.0]]),
+            np.array(
+                [
+                    [[0.0, interaction_size_xy], [interaction_size_xy, 0.0]],
+                    [[0.0, interaction_size_ryd], [interaction_size_ryd, 0.0]],
+                ]
+            ),
         )
     else:
         assert False
@@ -460,7 +466,7 @@ def test_interaction_matrix_torch(channel_type):
         gr = torch.autograd.grad(
             ham._interaction_matrix(
                 ham.noise_trajectories[0].trajectory.register
-            )[0, 1],
+            )[0, 0, 1],
             q_dict["superman"],
         )
         assert torch.allclose(
@@ -471,20 +477,24 @@ def test_interaction_matrix_torch(channel_type):
             ),
         )
     elif channel_type == "mw_global":
-        interaction_size = ham._device.interaction_coeff_xy / 8**3
+        interaction_size_xy = ham._device.interaction_coeff_xy / 8**3
+        interaction_size_ryd = ham._device.interaction_coeff / 8**6
         assert torch.allclose(
             ham._interaction_matrix(
                 ham.noise_trajectories[0].trajectory.register
             ),
             torch.tensor(
-                [[0.0, interaction_size], [interaction_size, 0.0]],
+                [
+                    [[0.0, interaction_size_xy], [interaction_size_xy, 0.0]],
+                    [[0.0, interaction_size_ryd], [interaction_size_ryd, 0.0]],
+                ],
                 dtype=torch.float64,
             ),
         )
         gr = torch.autograd.grad(
             ham._interaction_matrix(
                 ham.noise_trajectories[0].trajectory.register
-            )[0, 1],
+            )[0, 0, 1],
             q_dict["superman"],
         )
         assert torch.allclose(
@@ -540,13 +550,13 @@ def test_noisy_interaction_matrix():
                 [0.0000, 26.4198, 0.0000, 0.0000],
                 [0.0000, 0.0000, 0.0000, 0.0000],
             ]
-        ),
+        ).reshape(1, 4, 4),
     )
     assert (
-        actual[1, 2]
+        actual[0, 1, 2]
         == ham._interaction_matrix(
             ham.noise_trajectories[0].trajectory.register
-        )[1, 2]
+        )[0, 1, 2]
     )
 
 
@@ -592,14 +602,14 @@ def test_noisy_interaction_matrix_torch():
                 [0.0000, 0.0000, 0.0000, 0.0000],
             ],
             dtype=torch.float64,
-        ),
+        ).reshape(1, 4, 4),
     )
 
     assert (
-        actual[1, 2]
+        actual[0, 1, 2]
         == ham._interaction_matrix(
             ham.noise_trajectories[0].trajectory.register
-        )[1, 2]
+        )[0, 1, 2]
     )
 
 


### PR DESCRIPTION
The XY mode has a Rydberg interaction between the `d` states. This MR extends the `interaction_matrix` config parameter, to allow for 2 interaction matrices as a shape `(2,N,N)` tensor in the XY case, and adds the Rydberg term.

Closes #1035 