### PR TITLE
Fix: Definition of InterpolatedWaveform with non-integer nanosecond times

### DIFF
--- a/pulser-core/pulser/waveforms.py
+++ b/pulser-core/pulser/waveforms.py
@@ -863,11 +863,11 @@ class InterpolatedWaveform(Waveform):
         duration: The waveform duration (in ns).
         values: Values of the interpolation points. Must be a list of castable
             to float or a parametrized object.
-        times: Fractions of the total duration (between 0
-            and 1), indicating where to place each value on the time axis. Must
-            be a list of castable to float or a parametrized object. If
-            not given, the values are spread evenly throughout the full
-            duration of the waveform.
+        times: Fractions of the total duration (between 0 and 1, 1
+            corresponding to the time `duration-1`), indicating where
+            to place each value on the time axis. Must be a list of castable
+            to float or a parametrized object. If not given, the values are
+            spread evenly throughout the full duration of the waveform.
         interpolator: The SciPy interpolation class
             to use. Supports "PchipInterpolator" and "interp1d".
 
@@ -940,7 +940,7 @@ class InterpolatedWaveform(Waveform):
         interp_cls = getattr(interpolate, interpolator)
         self._data_pts = np.array(
             [
-                (round(t), v)
+                (t, v)
                 for t, v in zip(
                     self._times * (self._duration - 1), self._values
                 )

--- a/tests/test_waveforms.py
+++ b/tests/test_waveforms.py
@@ -296,6 +296,16 @@ def test_interpolated():
     assert np.all(interpolated_wf.samples.as_array() <= max_amp)
     assert np.all(interpolated_wf.samples.as_array() >= 0)
 
+    # Defining an InterpolatedWaveform with times defined below ns
+    points_nb = 1001
+    duration = 100  # ns
+    values = np.linspace(0, 10, points_nb)
+    times = np.linspace(0, duration, points_nb)
+    interpolated_wf = InterpolatedWaveform(
+        duration + 1, values, times / duration
+    )
+    assert all(np.isclose(interpolated_wf.samples, values[::10]))
+
 
 def test_deprecated_interp1d_interpolator():
     dt = 1000


### PR DESCRIPTION
Currently, when a user a list of fractional times, they are scaled by `duration-1` (since InterpolatedWaveform defines values at [0; duration-1]) and then rounded to 1. This rounding is wrong, as then the interpolation is not performed exactly on the users input, if some of the times are at a non-integer number of nanoseconds. Especially, if the user provides a list of values to interpolate at some times that might be below 1 nanosecond, the initialization of InterpolatedWaveform fails with a not-so-descriptive error message coming from the interpolating function:
```
InterpolatedWaveform(100, np.linspace(0, 10, 1000))
```
Raises: `ValueError: 'x' must be strictly increasing sequence`

This MR gets rid of the rounding, for users to get the exact behaviour of the Interpolator (the interpolating function is then sampled at integer nanosecond times).
