### PR TITLE
Fix legacy serialization of a parametrized object with only keyword args

### DIFF
--- a/pulser-core/pulser/parametrized/paramobj.py
+++ b/pulser-core/pulser/parametrized/paramobj.py
@@ -269,7 +269,10 @@ class ParamObj(Parametrized, OpSupport):
                 "supported."
             )
         elif (
-            hasattr(args[0], self.cls.__name__)
+            # A method call will have at least one arg i.e. self/cls
+            # (calls to staticmethod are not serializable)
+            len(args) > 0
+            and hasattr(args[0], self.cls.__name__)
             and inspect.isfunction(self.cls)
             and self.cls.__module__ != "pulser.math"
         ):

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -311,3 +311,13 @@ def test_make_json_compatible():
     assert make_json_compatible("abc") == "abc"
     with pytest.raises(TypeError, match="not JSON serializable"):
         make_json_compatible(1j)
+
+
+def test_kwargs_only_paramobj():
+    reg = Register.square(4, prefix="q")
+    seq = Sequence(reg, DigitalAnalogDevice)
+    dt = seq.declare_variable("dt")
+
+    # Encode-decode should succeed on both cases
+    encode_decode(BlackmanWaveform(dt, 2))
+    encode_decode(BlackmanWaveform(duration=dt, area=2))


### PR DESCRIPTION
I think the title is self explanatory. I'm surprised this went unnoticed all these years!