### PR TITLE
Specify we use 1-sided PSD for detuning noise in the docs

### DIFF
--- a/pulser-core/pulser/_hamiltonian_data/hamiltonian_data.py
+++ b/pulser-core/pulser/_hamiltonian_data/hamiltonian_data.py
@@ -148,10 +148,13 @@ def _generate_detuning_fluctuations(
     -----
     High frequency term uses Gaussian stochastic noise with power
         spectral density `psd`:
-        δ_hf(t) = Σ_k sqrt(2 * Δf_k * psd_k) * cos(2π(f_k * t + φ_k))
-        where φ_k ~ U[0, 1) (uniform random phase),
-        Δf_k = freqs[k+1] - freqs[k].
-        The last (freqs[-1], psd[-1]) is unused.
+        δ_hf(t) = Σ_k sqrt(2 * Δf_k * psd_k) * cos(f_k * t + φ_k)
+        where φ_k ~ U[0, 2π) (uniform random phase),
+        Δf_k = omegas[k+1] - omegas[k].
+        The last (omegas[-1], psd[-1]) is unused.
+        See Eq. 3.55 of https://theses.hal.science/tel-00010730,
+        except that we use the 1-sided PSD, so factor of 2
+        is inside the square root.
     """
     det_hf = np.zeros_like(times)
 

--- a/pulser-core/pulser/_hamiltonian_data/hamiltonian_data.py
+++ b/pulser-core/pulser/_hamiltonian_data/hamiltonian_data.py
@@ -148,9 +148,9 @@ def _generate_detuning_fluctuations(
     -----
     High frequency term uses Gaussian stochastic noise with power
         spectral density `psd`:
-        δ_hf(t) = Σ_k sqrt(2 * Δf_k * psd_k) * cos(f_k * t + φ_k)
+        δ_hf(t) = Σ_k sqrt(2 * Δω_k * psd_k) * cos(ω_k * t + φ_k)
         where φ_k ~ U[0, 2π) (uniform random phase),
-        Δf_k = omegas[k+1] - omegas[k].
+        Δω_k = omegas[k+1] - omegas[k].
         The last (omegas[-1], psd[-1]) is unused.
         See Eq. 3.55 of https://theses.hal.science/tel-00010730,
         except that we use the 1-sided PSD, so factor of 2

--- a/pulser-core/pulser/noise_model.py
+++ b/pulser-core/pulser/noise_model.py
@@ -226,8 +226,8 @@ class NoiseModel:
       ``detuning_sigma``
 
       (2) time-dependent high-frequency fluctuations, defined by the
-      power spectral density (PSD) ``detuning_hf_psd`` over the relevant
-      ``detuning_hf_omegas`` angular frequency support.
+      **1-sided** power spectral density (PSD) ``detuning_hf_psd``
+      over the relevant ``detuning_hf_omegas`` angular frequency support.
       :math:`\delta_{hf}(t) = \sum_k \sqrt{2*\Delta \omega_k*\mathrm{PSD}_k}
       * \cos(\omega_k * t + \phi_k)`
       where :math:`\phi_k \backsim U[0, 2\pi)` (uniform random phase),
@@ -286,7 +286,9 @@ class NoiseModel:
             provided together with `detuning_hf_omegas` define high frequency
             noise contribution of time dependent detuning (in rad/µs).
             Must either be empty or a tuple with at least two values,
-            matching the length of `detuning_hf_omegas`. Default is ().
+            matching the length of `detuning_hf_omegas`.
+            Note that this is the 1-sided PSD, which differs from the
+            2-sided PSD by a factor of 2! Default is ().
         detuning_hf_omegas: 1D tuple (in rad/µs) of relevant angular frequency
             support for the PSD. Along with the PSD, it is required to define
             high frequency noise contribution of time dependent detuning


### PR DESCRIPTION
I made explicit in the docs for the `NoiseModel` that we need the 1-sided `PSD`, and that it differs from the 2-sided one by a factor of 2.