### PR TITLE
Let the user override the default aggregation method in an Observable

### DIFF
--- a/pulser-core/pulser/backend/default_observables.py
+++ b/pulser-core/pulser/backend/default_observables.py
@@ -40,8 +40,8 @@ class StateResult(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
-        aggregation_method: How to combine the values of this observable
-            from multiple results.
+        default_aggregation_method: How to combine the values of this
+            observable from multiple results.
     """
 
     def __init__(
@@ -49,13 +49,14 @@ class StateResult(Observable):
         *,
         evaluation_times: Sequence[float] | None = None,
         tag_suffix: str | None = None,
-        aggregation_method: AggregationMethod = AggregationMethod.SKIP_WARN,
+        default_aggregation_method: AggregationMethod
+            = AggregationMethod.SKIP_WARN,  # fmt: skip
     ):
         """Initializes the observable."""
         super().__init__(
             evaluation_times=evaluation_times,
             tag_suffix=tag_suffix,
-            aggregation_method=aggregation_method,
+            default_aggregation_method=default_aggregation_method,
         )
 
     @property
@@ -95,8 +96,8 @@ class BitStrings(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
-        aggregation_method: How to combine the values of this observable
-            from multiple results.
+        default_aggregation_method: How to combine the values of this
+            observable from multiple results.
     """
 
     def __init__(
@@ -106,13 +107,14 @@ class BitStrings(Observable):
         num_shots: int | None = None,
         one_state: Eigenstate | None = None,
         tag_suffix: str | None = None,
-        aggregation_method: AggregationMethod = AggregationMethod.BAG_UNION,
+        default_aggregation_method: AggregationMethod
+            = AggregationMethod.BAG_UNION,  # fmt: skip
     ):
         """Initializes the observable."""
         super().__init__(
             evaluation_times=evaluation_times,
             tag_suffix=tag_suffix,
-            aggregation_method=aggregation_method,
+            default_aggregation_method=default_aggregation_method,
         )
         # Relies on the validation in the setter
         self.num_shots = num_shots
@@ -197,8 +199,8 @@ class Fidelity(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
-        aggregation_method: How to combine the values of this observable
-            from multiple results.
+        default_aggregation_method: How to combine the values of this
+            observable from multiple results.
     """
 
     def __init__(
@@ -207,13 +209,13 @@ class Fidelity(Observable):
         *,
         evaluation_times: Sequence[float] | None = None,
         tag_suffix: str | None = None,
-        aggregation_method: AggregationMethod = AggregationMethod.MEAN,
+        default_aggregation_method: AggregationMethod = AggregationMethod.MEAN,
     ):
         """Initializes the observable."""
         super().__init__(
             evaluation_times=evaluation_times,
             tag_suffix=tag_suffix,
-            aggregation_method=aggregation_method,
+            default_aggregation_method=default_aggregation_method,
         )
         if not isinstance(state, State):
             raise TypeError(
@@ -247,8 +249,8 @@ class Expectation(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
-        aggregation_method: How to combine the values of this observable
-            from multiple results.
+        default_aggregation_method: How to combine the values of this
+            observable from multiple results.
     """
 
     def __init__(
@@ -257,13 +259,13 @@ class Expectation(Observable):
         *,
         evaluation_times: Sequence[float] | None = None,
         tag_suffix: str | None = None,
-        aggregation_method: AggregationMethod = AggregationMethod.MEAN,
+        default_aggregation_method: AggregationMethod = AggregationMethod.MEAN,
     ):
         """Initializes the observable."""
         super().__init__(
             evaluation_times=evaluation_times,
             tag_suffix=tag_suffix,
-            aggregation_method=aggregation_method,
+            default_aggregation_method=default_aggregation_method,
         )
         if not isinstance(operator, Operator):
             raise TypeError(
@@ -303,8 +305,8 @@ class CorrelationMatrix(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
-        aggregation_method: How to combine the values of this observable
-            from multiple results.
+        default_aggregation_method: How to combine the values of this
+            observable from multiple results.
     """
 
     def __init__(
@@ -313,13 +315,13 @@ class CorrelationMatrix(Observable):
         evaluation_times: Sequence[float] | None = None,
         one_state: Eigenstate | None = None,
         tag_suffix: str | None = None,
-        aggregation_method: AggregationMethod = AggregationMethod.MEAN,
+        default_aggregation_method: AggregationMethod = AggregationMethod.MEAN,
     ):
         """Initializes the observable."""
         super().__init__(
             evaluation_times=evaluation_times,
             tag_suffix=tag_suffix,
-            aggregation_method=aggregation_method,
+            default_aggregation_method=default_aggregation_method,
         )
         self.one_state = one_state
 
@@ -388,8 +390,8 @@ class Occupation(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
-        aggregation_method: How to combine the values of this observable
-            from multiple results.
+        default_aggregation_method: How to combine the values of this
+            observable from multiple results.
     """
 
     def __init__(
@@ -398,13 +400,13 @@ class Occupation(Observable):
         evaluation_times: Sequence[float] | None = None,
         one_state: Eigenstate | None = None,
         tag_suffix: str | None = None,
-        aggregation_method: AggregationMethod = AggregationMethod.MEAN,
+        default_aggregation_method: AggregationMethod = AggregationMethod.MEAN,
     ):
         """Initializes the observable."""
         super().__init__(
             evaluation_times=evaluation_times,
             tag_suffix=tag_suffix,
-            aggregation_method=aggregation_method,
+            default_aggregation_method=default_aggregation_method,
         )
         self.one_state = one_state
 
@@ -446,8 +448,8 @@ class Energy(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
-        aggregation_method: How to combine the values of this observable
-            from multiple results.
+        default_aggregation_method: How to combine the values of this
+         observable from multiple results.
     """
 
     def __init__(
@@ -455,13 +457,13 @@ class Energy(Observable):
         *,
         evaluation_times: Sequence[float] | None = None,
         tag_suffix: str | None = None,
-        aggregation_method: AggregationMethod = AggregationMethod.MEAN,
+        default_aggregation_method: AggregationMethod = AggregationMethod.MEAN,
     ):
         """Initializes the observable."""
         super().__init__(
             evaluation_times=evaluation_times,
             tag_suffix=tag_suffix,
-            aggregation_method=aggregation_method,
+            default_aggregation_method=default_aggregation_method,
         )
 
     @property
@@ -489,8 +491,8 @@ class EnergyVariance(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
-        aggregation_method: How to combine the values of this observable
-            from multiple results.
+        default_aggregation_method: How to combine the values of this
+            observable from multiple results.
     """
 
     def __init__(
@@ -498,13 +500,14 @@ class EnergyVariance(Observable):
         *,
         evaluation_times: Sequence[float] | None = None,
         tag_suffix: str | None = None,
-        aggregation_method: AggregationMethod = AggregationMethod.SKIP_WARN,
+        default_aggregation_method: AggregationMethod
+            = AggregationMethod.SKIP_WARN,  # fmt: skip
     ):
         """Initializes the observable."""
         super().__init__(
             evaluation_times=evaluation_times,
             tag_suffix=tag_suffix,
-            aggregation_method=aggregation_method,
+            default_aggregation_method=default_aggregation_method,
         )
 
     @property
@@ -539,8 +542,8 @@ class EnergySecondMoment(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
-        aggregation_method: How to combine the values of this observable
-            from multiple results.
+        default_aggregation_method: How to combine the values of this
+            observable from multiple results.
     """
 
     def __init__(
@@ -548,13 +551,13 @@ class EnergySecondMoment(Observable):
         *,
         evaluation_times: Sequence[float] | None = None,
         tag_suffix: str | None = None,
-        aggregation_method: AggregationMethod = AggregationMethod.MEAN,
+        default_aggregation_method: AggregationMethod = AggregationMethod.MEAN,
     ):
         """Initializes the observable."""
         super().__init__(
             evaluation_times=evaluation_times,
             tag_suffix=tag_suffix,
-            aggregation_method=aggregation_method,
+            default_aggregation_method=default_aggregation_method,
         )
 
     @property

--- a/pulser-core/pulser/backend/default_observables.py
+++ b/pulser-core/pulser/backend/default_observables.py
@@ -40,7 +40,23 @@ class StateResult(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
+        aggregation_method: How to combine the values of this observable
+            from multiple results.
     """
+
+    def __init__(
+        self,
+        *,
+        evaluation_times: Sequence[float] | None = None,
+        tag_suffix: str | None = None,
+        aggregation_method: AggregationMethod = AggregationMethod.SKIP_WARN,
+    ):
+        """Initializes the observable."""
+        super().__init__(
+            evaluation_times=evaluation_times,
+            tag_suffix=tag_suffix,
+            aggregation_method=aggregation_method,
+        )
 
     @property
     def _base_tag(self) -> str:
@@ -57,8 +73,6 @@ class StateResult(Observable):
     def apply(self, *, state: StateType, **kwargs: Any) -> StateType:
         """Calculates the observable to store in the Results."""
         return copy.deepcopy(state)
-
-    default_aggregation_method = AggregationMethod.SKIP_WARN
 
 
 class BitStrings(Observable):
@@ -81,6 +95,8 @@ class BitStrings(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
+        aggregation_method: How to combine the values of this observable
+            from multiple results.
     """
 
     def __init__(
@@ -90,10 +106,13 @@ class BitStrings(Observable):
         num_shots: int | None = None,
         one_state: Eigenstate | None = None,
         tag_suffix: str | None = None,
+        aggregation_method: AggregationMethod = AggregationMethod.BAG_UNION,
     ):
         """Initializes the observable."""
         super().__init__(
-            evaluation_times=evaluation_times, tag_suffix=tag_suffix
+            evaluation_times=evaluation_times,
+            tag_suffix=tag_suffix,
+            aggregation_method=aggregation_method,
         )
         # Relies on the validation in the setter
         self.num_shots = num_shots
@@ -160,8 +179,6 @@ class BitStrings(Observable):
             p_false_neg=config.noise_model.p_false_neg,
         )
 
-    default_aggregation_method = AggregationMethod.BAG_UNION
-
 
 class Fidelity(Observable):
     """Stores the fidelity with a pure state at the evaluation times.
@@ -180,6 +197,8 @@ class Fidelity(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
+        aggregation_method: How to combine the values of this observable
+            from multiple results.
     """
 
     def __init__(
@@ -188,10 +207,13 @@ class Fidelity(Observable):
         *,
         evaluation_times: Sequence[float] | None = None,
         tag_suffix: str | None = None,
+        aggregation_method: AggregationMethod = AggregationMethod.MEAN,
     ):
         """Initializes the observable."""
         super().__init__(
-            evaluation_times=evaluation_times, tag_suffix=tag_suffix
+            evaluation_times=evaluation_times,
+            tag_suffix=tag_suffix,
+            aggregation_method=aggregation_method,
         )
         if not isinstance(state, State):
             raise TypeError(
@@ -212,8 +234,6 @@ class Fidelity(Observable):
         """Calculates the observable to store in the Results."""
         return self.state.overlap(state)
 
-    default_aggregation_method = AggregationMethod.MEAN
-
 
 class Expectation(Observable):
     """Stores the expectation of the given operator on the current state.
@@ -227,6 +247,8 @@ class Expectation(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
+        aggregation_method: How to combine the values of this observable
+            from multiple results.
     """
 
     def __init__(
@@ -235,10 +257,13 @@ class Expectation(Observable):
         *,
         evaluation_times: Sequence[float] | None = None,
         tag_suffix: str | None = None,
+        aggregation_method: AggregationMethod = AggregationMethod.MEAN,
     ):
         """Initializes the observable."""
         super().__init__(
-            evaluation_times=evaluation_times, tag_suffix=tag_suffix
+            evaluation_times=evaluation_times,
+            tag_suffix=tag_suffix,
+            aggregation_method=aggregation_method,
         )
         if not isinstance(operator, Operator):
             raise TypeError(
@@ -260,8 +285,6 @@ class Expectation(Observable):
         """Calculates the observable to store in the Results."""
         return self.operator.expect(state)
 
-    default_aggregation_method = AggregationMethod.MEAN
-
 
 class CorrelationMatrix(Observable):
     """Stores the correlation matrix for the current state.
@@ -280,6 +303,8 @@ class CorrelationMatrix(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
+        aggregation_method: How to combine the values of this observable
+            from multiple results.
     """
 
     def __init__(
@@ -288,10 +313,13 @@ class CorrelationMatrix(Observable):
         evaluation_times: Sequence[float] | None = None,
         one_state: Eigenstate | None = None,
         tag_suffix: str | None = None,
+        aggregation_method: AggregationMethod = AggregationMethod.MEAN,
     ):
         """Initializes the observable."""
         super().__init__(
-            evaluation_times=evaluation_times, tag_suffix=tag_suffix
+            evaluation_times=evaluation_times,
+            tag_suffix=tag_suffix,
+            aggregation_method=aggregation_method,
         )
         self.one_state = one_state
 
@@ -343,8 +371,6 @@ class CorrelationMatrix(Observable):
             for i in range(state.n_qudits)
         ]
 
-    default_aggregation_method = AggregationMethod.MEAN
-
 
 class Occupation(Observable):
     """Stores the occupation number of an eigenstate on each qudit.
@@ -362,6 +388,8 @@ class Occupation(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
+        aggregation_method: How to combine the values of this observable
+            from multiple results.
     """
 
     def __init__(
@@ -370,10 +398,13 @@ class Occupation(Observable):
         evaluation_times: Sequence[float] | None = None,
         one_state: Eigenstate | None = None,
         tag_suffix: str | None = None,
+        aggregation_method: AggregationMethod = AggregationMethod.MEAN,
     ):
         """Initializes the observable."""
         super().__init__(
-            evaluation_times=evaluation_times, tag_suffix=tag_suffix
+            evaluation_times=evaluation_times,
+            tag_suffix=tag_suffix,
+            aggregation_method=aggregation_method,
         )
         self.one_state = one_state
 
@@ -401,8 +432,6 @@ class Occupation(Observable):
             for i in range(state.n_qudits)
         ]
 
-    default_aggregation_method = AggregationMethod.MEAN
-
 
 class Energy(Observable):
     """Stores the energy of the system at the evaluation times.
@@ -417,7 +446,23 @@ class Energy(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
+        aggregation_method: How to combine the values of this observable
+            from multiple results.
     """
+
+    def __init__(
+        self,
+        *,
+        evaluation_times: Sequence[float] | None = None,
+        tag_suffix: str | None = None,
+        aggregation_method: AggregationMethod = AggregationMethod.MEAN,
+    ):
+        """Initializes the observable."""
+        super().__init__(
+            evaluation_times=evaluation_times,
+            tag_suffix=tag_suffix,
+            aggregation_method=aggregation_method,
+        )
 
     @property
     def _base_tag(self) -> str:
@@ -428,8 +473,6 @@ class Energy(Observable):
     ) -> Any:
         """Calculates the observable to store in the Results."""
         return hamiltonian.expect(state)
-
-    default_aggregation_method = AggregationMethod.MEAN
 
 
 class EnergyVariance(Observable):
@@ -446,7 +489,23 @@ class EnergyVariance(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
+        aggregation_method: How to combine the values of this observable
+            from multiple results.
     """
+
+    def __init__(
+        self,
+        *,
+        evaluation_times: Sequence[float] | None = None,
+        tag_suffix: str | None = None,
+        aggregation_method: AggregationMethod = AggregationMethod.SKIP_WARN,
+    ):
+        """Initializes the observable."""
+        super().__init__(
+            evaluation_times=evaluation_times,
+            tag_suffix=tag_suffix,
+            aggregation_method=aggregation_method,
+        )
 
     @property
     def _base_tag(self) -> str:
@@ -466,8 +525,6 @@ class EnergyVariance(Observable):
         )
         return identity.expect(h_state) - hamiltonian.expect(state) ** 2
 
-    default_aggregation_method = AggregationMethod.SKIP_WARN
-
 
 class EnergySecondMoment(Observable):
     """Stores the expectation value of ``H(t)^2`` at the evaluation times.
@@ -482,7 +539,23 @@ class EnergySecondMoment(Observable):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
+        aggregation_method: How to combine the values of this observable
+            from multiple results.
     """
+
+    def __init__(
+        self,
+        *,
+        evaluation_times: Sequence[float] | None = None,
+        tag_suffix: str | None = None,
+        aggregation_method: AggregationMethod = AggregationMethod.MEAN,
+    ):
+        """Initializes the observable."""
+        super().__init__(
+            evaluation_times=evaluation_times,
+            tag_suffix=tag_suffix,
+            aggregation_method=aggregation_method,
+        )
 
     @property
     def _base_tag(self) -> str:
@@ -501,5 +574,3 @@ class EnergySecondMoment(Observable):
             operations=[(1.0, [])],
         )
         return identity.expect(h_state)
-
-    default_aggregation_method = AggregationMethod.MEAN

--- a/pulser-core/pulser/backend/observable.py
+++ b/pulser-core/pulser/backend/observable.py
@@ -95,8 +95,8 @@ class Observable(Callback):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
-        aggregation_method: How to combine the values of this observable
-            from multiple results.
+        default_aggregation_method: How to combine the values of this
+            observable from multiple results.
     """
 
     evaluation_times: NDArray[np.floating[Any]] | None
@@ -104,7 +104,7 @@ class Observable(Callback):
     def __init__(
         self,
         *,
-        aggregation_method: AggregationMethod,
+        default_aggregation_method: AggregationMethod,
         evaluation_times: Sequence[float] | None = None,
         tag_suffix: str | None = None,
     ):
@@ -116,12 +116,12 @@ class Observable(Callback):
             else None
         )
         self._tag_suffix = tag_suffix
-        self._aggregation_method = aggregation_method
+        self._default_aggregation_method = default_aggregation_method
 
     @property
-    def aggregation_method(self) -> AggregationMethod:
+    def default_aggregation_method(self) -> AggregationMethod:
         """How the values from multiple results are combined."""
-        return self._aggregation_method
+        return self._default_aggregation_method
 
     @property
     @abstractmethod
@@ -133,7 +133,7 @@ class Observable(Callback):
             "observable": self._base_tag,
             "evaluation_times": self.evaluation_times,
             "tag_suffix": self._tag_suffix,
-            "aggregation_method": self._aggregation_method,
+            "default_aggregation_method": self._default_aggregation_method,
             "uuid": str(self._uuid),
         }
 

--- a/pulser-core/pulser/backend/observable.py
+++ b/pulser-core/pulser/backend/observable.py
@@ -95,6 +95,8 @@ class Observable(Callback):
         tag_suffix: An optional suffix to append to the tag. Needed if
             multiple instances of the same observable are given to the
             same EmulationConfig.
+        aggregation_method: How to combine the values of this observable
+            from multiple results.
     """
 
     evaluation_times: NDArray[np.floating[Any]] | None
@@ -102,6 +104,7 @@ class Observable(Callback):
     def __init__(
         self,
         *,
+        aggregation_method: AggregationMethod,
         evaluation_times: Sequence[float] | None = None,
         tag_suffix: str | None = None,
     ):
@@ -113,6 +116,12 @@ class Observable(Callback):
             else None
         )
         self._tag_suffix = tag_suffix
+        self._aggregation_method = aggregation_method
+
+    @property
+    def aggregation_method(self) -> AggregationMethod:
+        """How the values from multiple results are combined."""
+        return self._aggregation_method
 
     @property
     @abstractmethod
@@ -124,6 +133,7 @@ class Observable(Callback):
             "observable": self._base_tag,
             "evaluation_times": self.evaluation_times,
             "tag_suffix": self._tag_suffix,
+            "aggregation_method": self._aggregation_method,
             "uuid": str(self._uuid),
         }
 
@@ -229,5 +239,3 @@ class Observable(Callback):
                 f"Instead, got {evaluation_times!r}."
             )
         return eval_times_arr
-
-    default_aggregation_method = AggregationMethod.SKIP

--- a/pulser-core/pulser/backend/results.py
+++ b/pulser-core/pulser/backend/results.py
@@ -96,7 +96,7 @@ class Results:
             tag=observable.tag,
             time=time,
             value=value,
-            aggregation_method=observable.aggregation_method,
+            aggregation_method=observable.default_aggregation_method,
         )
 
     def __getattr__(self, name: str) -> list[Any]:

--- a/pulser-core/pulser/backend/results.py
+++ b/pulser-core/pulser/backend/results.py
@@ -96,7 +96,7 @@ class Results:
             tag=observable.tag,
             time=time,
             value=value,
-            aggregation_method=observable.default_aggregation_method,
+            aggregation_method=observable.aggregation_method,
         )
 
     def __getattr__(self, name: str) -> list[Any]:

--- a/pulser-core/pulser/backend/results.py
+++ b/pulser-core/pulser/backend/results.py
@@ -284,7 +284,7 @@ class Results:
             results_to_aggregate: The list of Results to aggregate
 
         Keyword Args:
-            observable_tag: Overrides the default aggregator.
+            aggregation_functions: Overrides the default aggregator.
                 The argument name should be the tag of the Observable.
                 The value is a Callable taking a list of the type to aggregate.
                 Note that this does not override the default aggregation

--- a/pulser-core/pulser/json/abstract_repr/backend.py
+++ b/pulser-core/pulser/json/abstract_repr/backend.py
@@ -81,9 +81,9 @@ def _deserialize_observable(
     obs_params = ser_obs.copy()
     obs_name = obs_params.pop("observable")
     obs_uuid = obs_params.pop("uuid", None)
-    if "aggregation_method" in obs_params:
-        obs_params["aggregation_method"] = AggregationMethod(
-            obs_params["aggregation_method"]
+    if "default_aggregation_method" in obs_params:
+        obs_params["default_aggregation_method"] = AggregationMethod(
+            obs_params["default_aggregation_method"]
         )
     obs: Observable
     match obs_name:

--- a/pulser-core/pulser/json/abstract_repr/backend.py
+++ b/pulser-core/pulser/json/abstract_repr/backend.py
@@ -15,6 +15,7 @@ from pulser.backend.default_observables import (
     Fidelity,
     Occupation,
 )
+from pulser.backend.observable import AggregationMethod
 from pulser.exceptions.serialization import AbstractReprError
 from pulser.json.abstract_repr.deserializer import (
     _deserialize_noise_model,
@@ -80,6 +81,10 @@ def _deserialize_observable(
     obs_params = ser_obs.copy()
     obs_name = obs_params.pop("observable")
     obs_uuid = obs_params.pop("uuid", None)
+    if "aggregation_method" in obs_params:
+        obs_params["aggregation_method"] = AggregationMethod(
+            obs_params["aggregation_method"]
+        )
     obs: Observable
     match obs_name:
         case "bitstrings":

--- a/pulser-core/pulser/json/abstract_repr/schemas/config-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/config-schema.json
@@ -239,7 +239,7 @@
                     "null"
                 ]
             },
-            "aggregation_method": {
+            "default_aggregation_method": {
                 "description": "how values from multiple results are combined",
                 "type": "integer"
             },
@@ -253,7 +253,7 @@
             "evaluation_times",
             "operator",
             "tag_suffix",
-            "aggregation_method"
+            "default_aggregation_method"
         ],
         "additionalProperties": false
     },
@@ -289,7 +289,7 @@
                     "null"
                 ]
             },
-            "aggregation_method": {
+            "default_aggregation_method": {
                 "description": "how values from multiple results are combined",
                 "type": "integer"
             },
@@ -304,7 +304,7 @@
             "num_shots",
             "one_state",
             "tag_suffix",
-            "aggregation_method"
+            "default_aggregation_method"
         ],
         "additionalProperties": false
     },
@@ -329,7 +329,7 @@
                     "null"
                 ]
             },
-            "aggregation_method": {
+            "default_aggregation_method": {
                 "description": "how values from multiple results are combined",
                 "type": "integer"
             },
@@ -343,7 +343,7 @@
             "evaluation_times",
             "state",
             "tag_suffix",
-            "aggregation_method"
+            "default_aggregation_method"
         ],
         "additionalProperties": false
     },
@@ -372,7 +372,7 @@
                     "null"
                 ]
             },
-            "aggregation_method": {
+            "default_aggregation_method": {
                 "description": "how values from multiple results are combined",
                 "type": "integer"
             },
@@ -386,7 +386,7 @@
             "evaluation_times",
             "one_state",
             "tag_suffix",
-            "aggregation_method"
+            "default_aggregation_method"
         ],
         "additionalProperties": false
     },
@@ -415,7 +415,7 @@
                     "null"
                 ]
             },
-            "aggregation_method": {
+            "default_aggregation_method": {
                 "description": "how values from multiple results are combined",
                 "type": "integer"
             },
@@ -429,7 +429,7 @@
             "evaluation_times",
             "one_state",
             "tag_suffix",
-            "aggregation_method"
+            "default_aggregation_method"
         ],
         "additionalProperties": false
     },
@@ -451,7 +451,7 @@
                     "null"
                 ]
             },
-            "aggregation_method": {
+            "default_aggregation_method": {
                 "description": "how values from multiple results are combined",
                 "type": "integer"
             },
@@ -464,7 +464,7 @@
             "observable",
             "evaluation_times",
             "tag_suffix",
-            "aggregation_method"
+            "default_aggregation_method"
         ],
         "additionalProperties": false
     },
@@ -486,7 +486,7 @@
                     "null"
                 ]
             },
-            "aggregation_method": {
+            "default_aggregation_method": {
                 "description": "how values from multiple results are combined",
                 "type": "integer"
             },
@@ -499,7 +499,7 @@
             "observable",
             "evaluation_times",
             "tag_suffix",
-            "aggregation_method"
+            "default_aggregation_method"
         ],
         "additionalProperties": false
     },
@@ -521,7 +521,7 @@
                     "null"
                 ]
             },
-            "aggregation_method": {
+            "default_aggregation_method": {
                 "description": "how values from multiple results are combined",
                 "type": "integer"
             },
@@ -534,7 +534,7 @@
             "observable",
             "evaluation_times",
             "tag_suffix",
-            "aggregation_method"
+            "default_aggregation_method"
         ],
         "additionalProperties": false
     },

--- a/pulser-core/pulser/json/abstract_repr/schemas/config-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/config-schema.json
@@ -239,6 +239,10 @@
                     "null"
                 ]
             },
+            "aggregation_method": {
+                "description": "how values from multiple results are combined",
+                "type": "integer"
+            },
             "uuid": {
                 "description": "The observable's internal UUID",
                 "type": "string"
@@ -248,7 +252,8 @@
             "observable",
             "evaluation_times",
             "operator",
-            "tag_suffix"
+            "tag_suffix",
+            "aggregation_method"
         ],
         "additionalProperties": false
     },
@@ -284,6 +289,10 @@
                     "null"
                 ]
             },
+            "aggregation_method": {
+                "description": "how values from multiple results are combined",
+                "type": "integer"
+            },
             "uuid": {
                 "description": "The observable's internal UUID",
                 "type": "string"
@@ -294,7 +303,8 @@
             "evaluation_times",
             "num_shots",
             "one_state",
-            "tag_suffix"
+            "tag_suffix",
+            "aggregation_method"
         ],
         "additionalProperties": false
     },
@@ -319,6 +329,10 @@
                     "null"
                 ]
             },
+            "aggregation_method": {
+                "description": "how values from multiple results are combined",
+                "type": "integer"
+            },
             "uuid": {
                 "description": "The observable's internal UUID",
                 "type": "string"
@@ -328,7 +342,8 @@
             "observable",
             "evaluation_times",
             "state",
-            "tag_suffix"
+            "tag_suffix",
+            "aggregation_method"
         ],
         "additionalProperties": false
     },
@@ -357,6 +372,10 @@
                     "null"
                 ]
             },
+            "aggregation_method": {
+                "description": "how values from multiple results are combined",
+                "type": "integer"
+            },
             "uuid": {
                 "description": "The observable's internal UUID",
                 "type": "string"
@@ -366,7 +385,8 @@
             "observable",
             "evaluation_times",
             "one_state",
-            "tag_suffix"
+            "tag_suffix",
+            "aggregation_method"
         ],
         "additionalProperties": false
     },
@@ -395,6 +415,10 @@
                     "null"
                 ]
             },
+            "aggregation_method": {
+                "description": "how values from multiple results are combined",
+                "type": "integer"
+            },
             "uuid": {
                 "description": "The observable's internal UUID",
                 "type": "string"
@@ -404,7 +428,8 @@
             "observable",
             "evaluation_times",
             "one_state",
-            "tag_suffix"
+            "tag_suffix",
+            "aggregation_method"
         ],
         "additionalProperties": false
     },
@@ -426,6 +451,10 @@
                     "null"
                 ]
             },
+            "aggregation_method": {
+                "description": "how values from multiple results are combined",
+                "type": "integer"
+            },
             "uuid": {
                 "description": "The observable's internal UUID",
                 "type": "string"
@@ -434,7 +463,8 @@
         "required": [
             "observable",
             "evaluation_times",
-            "tag_suffix"
+            "tag_suffix",
+            "aggregation_method"
         ],
         "additionalProperties": false
     },
@@ -456,6 +486,10 @@
                     "null"
                 ]
             },
+            "aggregation_method": {
+                "description": "how values from multiple results are combined",
+                "type": "integer"
+            },
             "uuid": {
                 "description": "The observable's internal UUID",
                 "type": "string"
@@ -464,7 +498,8 @@
         "required": [
             "observable",
             "evaluation_times",
-            "tag_suffix"
+            "tag_suffix",
+            "aggregation_method"
         ],
         "additionalProperties": false
     },
@@ -486,6 +521,10 @@
                     "null"
                 ]
             },
+            "aggregation_method": {
+                "description": "how values from multiple results are combined",
+                "type": "integer"
+            },
             "uuid": {
                 "description": "The observable's internal UUID",
                 "type": "string"
@@ -494,7 +533,8 @@
         "required": [
             "observable",
             "evaluation_times",
-            "tag_suffix"
+            "tag_suffix",
+            "aggregation_method"
         ],
         "additionalProperties": false
     },

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -885,13 +885,13 @@ def test_results_aggregation(matching_uuids):
 )
 def test_observable_aggregation_method(obs_cls, default_method):
     # The default matches the historical per-class value
-    assert obs_cls().aggregation_method == default_method
+    assert obs_cls().default_aggregation_method == default_method
     # The value is exposed as a read-only property
     with pytest.raises(AttributeError):
-        obs_cls().aggregation_method = AggregationMethod.SKIP
+        obs_cls().default_aggregation_method = AggregationMethod.SKIP
     # It can be overridden per-instance through the constructor
-    overridden = obs_cls(aggregation_method=AggregationMethod.SKIP)
-    assert overridden.aggregation_method == AggregationMethod.SKIP
+    overridden = obs_cls(default_aggregation_method=AggregationMethod.SKIP)
+    assert overridden.default_aggregation_method == AggregationMethod.SKIP
 
 
 def test_results_aggregation_errors(caplog):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -871,6 +871,29 @@ def test_results_aggregation(matching_uuids):
     assert Results.aggregate([results1]) is results1
 
 
+@pytest.mark.parametrize(
+    "obs_cls, default_method",
+    [
+        (StateResult, AggregationMethod.SKIP_WARN),
+        (BitStrings, AggregationMethod.BAG_UNION),
+        (CorrelationMatrix, AggregationMethod.MEAN),
+        (Occupation, AggregationMethod.MEAN),
+        (Energy, AggregationMethod.MEAN),
+        (EnergyVariance, AggregationMethod.SKIP_WARN),
+        (EnergySecondMoment, AggregationMethod.MEAN),
+    ],
+)
+def test_observable_aggregation_method(obs_cls, default_method):
+    # The default matches the historical per-class value
+    assert obs_cls().aggregation_method == default_method
+    # The value is exposed as a read-only property
+    with pytest.raises(AttributeError):
+        obs_cls().aggregation_method = AggregationMethod.SKIP
+    # It can be overridden per-instance through the constructor
+    overridden = obs_cls(aggregation_method=AggregationMethod.SKIP)
+    assert overridden.aggregation_method == AggregationMethod.SKIP
+
+
 def test_results_aggregation_errors(caplog):
     uid = uuid.uuid4()
     agg_type = AggregationMethod.MEAN

--- a/tests/test_backend_abstract_repr.py
+++ b/tests/test_backend_abstract_repr.py
@@ -95,6 +95,11 @@ class TestObservableRepr:
                 (example_operator,),
                 {"tag_suffix": "my_op"},
             ),
+            (
+                Expectation,
+                (example_operator,),
+                {"aggregation_method": AggregationMethod.SKIP},
+            ),
         ],
     )
     def test_observable_repr(
@@ -146,6 +151,8 @@ class TestObservableRepr:
             assert repr.get("num_shots", None) == expected_kwargs.get(
                 "num_shots", None
             )
+            # The aggregation_method survives the round-trip
+            assert repr["aggregation_method"] == obs.aggregation_method
 
         # Check observable against the schema via config serialization
         ser_config = json.loads(

--- a/tests/test_backend_abstract_repr.py
+++ b/tests/test_backend_abstract_repr.py
@@ -98,7 +98,7 @@ class TestObservableRepr:
             (
                 Expectation,
                 (example_operator,),
-                {"aggregation_method": AggregationMethod.SKIP},
+                {"default_aggregation_method": AggregationMethod.SKIP},
             ),
         ],
     )
@@ -151,8 +151,11 @@ class TestObservableRepr:
             assert repr.get("num_shots", None) == expected_kwargs.get(
                 "num_shots", None
             )
-            # The aggregation_method survives the round-trip
-            assert repr["aggregation_method"] == obs.aggregation_method
+            # The default_aggregation_method survives the round-trip
+            assert (
+                repr["default_aggregation_method"]
+                == obs.default_aggregation_method
+            )
 
         # Check observable against the schema via config serialization
         ser_config = json.loads(


### PR DESCRIPTION
- Made `default_aggregation_method` a property, default value is the old hard-coded value
- Added the property to the (de)serialization.