### PR TITLE
Relax requirement of non-zero weights in WeightMap to a warning

### DIFF
--- a/pulser-core/pulser/channels/dmm.py
+++ b/pulser-core/pulser/channels/dmm.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Defines the detuning map modulator."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field, fields
@@ -191,15 +192,15 @@ class DMM(Channel):
                 "To respect this constraint, keep the detuning above "
                 f"{self.total_bottom_detuning/sum_weight} rad/µs."
             )
-        avg_abs_detuning = np.average(np.abs(round_detuning))
 
         weights_arr = np.array(detuning_map.weights)
         non_zero_weight_inds = np.nonzero(weights_arr)
-        # Can't be empty because the WeightMap enforces having at least one
-        # non-zero weight
-        assert (
-            len(non_zero_weight_inds) == 1 and len(non_zero_weight_inds[0]) > 0
-        )
+        assert len(non_zero_weight_inds) == 1, "Weights array is not 1D"
+        if len(non_zero_weight_inds[0]) == 0:
+            # All weights are zero, skip min_avg_abs_detuning validation
+            return
+
+        avg_abs_detuning = np.average(np.abs(round_detuning))
         min_non_zero_weight = np.min(weights_arr[non_zero_weight_inds])
         if (
             0

--- a/pulser-core/pulser/json/abstract_repr/validation.py
+++ b/pulser-core/pulser/json/abstract_repr/validation.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Function for validation of JSON serialization to abstract representation."""
+
 import json
 from importlib.metadata import version
 from typing import Any, Callable
@@ -109,7 +110,7 @@ def validate_abstract_repr(
                 _FAST_VALIDATORS[name](obj)
             except fastjsonschema.JsonSchemaException:
                 _validate_with_jsonschema(obj, name)
-        else:
+        else:  # pragma: no cover
             _validate_with_jsonschema(obj, name)
     except Exception as exc:
         try:

--- a/pulser-core/pulser/register/weight_maps.py
+++ b/pulser-core/pulser/register/weight_maps.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import hashlib
 import typing
+import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Mapping, Optional, TypeVar, cast
 
@@ -67,8 +68,9 @@ class WeightMap(Traps, RegDrawer):
         ):
             raise ValueError("All weights must be between 0 and 1.")
         if np.count_nonzero(weights) == 0:
-            raise ValueError(
-                "A WeightMap must have at least one non-zero weight."
+            warnings.warn(
+                "A WeightMap should have at least one non-zero weight.",
+                stacklevel=3,
             )
         object.__setattr__(self, "weights", tuple(weights))
 

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -219,8 +219,8 @@ class TestDetuningMap:
                 ValueError, match="All weights must be between 0 and 1."
             ):
                 reg.define_detuning_map(bad_weights)  # type: ignore
-            with pytest.raises(
-                ValueError, match="must have at least one non-zero weight"
+            with pytest.warns(
+                UserWarning, match="should have at least one non-zero weight"
             ):
                 reg.define_detuning_map(zero_weights)  # type: ignore
 
@@ -297,7 +297,7 @@ class TestDetuningMap:
         og_coords = det_map.trap_coordinates
         expected_coords = og_coords + np.array(offset)
         new_det_map = det_map.with_pos_offset(*offset)
-        # Original det map is unchaged
+        # Original det map is unchanged
         np.testing.assert_equal(det_map.trap_coordinates, og_coords)
         assert det_map != new_det_map
         assert new_det_map == DetuningMap(
@@ -454,3 +454,12 @@ class TestDMM:
             ),
         ):
             physical_dmm.validate_pulse(too_low_pulse, det_map)
+
+        # If all weights are zero, validation doesn't fail
+        with pytest.warns(
+            UserWarning, match="should have at least one non-zero weight"
+        ):
+            det_map = TriangularLatticeLayout(100, 10).define_detuning_map(
+                {0: 0.0}
+            )
+        physical_dmm.validate_pulse(too_low_pulse, det_map)


### PR DESCRIPTION
This requirement that at least one weight must be non-zero in a `WeightMap` was introduced in 1.8 and was unecessarily strict. A user requested it to be relaxed to a warning, so here it is