### PR TITLE
Refine the phase update moments in the samples

### DIFF
--- a/pulser-core/pulser/sequence/_schedule.py
+++ b/pulser-core/pulser/sequence/_schedule.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Special containers to store the schedule of operations in the Sequence."""
+
 from __future__ import annotations
 
 import warnings
@@ -190,19 +191,26 @@ class _ChannelSchedule:
                 # The phase of detuned delays is not considered
                 continue
 
-            ph_jump_t = self.channel_obj.phase_jump_time
             for last_pulse_ind in range(ind - 1, -1, -1):  # From ind-1 to 0
                 last_pulse_slot = channel_slots[last_pulse_ind]
                 # Skips over detuned delay pulses
+                last_pulse = cast(Pulse, last_pulse_slot.type)
                 if not (
                     ignore_detuned_delay_phase
-                    and self.is_detuned_delay(
-                        cast(Pulse, last_pulse_slot.type)
-                    )
+                    and self.is_detuned_delay(last_pulse)
                 ):
-                    # Accounts for when pulse is added with 'no-delay'
+                    last_pulse_tf_with_fall_time = (
+                        last_pulse_slot.tf
+                        + last_pulse.fall_time(
+                            self.channel_obj,
+                            in_eom_mode=self.in_eom_mode(
+                                time_slot=last_pulse_slot
+                            ),
+                        )
+                    )
+                    # 'min()' accounts for when pulse is added with 'no-delay'
                     # i.e. there is no phase_jump_time in between a phase jump
-                    t_start = max(s.ti - ph_jump_t, last_pulse_slot.tf)
+                    t_start = min(s.ti, last_pulse_tf_with_fall_time)
                     break
             else:
                 t_start = 0

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -3083,6 +3083,9 @@ def test_modify_eom_setpoint(
     seq.enable_eom_mode("ryd", amp, det_on)
     assert seq.is_in_eom_mode("ryd")
     seq.add_eom_pulse("ryd", dt, 0.0)
+    end_of_first_pulse = seq.build(params=[1, 0]).get_duration(
+        include_fall_time=True
+    )
     seq.delay(dt, "ryd")
 
     new_amp, new_det_on = amp + amp_diff, det_on + det_diff
@@ -3137,8 +3140,11 @@ def test_modify_eom_setpoint(
         assert final_phase == 0.0
     else:
         assert final_phase != 0.0
-    np.testing.assert_array_equal(ch_samples.phase[: 2 * dt], 0.0)
-    np.testing.assert_array_equal(ch_samples.phase[-2 * dt :], final_phase)
+    np.testing.assert_array_equal(ch_samples.phase[:end_of_first_pulse], 0.0)
+    start_of_second_pulse = -2 * dt
+    np.testing.assert_array_equal(
+        ch_samples.phase[start_of_second_pulse:], final_phase
+    )
 
 
 def test_max_duration(reg, mod_device):

--- a/tests/test_sequence_sampler.py
+++ b/tests/test_sequence_sampler.py
@@ -510,10 +510,11 @@ def test_phase_sampling(mod_device, custom_phase_jump_time):
     seq.add(Pulse.ConstantPulse(dt, 1, 0, phase=1), "ch0")
     # With 'no-delay', the jump should in between the two pulses
     seq.add(Pulse.ConstantPulse(dt, 1, 0, phase=2), "ch0", protocol="no-delay")
+    pulse2_end_with_fall = seq.get_duration(include_fall_time=True)
     # With the standard protocol, there shoud be a delay added and then
     # phase jump time is accounted for
     seq.add(Pulse.ConstantPulse(dt, 1, 0, phase=3), "ch0")
-    pulse3_start = seq.get_duration() - dt
+    pulse3_end_with_fall = seq.get_duration(include_fall_time=True)
     # Detuned delay (its phase should be ignored)
     seq.add(
         Pulse.ConstantPulse(1000, 0, 1, phase=0), "ch0", protocol="no-delay"
@@ -532,11 +533,11 @@ def test_phase_sampling(mod_device, custom_phase_jump_time):
         assert ph_jump_time > 0
     expected_phase = np.zeros(full_duration)
     expected_phase[:dt] = 1.0
-    transition2_3 = pulse3_start - ph_jump_time
+    transition2_3 = pulse2_end_with_fall
     assert transition2_3 >= 2 * dt  # = End of pulse2
     expected_phase[dt:transition2_3] = 2.0
     # The detuned delay is ignored
-    transition3_4 = full_duration - dt - ph_jump_time
+    transition3_4 = pulse3_end_with_fall
     expected_phase[transition2_3:transition3_4] = 3.0
     expected_phase[transition3_4:] = 4.0
 


### PR DESCRIPTION
Although these are **inconsequential to the results**, the current representation of the moment a phase jump occurs is not an accurate depiction of what happens on the hardware.

Currently, the phase jump moment is displayed as being "as late as possible" (i.e. `phase_jump_time` before the beginning of the next pulse):

<img width="1692" height="457" alt="image" src="https://github.com/user-attachments/assets/2b52fb91-435b-4731-a9f0-4de49e0548ce" />

In reality, the phase jumps actually occur "as _early_ as possible" (i.e. as soon as the previous pulse is fully ramped down):

<img width="1692" height="457" alt="image" src="https://github.com/user-attachments/assets/cbd263c6-2319-4619-a32b-16e1ee0b53ed" />


This PR introduces the necessary changes to go from Picture 1 to Picture 2.

I'm keeping this as a draft for now because it has downstream consequences in dependant packages. We should only merge once we have thoroughly checked them all.