### PR TITLE
Add aggregators for (mean, std)

### DIFF
--- a/pulser-core/pulser/backend/aggregators.py
+++ b/pulser-core/pulser/backend/aggregators.py
@@ -35,7 +35,7 @@ T = TypeVar(
 )
 
 
-def _validate_values(values: list[T]) -> None:
+def _assert_values_not_empty(values: list[T]) -> None:
     """Validate that ``values`` is a non-empty list.
 
     Args:
@@ -90,7 +90,7 @@ def _std_aggregator(
     Returns:
         The standard deviation over the first dimension of the given values.
     """
-    _validate_values(values)
+    _assert_values_not_empty(values)
 
     elt = values[0]
 
@@ -101,17 +101,15 @@ def _std_aggregator(
         return cast(np.ndarray, np.stack(values).std(axis=0, ddof=1))
 
     if isinstance(elt, float):
-        return cast(
-            float, np.std(values, ddof=1)
-        )  # this would have type np.floating
+        return float(np.std(values, ddof=1))  # instead of np.floating
 
     if isinstance(elt, complex):
-        return cast(
-            complex, np.std(values, ddof=1)
-        )  # this would have type np.complexfloating
+        return complex(np.std(values, ddof=1))  # np.complexfloating
 
     if not isinstance(elt, Sequence):
-        raise ValueError("Cannot process this type of data.")
+        raise ValueError(
+            f"Std aggregator cannot process data of type {type(elt)}."
+        )
 
     _validate_sequence_elements(elt)
 
@@ -131,7 +129,7 @@ def _mean_aggregator(
     Returns:
         The average over the first dimension of the provided results.
     """
-    _validate_values(values)
+    _assert_values_not_empty(values)
 
     elt = values[0]
 
@@ -142,15 +140,15 @@ def _mean_aggregator(
         return cast(np.ndarray, np.stack(values).mean(axis=0))
 
     if isinstance(elt, float):
-        return cast(float, np.mean(values))  # this would have type np.floating
+        return float(np.mean(values))  # this would have type np.floating
 
     if isinstance(elt, complex):
-        return cast(
-            complex, np.mean(values)
-        )  # this would have type np.complexfloating
+        return complex(np.mean(values))  # np.complexfloating
 
     if not isinstance(elt, Sequence):
-        raise ValueError("Cannot process this type of data.")
+        raise ValueError(
+            f"Mean aggregator cannot process data of type {type(elt)}."
+        )
 
     _validate_sequence_elements(elt)
 
@@ -186,6 +184,5 @@ def _bag_union_aggregator(
 AGGREGATOR_MAPPING: dict[AggregationMethod, Callable] = {
     AggregationMethod.MEAN: _mean_aggregator,
     AggregationMethod.BAG_UNION: _bag_union_aggregator,
-    AggregationMethod.STD: _std_aggregator,
     AggregationMethod.MEANSTD: _mean_std_aggregator,
 }

--- a/pulser-core/pulser/backend/aggregators.py
+++ b/pulser-core/pulser/backend/aggregators.py
@@ -60,7 +60,6 @@ def _validate_sequence_elements(elt: Sequence) -> None:
     Raises:
         ValueError: If the nested structure contains bad types.
     """
-
     if elt == []:
         raise ValueError("Cannot process list of empty lists.")
 

--- a/pulser-core/pulser/backend/aggregators.py
+++ b/pulser-core/pulser/backend/aggregators.py
@@ -35,6 +35,63 @@ T = TypeVar(
 )
 
 
+def _std_aggregator(
+    values: list[T],
+) -> T:
+    """Get the standard deviation of the given results.
+
+    Argument:
+        values: The results to use. Supported are lists of:
+            numeric values, lists of numeric values,
+            lists of lists of numeric values, torch Tensors and numpy arrays.
+
+    Returns:
+        The standard deviation over the first dimension of the given values.
+    """
+    if not isinstance(values, list):
+        raise ValueError("Need to supply a list of values to process.")
+    if values == []:
+        raise ValueError("Cannot process 0 samples.")
+
+    elt = values[0]
+
+    if pm.AbstractArray.has_torch() and isinstance(elt, pm.torch.Tensor):
+        return pm.torch.stack(values).std(dim=0)
+
+    if isinstance(elt, np.ndarray):
+        return cast(np.ndarray, np.stack(values).std(axis=0, ddof=1))
+
+    if isinstance(elt, float):
+        return cast(
+            float, np.std(values, ddof=1)
+        )  # this would have type np.floating
+    if isinstance(elt, complex):
+        return cast(
+            complex, np.std(values, ddof=1)
+        )  # this would have type np.complexfloating
+
+    if not isinstance(elt, Sequence):
+        raise ValueError("Cannot process this type of data.")
+
+    if values[0] == []:
+        raise ValueError("Cannot process list of empty lists.")
+
+    if isinstance(elt[0], (float, complex)):
+        return list(np.std(values, axis=0, ddof=1).tolist())
+
+    if not isinstance(elt[0], list):
+        raise ValueError(f"Cannot process list of lists of {type(elt[0])}.")
+
+    if len(elt[0]) == 0:
+        raise ValueError("Cannot process list of matrices with empty columns.")
+
+    if not isinstance(elt[0][0], (float, complex)):
+        raise ValueError(
+            f"Cannot process list of matrices of {type(elt[0][0])}."
+        )
+    return list(np.std(values, axis=0, ddof=1).tolist())
+
+
 def _mean_aggregator(
     values: list[T],
 ) -> T:
@@ -90,6 +147,25 @@ def _mean_aggregator(
     return list(np.mean(values, axis=0).tolist())
 
 
+def _mean_std_aggregator(
+    values: list[T],
+) -> tuple[T, T]:
+    """Get the mean and standard deviation of the given results.
+
+    Argument:
+        values: The results to use. Supported are lists of:
+            numeric values, lists of numeric values,
+            lists of lists of numeric values, torch Tensors and numpy arrays.
+
+    Returns:
+        A tuple (mean, standard deviation)
+            over the first dimension of the provided results.
+    """
+    mean = _mean_aggregator(values)
+    std = _std_aggregator(values)
+    return (mean, std)
+
+
 def _bag_union_aggregator(
     values: list[Counter],
 ) -> Counter:
@@ -100,4 +176,6 @@ def _bag_union_aggregator(
 AGGREGATOR_MAPPING: dict[AggregationMethod, Callable] = {
     AggregationMethod.MEAN: _mean_aggregator,
     AggregationMethod.BAG_UNION: _bag_union_aggregator,
+    AggregationMethod.STD: _std_aggregator,
+    AggregationMethod.MEANSTD: _mean_std_aggregator,
 }

--- a/pulser-core/pulser/backend/aggregators.py
+++ b/pulser-core/pulser/backend/aggregators.py
@@ -35,6 +35,49 @@ T = TypeVar(
 )
 
 
+def _validate_values(values: list[T]) -> None:
+    """Validate that ``values`` is a non-empty list.
+
+    Args:
+        values: The list of values to validate.
+        action: A verb describing the operation (used in error messages).
+
+    Raises:
+        ValueError: If ``values`` is not a list or is empty.
+    """
+    if not isinstance(values, list):
+        raise ValueError("Need to supply a list of values to process.")
+    if values == []:
+        raise ValueError("Cannot process 0 samples.")
+
+
+def _validate_sequence_elements(elt: Sequence) -> None:
+    """Validate the nested structure of a sequence element.
+
+    Args:
+        elt: The first element of the values list (must be a ``Sequence``).
+
+    Raises:
+        ValueError: If the nested structure contains bad types.
+    """
+
+    if elt == []:
+        raise ValueError("Cannot process list of empty lists.")
+
+    if not isinstance(elt[0], (float, complex, list)):
+        raise ValueError(f"Cannot process list of lists of {type(elt[0])}.")
+
+    if isinstance(elt[0], list):
+        if len(elt[0]) == 0:
+            raise ValueError(
+                "Cannot process list of matrices with empty columns."
+            )
+        if not isinstance(elt[0][0], (float, complex)):
+            raise ValueError(
+                f"Cannot process list of matrices of {type(elt[0][0])}."
+            )
+
+
 def _std_aggregator(
     values: list[T],
 ) -> T:
@@ -48,10 +91,7 @@ def _std_aggregator(
     Returns:
         The standard deviation over the first dimension of the given values.
     """
-    if not isinstance(values, list):
-        raise ValueError("Need to supply a list of values to process.")
-    if values == []:
-        raise ValueError("Cannot process 0 samples.")
+    _validate_values(values)
 
     elt = values[0]
 
@@ -65,6 +105,7 @@ def _std_aggregator(
         return cast(
             float, np.std(values, ddof=1)
         )  # this would have type np.floating
+
     if isinstance(elt, complex):
         return cast(
             complex, np.std(values, ddof=1)
@@ -73,22 +114,8 @@ def _std_aggregator(
     if not isinstance(elt, Sequence):
         raise ValueError("Cannot process this type of data.")
 
-    if values[0] == []:
-        raise ValueError("Cannot process list of empty lists.")
+    _validate_sequence_elements(elt)
 
-    if isinstance(elt[0], (float, complex)):
-        return list(np.std(values, axis=0, ddof=1).tolist())
-
-    if not isinstance(elt[0], list):
-        raise ValueError(f"Cannot process list of lists of {type(elt[0])}.")
-
-    if len(elt[0]) == 0:
-        raise ValueError("Cannot process list of matrices with empty columns.")
-
-    if not isinstance(elt[0][0], (float, complex)):
-        raise ValueError(
-            f"Cannot process list of matrices of {type(elt[0][0])}."
-        )
     return list(np.std(values, axis=0, ddof=1).tolist())
 
 
@@ -105,10 +132,7 @@ def _mean_aggregator(
     Returns:
         The average over the first dimension of the provided results.
     """
-    if not isinstance(values, list):
-        raise ValueError("Need to supply a list of values to average.")
-    if values == []:
-        raise ValueError("Cannot average 0 samples.")
+    _validate_values(values)
 
     elt = values[0]
 
@@ -120,30 +144,17 @@ def _mean_aggregator(
 
     if isinstance(elt, float):
         return cast(float, np.mean(values))  # this would have type np.floating
+
     if isinstance(elt, complex):
         return cast(
             complex, np.mean(values)
         )  # this would have type np.complexfloating
 
     if not isinstance(elt, Sequence):
-        raise ValueError("Cannot average this type of data.")
+        raise ValueError("Cannot process this type of data.")
 
-    if values[0] == []:
-        raise ValueError("Cannot average list of empty lists.")
+    _validate_sequence_elements(elt)
 
-    if isinstance(elt[0], (float, complex)):
-        return list(np.mean(values, axis=0).tolist())
-
-    if not isinstance(elt[0], list):
-        raise ValueError(f"Cannot average list of lists of {type(elt[0])}.")
-
-    if len(elt[0]) == 0:
-        raise ValueError("Cannot average list of matrices with empty columns.")
-
-    if not isinstance(elt[0][0], (float, complex)):
-        raise ValueError(
-            f"Cannot average list of matrices of {type(elt[0][0])}."
-        )
     return list(np.mean(values, axis=0).tolist())
 
 

--- a/pulser-core/pulser/backend/default_observables.py
+++ b/pulser-core/pulser/backend/default_observables.py
@@ -472,11 +472,11 @@ class EnergyVariance(Observable):
 class EnergySecondMoment(Observable):
     """Stores the expectation value of ``H(t)^2`` at the evaluation times.
 
-    Useful for computing the variance when averaging over many executions of
-    the program.
+    Together with the mean, this can be used to compute the variance
+    when averaging over many executions of the program.
 
     Args:
-        evaluation_times: The relative times at which to compute the variance.
+        evaluation_times: The relative times at which to compute the moment.
             If left as `None`, uses the ``default_evaluation_times`` of the
             backend's ``EmulationConfig``.
         tag_suffix: An optional suffix to append to the tag. Needed if

--- a/pulser-core/pulser/backend/default_observables.py
+++ b/pulser-core/pulser/backend/default_observables.py
@@ -354,7 +354,7 @@ class Occupation(Observable):
 
     Args:
         evaluation_times: The relative times at which to compute the
-            correlation matrix. If left as ``None``, uses the
+            occupation. If left as ``None``, uses the
             ``default_evaluation_times`` of the backend's ``EmulationConfig``.
         one_state: The eigenstate to measure the population of. Can be left
             undefined if the state's eigenstates form a known eigenbasis with

--- a/pulser-core/pulser/backend/observable.py
+++ b/pulser-core/pulser/backend/observable.py
@@ -77,6 +77,8 @@ class AggregationMethod(IntEnum):
     SKIP_WARN = 1
     MEAN = 2
     BAG_UNION = 3
+    STD = 4
+    MEANSTD = 5
 
 
 class Observable(Callback):

--- a/pulser-core/pulser/backend/observable.py
+++ b/pulser-core/pulser/backend/observable.py
@@ -83,8 +83,7 @@ class AggregationMethod(IntEnum):
     SKIP_WARN = 1
     MEAN = 2
     BAG_UNION = 3
-    STD = 4
-    MEANSTD = 5
+    MEANSTD = 4
 
 
 class Observable(Callback):

--- a/pulser-core/pulser/backend/results.py
+++ b/pulser-core/pulser/backend/results.py
@@ -263,7 +263,7 @@ class Results:
     def aggregate(
         cls,
         results_to_aggregate: typing.Sequence[Results],
-        **aggregation_functions: Callable[[Any], Any],
+        **aggregation_functions: Callable[[Any], Any] | AggregationMethod,
     ) -> Results:
         """Aggregate a Sequence of Results objects into a single Results.
 
@@ -286,7 +286,8 @@ class Results:
         Keyword Args:
             observable_tag: Overrides the default aggregator.
                 The argument name should be the tag of the Observable.
-                The value is a Callable taking a list of the type to aggregate.
+                The value is a Callable taking a list of the type to aggregate,
+                or an AggregationMethod enum.
                 Note that this does not override the default aggregation
                 behaviour of the aggregated results.
 

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -1,9 +1,15 @@
 from collections import Counter
+from unittest.mock import patch
 
 import numpy as np
 import pytest
 
-from pulser.backend.aggregators import _bag_union_aggregator, _mean_aggregator
+from pulser.backend.aggregators import (
+    _bag_union_aggregator,
+    _mean_aggregator,
+    _mean_std_aggregator,
+    _std_aggregator,
+)
 
 
 def test_bag_union():
@@ -80,3 +86,83 @@ def test__mean_aggregator_errors():
         ValueError, match="Cannot average list of matrices with empty columns."
     ):
         _mean_aggregator([[[]], [[]]])
+
+
+@pytest.mark.parametrize(
+    "test_torch",
+    [True, False],
+)
+def test__std_aggregator(test_torch: bool):
+    input = [1.0, 2.0, 3.0, 4.0]
+    assert np.isclose(_std_aggregator(input), 1.2909944487358056)
+
+    input2 = [1.0j, 2.0j, 3.0j, 4.0j]
+    assert np.isclose(_std_aggregator(input2), 1.2909944487358056)
+
+    input3 = [
+        np.array([1.0, 2.0, 3.0]),
+        np.array([2.0, 3.0, 4.0]),
+        np.array([3.0, 4.0, 5.0]),
+    ]
+    assert np.all(_std_aggregator(input3) == np.array([1.0, 1.0, 1.0]))
+
+    input4 = [[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [3.0, 4.0, 5.0]]
+    assert _std_aggregator(input4) == [1.0, 1.0, 1.0]
+
+    input5 = [[[1.0, 2.0, 3.0]], [[2.0, 3.0, 4.0]], [[3.0, 4.0, 5.0]]]
+    assert _std_aggregator(input5) == [[1.0, 1.0, 1.0]]
+    if test_torch:
+        torch = pytest.importorskip("torch")
+        input6 = [
+            torch.tensor([1.0, 2.0, 3.0]),
+            torch.tensor([2.0, 3.0, 4.0]),
+            torch.tensor([3.0, 4.0, 5.0]),
+        ]
+        assert torch.allclose(
+            _std_aggregator(input6), torch.tensor([1.0, 1.0, 1.0])
+        )
+
+
+def test__std_aggregator_errors():
+    with pytest.raises(ValueError, match="Cannot process 0 samples."):
+        _std_aggregator([])
+
+    with pytest.raises(
+        ValueError, match="Cannot process list of empty lists."
+    ):
+        _std_aggregator([[], []])
+
+    with pytest.raises(
+        ValueError, match="Need to supply a list of values to process."
+    ):
+        _std_aggregator("abcd")
+
+    with pytest.raises(ValueError, match="Cannot process this type of data."):
+        _std_aggregator([{}, {}])
+
+    with pytest.raises(
+        ValueError, match=f"Cannot process list of lists of {type({})}."
+    ):
+        _std_aggregator([[{}], [{}]])
+
+    with pytest.raises(
+        ValueError, match=f"Cannot process list of matrices of {type('a')}."
+    ):
+        _std_aggregator([[["abcd"]], [["efgh"]]])
+
+    with pytest.raises(
+        ValueError, match="Cannot process list of matrices with empty columns."
+    ):
+        _std_aggregator([[[]], [[]]])
+
+
+def test__mean_std_aggregator():
+    with patch("pulser.backend.aggregators._mean_aggregator") as mock_mean:
+        with patch("pulser.backend.aggregators._std_aggregator") as mock_std:
+            mock_mean.return_value = 5.5
+            mock_std.return_value = 6.5
+            input = [1000.0, 2000.0]
+            result = _mean_std_aggregator(input)
+            mock_mean.assert_called_once_with(input)
+            mock_std.assert_called_once_with(input)
+            assert result == (5.5, 6.5)

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -56,34 +56,34 @@ def test__mean_aggregator(test_torch: bool):
 
 
 def test__mean_aggregator_errors():
-    with pytest.raises(ValueError, match="Cannot average 0 samples."):
+    with pytest.raises(ValueError, match="Cannot process 0 samples."):
         _mean_aggregator([])
 
     with pytest.raises(
-        ValueError, match="Cannot average list of empty lists."
+        ValueError, match="Cannot process list of empty lists."
     ):
         _mean_aggregator([[], []])
 
     with pytest.raises(
-        ValueError, match="Need to supply a list of values to average."
+        ValueError, match="Need to supply a list of values to process."
     ):
         _mean_aggregator("abcd")
 
-    with pytest.raises(ValueError, match="Cannot average this type of data."):
+    with pytest.raises(ValueError, match="Cannot process this type of data."):
         _mean_aggregator([{}, {}])
 
     with pytest.raises(
-        ValueError, match=f"Cannot average list of lists of {type({})}."
+        ValueError, match=f"Cannot process list of lists of {type({})}."
     ):
         _mean_aggregator([[{}], [{}]])
 
     with pytest.raises(
-        ValueError, match=f"Cannot average list of matrices of {type('a')}."
+        ValueError, match=f"Cannot process list of matrices of {type('a')}."
     ):
         _mean_aggregator([[["abcd"]], [["efgh"]]])
 
     with pytest.raises(
-        ValueError, match="Cannot average list of matrices with empty columns."
+        ValueError, match="Cannot process list of matrices with empty columns."
     ):
         _mean_aggregator([[[]], [[]]])
 

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -69,7 +69,9 @@ def test__mean_aggregator_errors():
     ):
         _mean_aggregator("abcd")
 
-    with pytest.raises(ValueError, match="Cannot process this type of data."):
+    with pytest.raises(
+        ValueError, match="Mean aggregator cannot process data"
+    ):
         _mean_aggregator([{}, {}])
 
     with pytest.raises(
@@ -137,7 +139,7 @@ def test__std_aggregator_errors():
     ):
         _std_aggregator("abcd")
 
-    with pytest.raises(ValueError, match="Cannot process this type of data."):
+    with pytest.raises(ValueError, match="Std aggregator cannot process data"):
         _std_aggregator([{}, {}])
 
     with pytest.raises(

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -854,6 +854,7 @@ def test_results_aggregation(matching_uuids):
         agg = Results.aggregate([results1, results2])
         mock_aggregator.__getitem__.assert_called_once_with(agg_type)
     agg2 = Results.aggregate([results1, results2], dummy_result=aggregator)
+
     assert (
         i == 4
     )  # twice in agg, twice in agg2, once each for the 2 results added above.
@@ -867,6 +868,11 @@ def test_results_aggregation(matching_uuids):
         assert ag.dummy_result == [2.0, 3.0]
 
     assert Results.aggregate([results1]) is results1
+
+    agg3 = Results.aggregate(
+        [results1, results2], dummy_result=AggregationMethod.MEANSTD
+    )
+    assert all(map(lambda x: isinstance(x, tuple), agg3.dummy_result))
 
 
 def test_results_aggregation_errors(caplog):


### PR DESCRIPTION
I've added inbuilt aggregation functions for the sample standard deviation of the list of results, and for a tuple containing both the mean and the std. I've also added tests.

To make the new functions easier to use, I've widened the supported types for `aggregation_functions`  in `Results.aggregate`. Before it was only a `Callable` but now it also takes the existing `AggregationMethod` enum. This makes it easier to use the added aggregation functions to override the default behaviour.

Closes #1026