### PR TITLE
Deprecate "interp1d" option and `interpolator_kwargs` in `InterpolatedWaveform`

### DIFF
--- a/pulser-core/pulser/waveforms.py
+++ b/pulser-core/pulser/waveforms.py
@@ -858,8 +858,15 @@ class InterpolatedWaveform(Waveform):
             duration of the waveform.
         interpolator: The SciPy interpolation class
             to use. Supports "PchipInterpolator" and "interp1d".
+
+            *Passing "interp1d" is deprecated since pulser v1.9 and will be
+            removed in a future version; only "PchipInterpolator" (the
+            default) will remain supported.*
         **interpolator_kwargs: Extra parameters to give to the chosen
             interpolator class.
+
+            *Deprecated since pulser v1.9; extra keyword arguments for the
+            interpolator will no longer be accepted in a future version.*
     """
 
     def __new__(cls, *args, **kwargs):  # type: ignore
@@ -897,6 +904,23 @@ class InterpolatedWaveform(Waveform):
             raise ValueError(
                 f"Invalid interpolator '{interpolator}', only "
                 "accepts: " + ", ".join(valid_interpolators)
+            )
+        if interpolator == "interp1d":
+            warnings.warn(
+                "Setting 'interpolator' to \"interp1d\" has been deprecated "
+                "since pulser v1.9 and will be removed in a future version. "
+                "Only 'PchipInterpolator' (the default) will remain "
+                "supported.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if interpolator_kwargs:
+            warnings.warn(
+                "Passing extra keyword arguments to configure the SciPy "
+                "interpolator has been deprecated since pulser v1.9 and will "
+                "be removed in a future version.",
+                DeprecationWarning,
+                stacklevel=2,
             )
         interp_cls = getattr(interpolate, interpolator)
         self._data_pts = np.array(

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -997,7 +997,9 @@ class TestSerialization:
         ):
             Register({"0": (0, 0), 0: (20, 20)})._to_abstract_repr()
 
-        with pytest.raises(
+        with pytest.deprecated_call(
+            match="Setting 'interpolator' to \"interp1d\"",
+        ), pytest.raises(
             AbstractReprError,
             match="Export of an InterpolatedWaveform is only supported for the"
             " 'PchipInterpolator'",
@@ -1006,7 +1008,9 @@ class TestSerialization:
                 1000, [0, 1, 0], interpolator="interp1d"
             )._to_abstract_repr()
 
-        with pytest.raises(
+        with pytest.deprecated_call(
+            match="Passing extra keyword arguments to configure the SciPy",
+        ), pytest.raises(
             AbstractReprError, match="without any 'interpolator_kwargs'"
         ):
             InterpolatedWaveform(

--- a/tests/test_waveforms.py
+++ b/tests/test_waveforms.py
@@ -235,34 +235,6 @@ def test_interpolated():
             1000, interp_values, times=times, interpolator="fake"
         )
 
-    dt = 1000
-    interp_wf = InterpolatedWaveform(
-        dt, [0, 1], interpolator="interp1d", kind="linear"
-    )
-    assert isinstance(interp_wf.interp_function, interp1d)
-    np.testing.assert_allclose(
-        interp_wf.samples.as_array(), np.linspace(0, 1.0, num=dt)
-    )
-
-    interp_wf *= 2
-    np.testing.assert_allclose(
-        interp_wf.samples.as_array(), np.linspace(0, 2.0, num=dt)
-    )
-
-    wf_str = "InterpolatedWaveform(Points: (0, 0), (999, 2)"
-    assert str(interp_wf) == wf_str + ")"
-    assert repr(interp_wf) == wf_str + ", Interpolator=interp1d)"
-
-    vals = np.linspace(0, 1, num=5) ** 2
-    interp_wf2 = InterpolatedWaveform(
-        dt, vals, interpolator="interp1d", kind="quadratic"
-    )
-    np.testing.assert_allclose(
-        interp_wf2.samples.as_array(),
-        np.linspace(0, 1, num=dt) ** 2,
-        atol=1e-3,
-    )
-
     # Test rounding when range of values is large
     wf = InterpolatedWaveform(
         1000, times=[0.0, 0.5, 1.0], values=[0, 2.6e7, 0]
@@ -323,6 +295,54 @@ def test_interpolated():
     interpolated_wf = InterpolatedWaveform(60.0, [0.0, 0.5, max_amp, 0.5, 0.0])
     assert np.all(interpolated_wf.samples.as_array() <= max_amp)
     assert np.all(interpolated_wf.samples.as_array() >= 0)
+
+
+def test_deprecated_interp1d_interpolator():
+    dt = 1000
+    with pytest.deprecated_call(
+        match="Setting 'interpolator' to \"interp1d\""
+    ):
+        interp_wf = InterpolatedWaveform(dt, [0, 1], interpolator="interp1d")
+    assert isinstance(interp_wf.interp_function, interp1d)
+    np.testing.assert_allclose(
+        interp_wf.samples.as_array(), np.linspace(0, 1.0, num=dt)
+    )
+
+    # __mul__ reconstructs the waveform, so it re-emits the warning
+    with pytest.deprecated_call(
+        match="Setting 'interpolator' to \"interp1d\""
+    ):
+        interp_wf *= 2
+    np.testing.assert_allclose(
+        interp_wf.samples.as_array(), np.linspace(0, 2.0, num=dt)
+    )
+
+    wf_str = "InterpolatedWaveform(Points: (0, 0), (999, 2)"
+    assert str(interp_wf) == wf_str + ")"
+    assert repr(interp_wf) == wf_str + ", Interpolator=interp1d)"
+
+
+def test_deprecated_interpolator_kwargs():
+    with pytest.deprecated_call(
+        match="Passing extra keyword arguments to configure the SciPy"
+    ):
+        InterpolatedWaveform(1000, [0, 1, 0], extrapolate=False)
+
+    # Passing "interp1d" together with extra kwargs emits both warnings
+    dt = 1000
+    vals = np.linspace(0, 1, num=5) ** 2
+    with pytest.warns(DeprecationWarning) as record:
+        interp_wf = InterpolatedWaveform(
+            dt, vals, interpolator="interp1d", kind="quadratic"
+        )
+    messages = [str(w.message) for w in record]
+    assert any('"interp1d"' in m for m in messages)
+    assert any("extra keyword arguments" in m for m in messages)
+    np.testing.assert_allclose(
+        interp_wf.samples.as_array(),
+        np.linspace(0, 1, num=dt) ** 2,
+        atol=1e-3,
+    )
 
 
 def test_kaiser():

--- a/tutorials/advanced_features/Interpolated Waveforms.ipynb
+++ b/tutorials/advanced_features/Interpolated Waveforms.ipynb
@@ -73,46 +73,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The other crucial component is the `interpolator`. Currently, the class supports two interpolator classes from the `scipy.interpolate` module: `PchipInterpolator` (chosen by default) and `interp1d`. Below, we change the interpolator to `interp1d`, which does a linear interpolation by default:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "int_wf2 = InterpolatedWaveform(duration, values, interpolator=\"interp1d\")\n",
-    "int_wf2.draw()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "One can also change the optional parameters of the chosen interpolator by giving them to `InterpolatedWaveform`. For example, the interpolation with `interp1d` can be cubic instead of linear by changing the `kind` parameter.\n",
-    "\n",
-    "Naturally, the choice of interpolator will dictate which extra parameters can be optionally provided. As such, one must refer to the chosen interpolator's documentation for the specific details."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "int_wf3 = InterpolatedWaveform(\n",
-    "    duration, values, interpolator=\"interp1d\", kind=\"cubic\"\n",
-    ")\n",
-    "int_wf3.draw()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Finally, an `InterpolatedWaveform` can be streched or contracted in both magnitude and duration: "
    ]
   },
@@ -165,9 +125,7 @@
     "det_vals = param_seq.declare_variable(\"det_vals\", size=4, dtype=float)\n",
     "\n",
     "amp_wf = InterpolatedWaveform(1000, amp_vals)\n",
-    "det_wf = InterpolatedWaveform(\n",
-    "    1000, det_vals, interpolator=\"interp1d\", kind=\"cubic\"\n",
-    ")\n",
+    "det_wf = InterpolatedWaveform(1000, det_vals)\n",
     "pls = Pulse(amp_wf, det_wf, 0)\n",
     "\n",
     "param_seq.add(pls, \"rydberg_global\")"


### PR DESCRIPTION
Closes #1052 