### PR TITLE
[FIX] flaky dict comparison test_qubit_weight_map

### DIFF
--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -127,7 +127,9 @@ class TestDetuningMap:
             new_weights[qid] = eff_weight
 
         # effect of the Gaussian trap profile
-        assert det_map.get_qubit_weight_map(qubits, spot_waist) == new_weights
+        assert det_map.get_qubit_weight_map(
+            qubits, spot_waist
+        ) == pytest.approx(new_weights)
 
         # Triangular layout
         tri_layout = TriangularLatticeLayout(100, spacing=5)


### PR DESCRIPTION
A comparison between two dictionaries was sometimes failing in test_dmm.py/test_qubit_weight_map, due to floating point precision (see an example: https://github.com/pasqal-io/Pulser/actions/runs/30455630995/attempts/1). This could be solved by simply re-running the test. This makes the comparison more robust using pytest.approx https://docs.pytest.org/en/stable/reference/reference.html#pytest-approx.