### PR TITLE
Deprecate QutipEmulator.run() and add QutipBackendV2.run_from_sequence_samples()

### DIFF
--- a/pulser-simulation/pulser_simulation/qutip_backend.py
+++ b/pulser-simulation/pulser_simulation/qutip_backend.py
@@ -147,18 +147,16 @@ class QutipBackendV2(EmulatorBackend):
     ) -> None:
         """Initializes the backend."""
         super().__init__(sequence, config=config, mimic_qpu=mimic_qpu)
-        noise_model: None | NoiseModel = None
-        if self._config.prefer_device_noise_model:
-            noise_model = sequence.device.noise_model
-        noise_model = noise_model or self._config.noise_model
+
         self._sim_obj = QutipEmulator.from_sequence(
             sequence,
             sampling_rate=self._config.sampling_rate,
-            noise_model=noise_model,
+            noise_model=self._get_noise_model(self._config, sequence.device),
             with_modulation=self._config.with_modulation,
             solver=self._config.solver,
             n_trajectories=self._config.n_trajectories,
         )
+
         self._sim_obj.set_evaluation_times(
             self._config._get_legacy_evaluation_times(
                 self._sim_obj.total_duration_ns
@@ -173,9 +171,20 @@ class QutipBackendV2(EmulatorBackend):
             "print_progress": self._config.print_progress,
             "progress_bar": self._config.progress_bar,
         }
+
         self._sim_obj._validate_options(self._qutip_options)
 
+    @staticmethod
+    def _get_noise_model(
+        config: EmulationConfig, device: BaseDevice
+    ) -> NoiseModel:
+        noise_model: None | NoiseModel = None
+        if config.prefer_device_noise_model:
+            noise_model = device.noise_model
+        return noise_model or config.noise_model
+
     def run(self) -> Results:
+        """Executes the sequence on the backend."""
         return QutipBackendV2._run_raw(
             self._sim_obj,
             self._sim_obj._register,
@@ -191,6 +200,14 @@ class QutipBackendV2(EmulatorBackend):
         *,
         config: EmulationConfig | None = None,
     ) -> Results:
+        """
+        Executes the sampled sequence on the backend
+
+        Args:
+            sequence_samples: the sampled sequence
+            register: the qubit register
+            device: the device to emulate
+        """
         config = config or QutipBackendV2.default_config
         sim_obj = QutipEmulator(
             sequence_samples,
@@ -198,14 +215,21 @@ class QutipBackendV2(EmulatorBackend):
             device,
             sampling_rate=config.sampling_rate,
             config=None,
-            noise_model=config.noise_model,
+            noise_model=QutipBackendV2._get_noise_model(config, device),
             solver=config.solver,
             n_trajectories=config.n_trajectories,
         )
+
+        sim_obj.set_evaluation_times(
+            config._get_legacy_evaluation_times(sim_obj.total_duration_ns),
+        )
+        if config.initial_state:
+            sim_obj.set_initial_state(config.initial_state.to_qobj())
         qutip_options = {
             "print_progress": config.print_progress,
             "progress_bar": config.progress_bar,
         }
+
         return QutipBackendV2._run_raw(
             sim_obj, register, config, qutip_options
         )

--- a/pulser-simulation/pulser_simulation/qutip_backend.py
+++ b/pulser-simulation/pulser_simulation/qutip_backend.py
@@ -108,7 +108,11 @@ class QutipBackend(Backend):
             noise model in EmulatorConfig requires it.
             Otherwise, returns CoherentResults.
         """
-        return self._sim_obj.run(progress_bar=progress_bar, **qutip_options)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return self._sim_obj.run(
+                progress_bar=progress_bar, **qutip_options
+            )
 
 
 class QutipBackendV2(EmulatorBackend):
@@ -174,7 +178,9 @@ class QutipBackendV2(EmulatorBackend):
 
         if not _has_stochastic_noise(self._sim_obj.noise_model):
             # A single run is needed, regardless of self.config.runs
-            single_res = self._sim_obj.run(**self._qutip_options)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                single_res = self._sim_obj.run(**self._qutip_options)
             assert isinstance(single_res, CoherentResults)
             res = Results(
                 atom_order=tuple(self._sequence.qubit_info),

--- a/pulser-simulation/pulser_simulation/qutip_backend.py
+++ b/pulser-simulation/pulser_simulation/qutip_backend.py
@@ -187,7 +187,6 @@ class QutipBackendV2(EmulatorBackend):
         """Executes the sequence on the backend."""
         return QutipBackendV2._run_raw(
             self._sim_obj,
-            self._sim_obj._register,
             self._config,
             self._qutip_options,
         )
@@ -230,14 +229,11 @@ class QutipBackendV2(EmulatorBackend):
             "progress_bar": config.progress_bar,
         }
 
-        return QutipBackendV2._run_raw(
-            sim_obj, register, config, qutip_options
-        )
+        return QutipBackendV2._run_raw(sim_obj, config, qutip_options)
 
     @staticmethod
     def _run_raw(
         sim_obj: QutipEmulator,
-        register: BaseRegister,
         config: EmulationConfig,
         qutip_options: dict[str, Any],
     ) -> Results:
@@ -251,7 +247,7 @@ class QutipBackendV2(EmulatorBackend):
                 single_res = sim_obj.run(**qutip_options)
             assert isinstance(single_res, CoherentResults)
             res = Results(
-                atom_order=tuple(register.qubit_ids),
+                atom_order=tuple(sim_obj._register.qubit_ids),
                 total_duration=sim_obj.total_duration_ns,
             )
 
@@ -290,7 +286,7 @@ class QutipBackendV2(EmulatorBackend):
             ):
                 for _ in range(reps):
                     res = Results(
-                        atom_order=tuple(register.qubit_ids),
+                        atom_order=tuple(sim_obj._register.qubit_ids),
                         total_duration=sim_obj.total_duration_ns,
                     )
                     for qutip_res in cleanres_noisyseq:

--- a/pulser-simulation/pulser_simulation/qutip_backend.py
+++ b/pulser-simulation/pulser_simulation/qutip_backend.py
@@ -200,13 +200,13 @@ class QutipBackendV2(EmulatorBackend):
         *,
         config: EmulationConfig | None = None,
     ) -> Results:
-        """
-        Executes the sampled sequence on the backend
+        """Executes the sampled sequence on the backend.
 
         Args:
-            sequence_samples: the sampled sequence
-            register: the qubit register
-            device: the device to emulate
+            sequence_samples: The sampled sequence to emulate.
+            register: The qubit register.
+            device: The device to emulate.
+            config: The configuration for the Qutip emulation.
         """
         config = config or QutipBackendV2.default_config
         sim_obj = QutipEmulator(

--- a/pulser-simulation/pulser_simulation/qutip_backend.py
+++ b/pulser-simulation/pulser_simulation/qutip_backend.py
@@ -22,7 +22,10 @@ from pulser.backend.abc import Backend, EmulatorBackend
 from pulser.backend.config import EmulationConfig, EmulatorConfig
 from pulser.backend.default_observables import BitStrings, StateResult
 from pulser.backend.results import Results
+from pulser.devices._device_datacls import BaseDevice
 from pulser.noise_model import NoiseModel
+from pulser.register.base_register import BaseRegister
+from pulser.sampler import SequenceSamples
 from pulser_simulation.aggregators import density_matrix_aggregator
 from pulser_simulation.qutip_config import QutipConfig
 from pulser_simulation.qutip_op import QutipOperator
@@ -173,18 +176,59 @@ class QutipBackendV2(EmulatorBackend):
         self._sim_obj._validate_options(self._qutip_options)
 
     def run(self) -> Results:
-        """Executes the sequence on the backend."""
-        eigenstates = self._sim_obj._current_hamiltonian.basis_data.eigenbasis
+        return QutipBackendV2._run_raw(
+            self._sim_obj,
+            self._sim_obj._register,
+            self._config,
+            self._qutip_options,
+        )
 
-        if not _has_stochastic_noise(self._sim_obj.noise_model):
+    @staticmethod
+    def run_from_sequence_samples(
+        sequence_samples: SequenceSamples,
+        register: BaseRegister,
+        device: BaseDevice,
+        *,
+        config: EmulationConfig | None = None,
+    ) -> Results:
+        config = config or QutipBackendV2.default_config
+        sim_obj = QutipEmulator(
+            sequence_samples,
+            register,
+            device,
+            sampling_rate=config.sampling_rate,
+            config=None,
+            noise_model=config.noise_model,
+            solver=config.solver,
+            n_trajectories=config.n_trajectories,
+        )
+        qutip_options = {
+            "print_progress": config.print_progress,
+            "progress_bar": config.progress_bar,
+        }
+        return QutipBackendV2._run_raw(
+            sim_obj, register, config, qutip_options
+        )
+
+    @staticmethod
+    def _run_raw(
+        sim_obj: QutipEmulator,
+        register: BaseRegister,
+        config: EmulationConfig,
+        qutip_options: dict[str, Any],
+    ) -> Results:
+        """Executes the sequence on the backend."""
+        eigenstates = sim_obj._current_hamiltonian.basis_data.eigenbasis
+
+        if not _has_stochastic_noise(sim_obj.noise_model):
             # A single run is needed, regardless of self.config.runs
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", DeprecationWarning)
-                single_res = self._sim_obj.run(**self._qutip_options)
+                single_res = sim_obj.run(**qutip_options)
             assert isinstance(single_res, CoherentResults)
             res = Results(
-                atom_order=tuple(self._sequence.qubit_info),
-                total_duration=self._sim_obj.total_duration_ns,
+                atom_order=tuple(register.qubit_ids),
+                total_duration=sim_obj.total_duration_ns,
             )
 
             for qutip_res in single_res:
@@ -193,22 +237,22 @@ class QutipBackendV2(EmulatorBackend):
                     qutip_res.state.unit(), eigenstates=eigenstates
                 )
                 ham: QutipOperator = QutipOperator(
-                    self._sim_obj._get_noiseless_hamiltonian(
-                        self._config.noise_model.with_leakage
+                    sim_obj._get_noiseless_hamiltonian(
+                        config.noise_model.with_leakage
                     )._hamiltonian(t * res.total_duration / 1000),
                     eigenstates=eigenstates,
                 )
-                for callback in self._config.callbacks:
+                for callback in config.callbacks:
                     callback(
-                        config=self._config,
+                        config=config,
                         t=float(t),
                         state=state,
                         hamiltonian=ham,
                         result=res,
                     )
-                for obs in self._config.observables:
+                for obs in config.observables:
                     obs(
-                        config=self._config,
+                        config=config,
                         t=float(t),
                         state=state,
                         hamiltonian=ham,
@@ -217,13 +261,13 @@ class QutipBackendV2(EmulatorBackend):
             return res
         else:
             results: list[Results] = []
-            for cleanres_noisyseq, reps in self._sim_obj._noisy_runs(
-                **self._qutip_options
+            for cleanres_noisyseq, reps in sim_obj._noisy_runs(
+                **qutip_options
             ):
                 for _ in range(reps):
                     res = Results(
-                        atom_order=tuple(self._sequence.qubit_info),
-                        total_duration=self._sim_obj.total_duration_ns,
+                        atom_order=tuple(register.qubit_ids),
+                        total_duration=sim_obj.total_duration_ns,
                     )
                     for qutip_res in cleanres_noisyseq:
                         t = qutip_res.evaluation_time
@@ -232,23 +276,23 @@ class QutipBackendV2(EmulatorBackend):
                             qutip_res.state.unit(), eigenstates=eigenstates
                         )
                         ham = QutipOperator(
-                            self._sim_obj._get_noiseless_hamiltonian(
-                                self._config.noise_model.with_leakage
+                            sim_obj._get_noiseless_hamiltonian(
+                                config.noise_model.with_leakage
                             )._hamiltonian(t * res.total_duration / 1000),
                             eigenstates=eigenstates,
                         )
 
-                        for callback in self._config.callbacks:
+                        for callback in config.callbacks:
                             callback(
-                                config=self._config,
+                                config=config,
                                 t=float(t),
                                 state=state,
                                 hamiltonian=ham,
                                 result=res,
                             )
-                        for obs in self._config.observables:
+                        for obs in config.observables:
                             obs(
-                                config=self._config,
+                                config=config,
                                 t=float(t),
                                 state=state,
                                 hamiltonian=ham,

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -804,7 +804,8 @@ class QutipEmulator:
         """Simulates the sequence using QuTiP's solvers.
 
         Will return NoisyResults if the noise in the SimConfig requires it.
-        Otherwise will return CoherentResults.
+        Otherwise will return CoherentResults. *Deprecated as of pulser 1.9
+        Please use QutipBackendV2 instead.*
 
         Args:
             progress_bar: If True, the progress bar of QuTiP's
@@ -820,6 +821,14 @@ class QutipEmulator:
 
                 .. _docs: https://bit.ly/3il9A2u
         """
+        warnings.warn(
+            (
+                "QutipEmulator is deprecated as of pulser 1.9. "
+                "Please use QutipBackendV2 instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._validate_options(options)
 
         if not _has_stochastic_noise(self.noise_model):

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -33,6 +33,7 @@ from pulser.backend.default_observables import (
 from pulser.backend.observable import Callback
 from pulser.channels.dmm import DMM
 from pulser.devices import AnalogDevice
+from pulser.sampler import sample
 from pulser_simulation.qutip_backend import QutipBackendV2
 from pulser_simulation.qutip_config import QutipConfig, Solver
 from pulser_simulation.qutip_op import QutipOperator
@@ -609,3 +610,29 @@ def test_dmm_temperature_without_spot_waist():
         match="Combining register noise with a DMM requires",
     ):
         QutipBackendV2(seq, config=config)
+
+
+@pytest.mark.parametrize("modulation", [True, False])
+def test_run_from_sequence_samples(modulation):
+    seq = pulser.Sequence(
+        pulser.Register.square(1, prefix="q"), pulser.AnalogDevice
+    )
+    seq.declare_channel("rydberg_global", "rydberg_global")
+    seq.add(pulser.Pulse.ConstantPulse(1000, 1, 0, 0), "rydberg_global")
+
+    backend = QutipBackendV2(seq)
+
+    results1 = backend.run()
+    results2 = backend.run_from_sequence_samples(
+        sample(
+            seq,
+            modulation=modulation,
+            extended_duration=seq.get_duration(include_fall_time=modulation),
+        ),
+        seq.register,
+        seq.device,
+    )
+
+    assert np.allclose(
+        results1.final_state._state.full(), results2.final_state._state.full()
+    )

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -232,7 +232,11 @@ def test_qutip_backend_v2_stochastic_noise():
             noise_model=get_noise_model(samples_per_run=100),
             n_trajectories=30,
         )
-    results_old_api = qutip_emulator.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        results_old_api = qutip_emulator.run()
 
     times = results.get_result_times("occupation")
     occupation = np.array([x[0] for x in results.occupation])

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -620,7 +620,12 @@ def test_run_from_sequence_samples(modulation):
     seq.declare_channel("rydberg_global", "rydberg_global")
     seq.add(pulser.Pulse.ConstantPulse(1000, 1, 0, 0), "rydberg_global")
 
-    backend = QutipBackendV2(seq)
+    config: QutipConfig | None = None
+    if modulation:
+        config = QutipConfig(
+            with_modulation=modulation, observables=[StateResult()]
+        )
+    backend = QutipBackendV2(seq, config=config)
 
     results1 = backend.run()
     results2 = backend.run_from_sequence_samples(
@@ -631,8 +636,10 @@ def test_run_from_sequence_samples(modulation):
         ),
         seq.register,
         seq.device,
+        config=config,
     )
 
-    assert np.allclose(
-        results1.final_state._state.full(), results2.final_state._state.full()
-    )
+    s1 = results1.final_state._state.full()
+    s2 = results2.final_state._state.full()
+
+    assert np.allclose(s1, s2)

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -642,4 +642,4 @@ def test_run_from_sequence_samples(modulation):
     s1 = results1.final_state._state.full()
     s2 = results2.final_state._state.full()
 
-    assert np.allclose(s1, s2)
+    assert np.allclose(s1, s2, atol=0, rtol=1e-16)  # really the same

--- a/tests/pulser_simulation/test_qutip_backend_v2.py
+++ b/tests/pulser_simulation/test_qutip_backend_v2.py
@@ -622,8 +622,13 @@ def test_run_from_sequence_samples(modulation):
 
     config: QutipConfig | None = None
     if modulation:
+        initial_state = QutipState.from_state_amplitudes(
+            eigenstates=("r", "g"), amplitudes={"g": 1.0}
+        )
         config = QutipConfig(
-            with_modulation=modulation, observables=[StateResult()]
+            with_modulation=modulation,
+            observables=[StateResult()],
+            initial_state=initial_state,
         )
     backend = QutipBackendV2(seq, config=config)
 

--- a/tests/pulser_simulation/test_simresults.py
+++ b/tests/pulser_simulation/test_simresults.py
@@ -79,12 +79,20 @@ def results_noisy(seq_no_meas):
             ),
             n_trajectories=15,
         )
-    return sim.run()
+        with pytest.warns(
+            DeprecationWarning,
+            match="QutipEmulator is deprecated as of pulser 1.9",
+        ):
+            return sim.run()
 
 
 @pytest.fixture
 def results(sim):
-    return sim.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        return sim.run()
 
 
 @pytest.mark.parametrize(
@@ -162,7 +170,11 @@ def test_get_final_state(
             device=seq_no_meas.device,
             noise_model=NoiseModel(dephasing_rate=0.01),
         )
-    _results = sim.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        _results = sim.run()
     assert isinstance(_results, CoherentResults)
     final_state = _results.get_final_state()
     assert final_state.isoper if noisychannel else final_state.isket
@@ -198,7 +210,11 @@ def test_get_final_state(
     seq_.add(pi_pulse, "ryd")
 
     sim_ = QutipEmulator.from_sequence(seq_)
-    results_ = sim_.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        results_ = sim_.run()
     results_ = cast(CoherentResults, results_)
 
     with pytest.raises(ValueError, match="'reduce_to_basis' must be"):
@@ -243,7 +259,11 @@ def test_get_final_state_noisy(reg, pi_pulse):
         ),
         n_trajectories=15,
     )
-    res3 = sim_noisy.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        res3 = sim_noisy.run()
     res3._meas_basis = "digital"
     final_state = res3.get_final_state()
     assert isdiagonal(final_state)
@@ -278,7 +298,11 @@ def test_expect(results, pi_pulse, reg):
     seq_single.declare_channel("ryd", "rydberg_global")
     seq_single.add(pi_pulse, "ryd")
     sim_single = QutipEmulator.from_sequence(seq_single)
-    results_single = sim_single.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        results_single = sim_single.run()
     op = [qutip.basis(2, 0).proj()]
     exp = results_single.expect(op)[0]
     assert np.isclose(exp[-1], 1)
@@ -293,7 +317,11 @@ def test_expect(results, pi_pulse, reg):
         seq_single, noise_model=noise_model
     )
     sim_single.set_evaluation_times("Minimal")
-    results_single = sim_single.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        results_single = sim_single.run()
     exp = results_single.expect(op)[0]
     assert len(exp) == 2
     assert isinstance(results_single, CoherentResults)
@@ -325,7 +353,11 @@ def test_expect(results, pi_pulse, reg):
         sampling_rate=0.1,
     )
     sim_single.set_evaluation_times(0.5)
-    res = sim_single.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        res = sim_single.run()
     assert isinstance(res, CoherentResults)
     # define an observable for the state
     assert np.isclose(
@@ -338,9 +370,13 @@ def test_expect(results, pi_pulse, reg):
     seq3dim.add(pi_pulse, "ram")
     seq3dim.add(pi_pulse, "ryd")
     sim3dim = QutipEmulator.from_sequence(seq3dim)
-    exp3dim = sim3dim.run().expect(
-        [qutip.tensor(qutip.basis(3, 0).proj(), qutip.qeye(3))]
-    )
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        exp3dim = sim3dim.run().expect(
+            [qutip.tensor(qutip.basis(3, 0).proj(), qutip.qeye(3))]
+        )
     assert np.isclose(exp3dim[0][-1], 1.89690200e-14)
 
 
@@ -364,7 +400,11 @@ def test_plot(results_noisy, results):
 def test_sim_without_measurement(seq_no_meas):
     assert not seq_no_meas.is_measured()
     sim_no_meas = QutipEmulator.from_sequence(seq_no_meas)
-    results_no_meas = sim_no_meas.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        results_no_meas = sim_no_meas.run()
     np.random.seed(123)
     assert results_no_meas.sample_final_state(1) == Counter({"11": 1})
 
@@ -382,13 +422,21 @@ def test_sample_final_state(results):
 def test_sample_final_state_three_level(seq_no_meas, pi_pulse):
     seq_no_meas.declare_channel("raman", "raman_local", "B")
     seq_no_meas.add(pi_pulse, "raman")
-    res_3level = QutipEmulator.from_sequence(seq_no_meas).run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        res_3level = QutipEmulator.from_sequence(seq_no_meas).run()
     # Raman pi pulse on one atom will not affect other,
     # even with global pi on rydberg
     assert len(res_3level.sample_final_state()) == 2
 
     seq_no_meas.measure("ground-rydberg")
-    res_3level_gb = QutipEmulator.from_sequence(seq_no_meas).run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        res_3level_gb = QutipEmulator.from_sequence(seq_no_meas).run()
     sampling_three_levelB = res_3level_gb.sample_final_state()
     # Rydberg will affect both:
     assert len(sampling_three_levelB) == 4
@@ -417,7 +465,11 @@ def test_sample_final_state_noisy(seq_no_meas, results_noisy):
         ),
         n_trajectories=10,
     )
-    final_state = res_3level.run().states[-1]
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        final_state = res_3level.run().states[-1]
     assert np.isclose(
         final_state.full(),
         np.array(
@@ -440,7 +492,11 @@ def test_results_xy(reg, pi_pulse):
     seq_.measure("XY")
 
     sim_ = QutipEmulator.from_sequence(seq_)
-    results_ = sim_.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        results_ = sim_.run()
 
     assert results_._dim == 2
     assert results_._size == 2
@@ -490,4 +546,8 @@ def test_false_positive():
         channel="ryd_glob",
     )
     sim = QutipEmulator.from_sequence(seq)
-    assert sim.run().get_final_state() != sim.initial_state
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        assert sim.run().get_final_state() != sim.initial_state

--- a/tests/pulser_simulation/test_simulation.py
+++ b/tests/pulser_simulation/test_simulation.py
@@ -596,10 +596,16 @@ def test_single_atom_simulation():
         Pulse.ConstantDetuning(ConstantWaveform(16, 1.0), 1.0, 0), "ch0"
     )
     one_sim = QutipEmulator.from_sequence(one_seq)
-    one_res = one_sim.run()
-    assert one_res._size == one_sim._current_hamiltonian.n_qudits
-    one_sim = QutipEmulator.from_sequence(one_seq, evaluation_times="Minimal")
-    one_resb = one_sim.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        one_res = one_sim.run()
+        assert one_res._size == one_sim._current_hamiltonian.n_qudits
+        one_sim = QutipEmulator.from_sequence(
+            one_seq, evaluation_times="Minimal"
+        )
+        one_resb = one_sim.run()
     assert one_resb._size == one_sim._current_hamiltonian.n_qudits
 
 
@@ -614,8 +620,12 @@ def test_add_max_step_and_delays():
         Pulse.ConstantDetuning(BlackmanWaveform(600, np.pi / 2), 0, 0), "ch"
     )
     sim = QutipEmulator.from_sequence(seq)
-    res_large_max_step = sim.run(max_step=1)
-    res_auto_max_step = sim.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        res_large_max_step = sim.run(max_step=1)
+        res_auto_max_step = sim.run()
     r = qutip.basis(2, 0)
     occ_large = res_large_max_step.expect([r.proj()])[0]
     occ_auto = res_auto_max_step.expect([r.proj()])[0]
@@ -656,26 +666,38 @@ def test_run(seq, patch_plt_show):
         sim.set_initial_state(qutip.Qobj(bad_initial))
 
     sim.set_initial_state(good_initial_array)
-    sim.run()
-    sim.set_initial_state(good_initial_qobj)
-    sim.run()
-    sim.set_initial_state(good_initial_qobj_no_dims)
-    sim.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        sim.run()
+        sim.set_initial_state(good_initial_qobj)
+        sim.run()
+        sim.set_initial_state(good_initial_qobj_no_dims)
+        sim.run()
     seq.measure("ground-rydberg")
     sim = QutipEmulator.from_sequence(seq, sampling_rate=0.01)
     sim.set_initial_state(good_initial_qobj_no_dims)
 
-    sim.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        sim.run()
     assert sim.samples_obj._measurement == "ground-rydberg"
 
-    sim.run(progress_bar=True)
-    sim.run(progress_bar=False)
-    sim.run(progress_bar=None)
-    with pytest.raises(
-        ValueError,
-        match="`progress_bar` must be a bool.",
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
     ):
-        sim.run(progress_bar=1)
+        sim.run(progress_bar=True)
+        sim.run(progress_bar=False)
+        sim.run(progress_bar=None)
+        with pytest.raises(
+            ValueError,
+            match="`progress_bar` must be a bool.",
+        ):
+            sim.run(progress_bar=1)
 
     sim = QutipEmulator.from_sequence(
         seq,
@@ -689,7 +711,11 @@ def test_run(seq, patch_plt_show):
         match="Can't combine state preparation errors with an initial state "
         "different from the ground.",
     ):
-        sim.run()
+        with pytest.warns(
+            DeprecationWarning,
+            match="QutipEmulator is deprecated as of pulser 1.9",
+        ):
+            sim.run()
 
 
 def test_eval_times(seq):
@@ -881,9 +907,15 @@ def test_noise(capfd, seq, matrices):
             "'SampledResult.get_samples()' resamples a sampling distribution"
         ),
     ):
-        assert sim2.run(print_progress=True).sample_final_state() == Counter(
-            {"000": 824, "100": 41, "101": 57, "001": 63, "010": 15}
-        )
+        with pytest.warns(
+            DeprecationWarning,
+            match="QutipEmulator is deprecated as of pulser 1.9",
+        ):
+            assert sim2.run(
+                print_progress=True
+            ).sample_final_state() == Counter(
+                {"000": 824, "100": 41, "101": 57, "001": 63, "010": 15}
+            )
     out, _ = capfd.readouterr()
     assert out.rstrip("\n").split("\n") == [
         "Emulating Trajectories [1 - 13]/15",
@@ -934,7 +966,13 @@ def test_noise_with_zero_epsilons(seq, matrices):
     )
     assert sim2.config.noise == ()
 
-    assert sim.run().sample_final_state() == sim2.run().sample_final_state()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        assert (
+            sim.run().sample_final_state() == sim2.run().sample_final_state()
+        )
 
 
 @pytest.mark.parametrize(
@@ -992,7 +1030,11 @@ def test_noises_rydberg(matrices, noise, result, n_collapse_ops):
         op.type == qutip.core.data.CSR
         for op in sim._current_hamiltonian._collapse_ops
     ]
-    res = sim.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        res = sim.run()
     res_samples = res.sample_final_state()
     assert res_samples == Counter(result)
     assert len(sim._current_hamiltonian._collapse_ops) == n_collapse_ops
@@ -1017,7 +1059,11 @@ def test_relaxation_noise(capfd):
         op.type == qutip.core.data.CSR
         for op in sim._current_hamiltonian._collapse_ops
     ]
-    res = sim.run(print_progress=True)
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        res = sim.run(print_progress=True)
     out, _ = capfd.readouterr()
     assert out.rstrip("\n").split("\n") == ["Emulating Trajectory 1/1"]
     start_samples = res.sample_state(1)
@@ -1112,7 +1158,11 @@ def test_noises_digital(matrices, noise, result, n_collapse_ops, seq_digital):
             noise_model=NoiseModel(relaxation_rate=0.01),
         )
 
-    res = sim.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        res = sim.run()
     res_samples = res.sample_final_state()
     assert res_samples == Counter(result)
     assert len(sim._current_hamiltonian._collapse_ops) == n_collapse_ops * len(
@@ -1237,7 +1287,11 @@ def test_noises_all(matrices, noise, result, n_collapse_ops, seq):
         seq.register.qubits
     )
     np.random.seed(123)
-    res = sim.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        res = sim.run()
     res_samples = res.sample_final_state()
     assert res_samples == Counter(result)
     trace_2 = np.trace((res.states[-1] ** 2).full())
@@ -1446,14 +1500,22 @@ def test_run_xy():
     )
     sim.set_initial_state(good_initial_array)
     assert sim.initial_state == good_initial_qobj
-    sim.run()
-    sim.set_initial_state(good_initial_qobj)
-    sim.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        sim.run()
+        sim.set_initial_state(good_initial_qobj)
+        sim.run()
 
     assert not sim.samples_obj._measurement
     simple_seq.measure(basis="XY")
     sim = QutipEmulator.from_sequence(simple_seq, sampling_rate=0.01)
-    sim.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        sim.run()
     assert sim.samples_obj._measurement == "XY"
 
 
@@ -1601,7 +1663,11 @@ def test_noisy_xy(
         len(sim._current_hamiltonian._collapse_ops) // len(simple_reg.qubits)
         == n_collapse_ops
     )
-    r = sim.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        r = sim.run()
     with pytest.warns(
         UserWarning,
         match=re.escape(
@@ -2087,7 +2153,11 @@ def test_initial_state_sim():
     emulator = QutipEmulator.from_sequence(seq)
     emulator.set_initial_state(initial_state)
     np.random.seed(123)
-    res = emulator.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        res = emulator.run()
     final_state = res.get_final_state()
     assert np.all(
         np.isclose(
@@ -2376,12 +2446,16 @@ def test_noisy_runs(noise):
     sim = QutipEmulator.from_sequence(
         seq, noise_model=noise_mod, n_trajectories=nruns
     )
-    with patch.object(
-        QutipEmulator, "_run_solver", wraps=sim._run_solver
-    ) as mock_run_solver:
-        result = sim.run()
-        assert mock_run_solver.call_count == nruns
-        assert isinstance(result, NoisyResults)
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        with patch.object(
+            QutipEmulator, "_run_solver", wraps=sim._run_solver
+        ) as mock_run_solver:
+            result = sim.run()
+            assert mock_run_solver.call_count == nruns
+            assert isinstance(result, NoisyResults)
 
 
 @pytest.mark.parametrize(
@@ -2498,7 +2572,11 @@ def test_qutip_invalid_solver_error(seq):
             solver="fakesolver",
             n_trajectories=1,
         )
-        sim.run()
+        with pytest.warns(
+            DeprecationWarning,
+            match="QutipEmulator is deprecated as of pulser 1.9",
+        ):
+            sim.run()
 
 
 @pytest.mark.parametrize("min_detuning_on", [False, True])
@@ -2543,7 +2621,11 @@ def test_eom_limit_det(mod_device, reg, min_detuning_on):
     # Check that simulation runs
     np.random.seed(123)
     sim = QutipEmulator.from_sequence(seq)
-    res = sim.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        res = sim.run()
     final_state = res.sample_final_state()
     if min_detuning_on:
         assert final_state == {
@@ -2559,4 +2641,8 @@ def test_eom_limit_det(mod_device, reg, min_detuning_on):
     sim = QutipEmulator.from_sequence(
         seq, noise_model=NoiseModel(detuning_sigma=0.1), n_trajectories=1
     )
-    sim.run()
+    with pytest.warns(
+        DeprecationWarning,
+        match="QutipEmulator is deprecated as of pulser 1.9",
+    ):
+        sim.run()


### PR DESCRIPTION
The new `QutipBackendV2.run_from_sequence_samples` is a static method because that was the easiest way to get everything to work. The core issue to circumvent is that `EmulatorBackend` requires a `Sequence` so I almost had to make it static.