### PR TITLE
Make changes to the config schema forwards compatible

### DIFF
--- a/pulser-core/pulser/json/abstract_repr/schemas/config-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/config-schema.json
@@ -82,10 +82,17 @@
                         "items": {
                             "type": "array",
                             "items": {
-                                "type": "array",
-                                "items": {
-                                    "type": "number"
-                                }
+                                "oneOf": [
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "number"
+                                        }
+                                    },
+                                    {
+                                        "type": "number"
+                                    }
+                                ]
                             }
                         }
                     }
@@ -252,8 +259,7 @@
             "observable",
             "evaluation_times",
             "operator",
-            "tag_suffix",
-            "default_aggregation_method"
+            "tag_suffix"
         ],
         "additionalProperties": false
     },
@@ -303,8 +309,7 @@
             "evaluation_times",
             "num_shots",
             "one_state",
-            "tag_suffix",
-            "default_aggregation_method"
+            "tag_suffix"
         ],
         "additionalProperties": false
     },
@@ -342,8 +347,7 @@
             "observable",
             "evaluation_times",
             "state",
-            "tag_suffix",
-            "default_aggregation_method"
+            "tag_suffix"
         ],
         "additionalProperties": false
     },
@@ -385,8 +389,7 @@
             "observable",
             "evaluation_times",
             "one_state",
-            "tag_suffix",
-            "default_aggregation_method"
+            "tag_suffix"
         ],
         "additionalProperties": false
     },
@@ -428,8 +431,7 @@
             "observable",
             "evaluation_times",
             "one_state",
-            "tag_suffix",
-            "default_aggregation_method"
+            "tag_suffix"
         ],
         "additionalProperties": false
     },
@@ -463,8 +465,7 @@
         "required": [
             "observable",
             "evaluation_times",
-            "tag_suffix",
-            "default_aggregation_method"
+            "tag_suffix"
         ],
         "additionalProperties": false
     },
@@ -498,8 +499,7 @@
         "required": [
             "observable",
             "evaluation_times",
-            "tag_suffix",
-            "default_aggregation_method"
+            "tag_suffix"
         ],
         "additionalProperties": false
     },
@@ -533,8 +533,7 @@
         "required": [
             "observable",
             "evaluation_times",
-            "tag_suffix",
-            "default_aggregation_method"
+            "tag_suffix"
         ],
         "additionalProperties": false
     },

--- a/tests/test_backend_abstract_repr.py
+++ b/tests/test_backend_abstract_repr.py
@@ -293,6 +293,38 @@ class TestConfigRepr:
         ):
             EmulationConfig.from_abstract_repr(1.0)
 
+    def test_legacy_interaction_matrix(self):
+        # pulser <= 1.8 serialized the interaction matrix as a 2D array
+        matrix = [[0.0, 0.5], [0.5, 0.0]]
+        config = EmulationConfig(
+            observables=[Energy()], interaction_matrix=matrix
+        )
+        ser_config = json.loads(config.to_abstract_repr())
+        assert np.array(ser_config["interaction_matrix"]).shape == (1, 2, 2)
+
+        ser_config["interaction_matrix"] = matrix
+        deserialized_config = EmulationConfig.from_abstract_repr(
+            json.dumps(ser_config)
+        )
+        assert np.allclose(
+            deserialized_config.interaction_matrix, config.interaction_matrix
+        )
+
+    def test_legacy_observable_without_aggregation_method(self):
+        # pulser <= 1.8 did not serialize 'default_aggregation_method'
+        obs = Energy()
+        ser_config = json.loads(
+            EmulationConfig(observables=[obs]).to_abstract_repr()
+        )
+        ser_config["observables"][0].pop("default_aggregation_method")
+        deserialized_config = EmulationConfig.from_abstract_repr(
+            json.dumps(ser_config)
+        )
+        assert (
+            deserialized_config.observables[0].default_aggregation_method
+            == obs.default_aggregation_method
+        )
+
     @mark.parametrize(
         "observables",
         [


### PR DESCRIPTION
We forgot to make the changes to the config schema forwards compatible, so that serialized configs with previous versions still pass validation under the latest schema.