### PR TITLE
Adjust XY tutorial for the correct interaction strengths

### DIFF
--- a/tutorials/quantum_simulation/Spin chain of 3 atoms in XY mode.ipynb
+++ b/tutorials/quantum_simulation/Spin chain of 3 atoms in XY mode.ipynb
@@ -19,7 +19,7 @@
     "H_{ij}^{\\text{int}} = \\sum_{i=1}^N\\sum_{j<i} \\left[\\frac{C_3}{R_{ij}^3} (|1\\rangle\\langle 0|_i |0\\rangle\\langle 1|_j + |0\\rangle\\langle 1|_i |1\\rangle\\langle 0|_j) + \\frac{C_6}{R_{ij}^6} |0\\rangle\\langle 0|_i |0\\rangle\\langle 0|_j\\right]\n",
     "$$\n",
     "\n",
-    "where $R_{ij}$ is the distance between atom $i$ and atom $j$, $C_3$ and $C_6$ are coefficients dependent on the device and taken as $\\frac{C_3}{\\hbar} = 3700 \\mu m^3/\\mu s$ and $\\frac{C_6}{\\hbar} = 5420158.53 \\mu m^6/\\mu s$ for the `MockDevice`.\n",
+    "where $R_{ij}$ is the distance between atom $i$ and atom $j$, $C_3$ and $C_6$ are coefficients dependent on the device and taken as $\\frac{C_3}{\\hbar} = 36288.36~\\mu m^3/\\mu s$ and $\\frac{C_6}{\\hbar} = 5420158.53~\\mu m^6/\\mu s$ for the `MockDevice`.\n",
     "\n",
     "More details on the XY mode can be found in the following reference: [Barredo et al. 2014](https://arxiv.org/pdf/1408.1055.pdf). In this page, we replicate these results to show how to use this alternative mode of operation."
    ]
@@ -32,9 +32,7 @@
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "import qutip\n",
     "\n",
-    "import pulser\n",
     "from pulser import Pulse, Sequence, Register\n",
     "from pulser.backend import Occupation\n",
     "from pulser_simulation import QutipBackendV2, QutipConfig\n",
@@ -141,7 +139,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "coords = np.array([[-8.0, 0], [0, 0], [8.0, 0]])\n",
+    "coords = np.array([[-20.0, 0], [0, 0], [20.0, 0]])\n",
     "qubits = {f\"q{i}\": coord for (i, coord) in enumerate(coords)}\n",
     "\n",
     "reg = Register(qubits)\n",
@@ -232,7 +230,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "coords = np.array([[-1.0, 0], [0, 0], [np.sqrt(2 / 3), np.sqrt(1 / 3)]]) * 8.0\n",
+    "coords = np.array([[-1.0, 0], [0, 0], [np.sqrt(2 / 3), np.sqrt(1 / 3)]]) * 20.0\n",
     "qubits = {f\"q{i}\": coord for (i, coord) in enumerate(coords)}\n",
     "\n",
     "reg = Register(qubits)\n",


### PR DESCRIPTION
The atom spacings in the XY tutorial were adapted to the previous value of `interaction_coeff_xy`, so they were giving incorrect results upon the addition of the C6 interaction to the XY hamiltionian and the new XY interaction coefficients. 

This tutorial adjusts the spacings to match the [original reference paper](https://arxiv.org/pdf/1408.1055), with seemingly good agreement.

Closes #1036 , which had been reopened in a rush.