### PR TITLE
Fix scipy incompatibility with numpy 1 in the CI

### DIFF
--- a/.github/workflows/pulser-setup/action.yml
+++ b/.github/workflows/pulser-setup/action.yml
@@ -45,7 +45,7 @@ runs:
       if: ${{ inputs.numpy == 'numpy-v1'}}
       shell: bash
       run: |
-        pip install numpy==1.26.4
+        pip install 'numpy==1.26.4' 'scipy<1.18'
     - name: Install numpy v2
       if: ${{ inputs.numpy == 'numpy-v2'}}
       shell: bash


### PR DESCRIPTION
We explicitly install `numpy==1.26.4` in some tests, which conflicts with `scipy >= 1.18` since it no longer supports numpy 2. This forces an install of `scipy <1.18` in these cases to circumvent the issue. 