### PR TITLE
Prevent evaluation time collisions due to rounding

### DIFF
--- a/pulser-core/pulser/backend/observable.py
+++ b/pulser-core/pulser/backend/observable.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from pulser.backend.results import Results
 
 
-def fuzzy_unique_sorted(sorted: np.ndarray, tolerance: float) -> bool:
+def _fuzzy_unique_sorted(sorted: np.ndarray, tolerance: float) -> bool:
     return not np.any(np.abs(sorted[:-1] - sorted[1:]) < tolerance)
 
 
@@ -214,7 +214,9 @@ class Observable(Callback):
             )
         # larger than machine precision, but effectively 0
         time_tolerance = 1e-12
-        unique_eval_times = fuzzy_unique_sorted(eval_times_arr, time_tolerance)
+        unique_eval_times = _fuzzy_unique_sorted(
+            eval_times_arr, time_tolerance
+        )
         if not unique_eval_times:
             raise ValueError(
                 f"Evaluation times must be unique up to {time_tolerance} but "

--- a/pulser-core/pulser/backend/observable.py
+++ b/pulser-core/pulser/backend/observable.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
     from pulser.backend.config import EmulationConfig
     from pulser.backend.results import Results
 
+TIME_TOLERANCE = 1e-12
+
 
 def _fuzzy_unique_sorted(sorted: np.ndarray, tolerance: float) -> bool:
     return not np.any(np.abs(sorted[:-1] - sorted[1:]) < tolerance)
@@ -213,13 +215,12 @@ class Observable(Callback):
                 f"Instead, got {evaluation_times!r}."
             )
         # larger than machine precision, but effectively 0
-        time_tolerance = 1e-12
         unique_eval_times = _fuzzy_unique_sorted(
-            eval_times_arr, time_tolerance
+            eval_times_arr, TIME_TOLERANCE
         )
         if not unique_eval_times:
             raise ValueError(
-                f"Evaluation times must be unique up to {time_tolerance} but "
+                f"Evaluation times must be unique up to {TIME_TOLERANCE} but "
                 f"{evaluation_times!r} has repeated values."
             )
         if not np.all(eval_times_arr[:-1] < eval_times_arr[1:]):

--- a/pulser-core/pulser/backend/observable.py
+++ b/pulser-core/pulser/backend/observable.py
@@ -31,6 +31,10 @@ if TYPE_CHECKING:
     from pulser.backend.results import Results
 
 
+def fuzzy_unique_sorted(sorted: np.ndarray, tolerance: float) -> bool:
+    return not np.any(np.abs(sorted[:-1] - sorted[1:]) < tolerance)
+
+
 class Callback(ABC):
     """A general Callback that is called during the emulation."""
 
@@ -208,10 +212,12 @@ class Observable(Callback):
                 "All evaluation times must be between 0. and 1. "
                 f"Instead, got {evaluation_times!r}."
             )
-        unique_eval_times = np.unique(eval_times_arr)
-        if unique_eval_times.size < eval_times_arr.size:
+        # larger than machine precision, but effectively 0
+        time_tolerance = 1e-12
+        unique_eval_times = fuzzy_unique_sorted(eval_times_arr, time_tolerance)
+        if not unique_eval_times:
             raise ValueError(
-                "Evaluation times must be unique but "
+                f"Evaluation times must be unique up to {time_tolerance} but "
                 f"{evaluation_times!r} has repeated values."
             )
         if not np.all(eval_times_arr[:-1] < eval_times_arr[1:]):

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -866,7 +866,7 @@ class QutipEmulator:
                 tuple(self._hamiltonian_data.register.qubits),
                 self._meas_basis,
                 total_count[ind],
-                evaluation_time=t / (self._tot_duration * 1e-3,),
+                evaluation_time=t / (self._tot_duration * 1e-3),
             )
             for ind, t in enumerate(self._eval_times_array)
         ]

--- a/pulser-simulation/pulser_simulation/simulation.py
+++ b/pulser-simulation/pulser_simulation/simulation.py
@@ -866,7 +866,7 @@ class QutipEmulator:
                 tuple(self._hamiltonian_data.register.qubits),
                 self._meas_basis,
                 total_count[ind],
-                evaluation_time=t / self._tot_duration * 1e3,
+                evaluation_time=t / (self._tot_duration * 1e-3,),
             )
             for ind, t in enumerate(self._eval_times_array)
         ]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -614,10 +614,12 @@ def test_emulation_config():
             observables=(BitStrings(),),
             default_evaluation_times=[-1e15, 0.0, 0.5, 1.0],
         )
-    with pytest.raises(ValueError, match="Evaluation times must be unique"):
+    with pytest.raises(
+        ValueError, match="Evaluation times must be unique up to"
+    ):
         EmulationConfig(
             observables=(BitStrings(),),
-            default_evaluation_times=[0.0, 0.5, 0.5, 1.0],
+            default_evaluation_times=[0.0, 0.5, 0.5 + 1e-14, 1.0],
         )
     with pytest.raises(
         ValueError, match="Evaluation times must be in ascending order"


### PR DESCRIPTION
Since `QutipBackendV2` uses `QutipEmulator` under the hood, it needs to convert `Obervable` evaluation times to the format required by `QutipEmulator`, and then back again at the end when storing the result in `Results`. Due to floating point arithmetic, the time stored in `Results` is not necessarily identical to that asked for in the result (it can differ by something of order machine precision). Since observable times have to be unique, this can cause collisions.

I solve the issue by requiring the evaluation times in an `Observable` or in `EmulationConfig.default_evaluation_times` to mutually differ by more than `1e-12`, which prevents colisions due to rounding, being orders of magnitude larger than machine precision.

Although it is possible to uniquely pair an obtained evaluation time to a requested one, I decided not to implement this, and allow for potential rounding errors to show in `Results`. The natural places to implement this would be in the `Obervable` or by post-processing the `Results` in `QutipBackendV2`. I'm afraid the first will have negative effects on the other emulators, and the second will lead to more code to maintain for a very marginal benefit.

Closes #1023 