### PR TITLE
[FIX] Avoid timeouts and allow repetitions in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
           skip-existing: true  # Allows repeating the action
           attestations: false  # Otherwise an attestation is added to dist/
       - name: Install from TestPyPI
-        timeout-minutes: 5
+        timeout-minutes: 30
         shell: bash
         run: |
           version="$(head -1 VERSION.txt)"
@@ -50,8 +50,10 @@ jobs:
           pytest
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true  # Allows repeating the action
       - name: Confirm deployment
-        timeout-minutes: 5
+        timeout-minutes: 30
         shell: bash
         run: |
           version="$(head -1 VERSION.txt)"


### PR DESCRIPTION
Lately the `publish.yml` has been timing out at the "Confirm deployment" stage (cf. https://github.com/pasqal-io/Pulser/actions/runs/31026583078) 

I'm not sure why it's timing out now, but it seems that if we increase the timeout interval it should be ok. 

Also, when the job fails after publishing to `PyPI`, we can't rerun it because if fails at publishing to PyPI. The `skip-existing` option added here should fix that.

