### PR TITLE
fix: default open value for RemoteConnection.submit was wrong

### DIFF
--- a/pulser-core/pulser/backend/remote.py
+++ b/pulser-core/pulser/backend/remote.py
@@ -167,7 +167,7 @@ class RemoteConnection(ABC):
         self,
         sequence: Sequence,
         wait: bool = False,
-        open: bool = True,
+        open: bool = False,
         batch_id: str | None = None,
         **kwargs: Any,
     ) -> RemoteResults:


### PR DESCRIPTION
In c12306a40b7f570ef58bd6fdd400f101237fa86c, while pulser-pasqal was still part of Pulser repo, `open = True` was added on the interface while `PasqalCloud` implementation added `open = False`. Scaleway did the same thing.

`open = True` by default is wrong as the `RemoteConnection.submit` method is only supposed to be called by a backend and `RemoteBackend` only pass `open=True` when calling `open_batch()`. Hence there is no way to call `open=False`, which means it's the value it should have by default, which is why implementations defined `open = False`.