### PR TITLE
Report offending input in register error messages

### DIFF
--- a/pulser-core/pulser/register/base_register.py
+++ b/pulser-core/pulser/register/base_register.py
@@ -68,7 +68,8 @@ class BaseRegister(ABC, CoordsCollection):
         if not isinstance(qubits, dict):
             raise TypeError(
                 "The qubits have to be stored in a dictionary "
-                "matching qubit ids to position coordinates."
+                "matching qubit ids to position coordinates; "
+                f"got {type(qubits)}."
             )
         if not qubits:
             raise ValueError(
@@ -98,7 +99,7 @@ class BaseRegister(ABC, CoordsCollection):
             if kwargs.keys() != {"layout", "trap_ids"}:
                 raise ValueError(
                     "If specifying 'kwargs', they must only be 'layout' and "
-                    "'trap_ids'."
+                    f"'trap_ids'; got {sorted(kwargs)}."
                 )
             layout: RegisterLayout = kwargs["layout"]
             trap_ids: tuple[int, ...] = tuple(kwargs["trap_ids"])
@@ -149,7 +150,9 @@ class BaseRegister(ABC, CoordsCollection):
         if not set(id_list) <= set(self.qubit_ids):
             raise ValueError(
                 "The IDs list must be selected among the IDs of the register's"
-                " qubits."
+                " qubits; "
+                f"{sorted(set(id_list) - set(self.qubit_ids))} not in "
+                f"{list(self.qubit_ids)}."
             )
         return [self.qubit_ids.index(id_) for id_ in id_list]
 
@@ -190,14 +193,15 @@ class BaseRegister(ABC, CoordsCollection):
             if labels is not None:
                 raise NotImplementedError(
                     "It is impossible to specify a prefix and "
-                    "a set of labels at the same time"
+                    "a set of labels at the same time; "
+                    f"got prefix={prefix!r} and labels={list(labels)}."
                 )
 
         elif labels is not None:
             if len(coords_) != len(labels):
                 raise ValueError(
-                    f"Label length ({len(labels)}) does not"
-                    f"match number of coordinates ({len(coords_)})"
+                    f"Label length ({len(labels)}) does not "
+                    f"match number of coordinates ({len(coords_)})."
                 )
             qubits = dict(zip(cast(Iterable, labels), coords_))
         else:
@@ -212,15 +216,21 @@ class BaseRegister(ABC, CoordsCollection):
         if register_layout.dimensionality != self.dimensionality:
             raise ValueError(
                 "The RegisterLayout dimensionality is not the same as this "
-                "register's."
+                f"register's; layout is {register_layout.dimensionality}D "
+                f"and register is {self.dimensionality}D."
             )
         if len(set(trap_ids)) != len(trap_ids):
-            raise ValueError("Every 'trap_id' must be a unique integer.")
+            repeated = sorted({t for t in trap_ids if trap_ids.count(t) > 1})
+            raise ValueError(
+                "Every 'trap_id' must be a unique integer; "
+                f"found repeated ids {repeated} in {list(trap_ids)}."
+            )
 
         if len(trap_ids) != len(self._ids):
             raise ValueError(
                 "The amount of 'trap_ids' must be equal to the number of atoms"
-                " in the register."
+                f" in the register; got {len(trap_ids)} trap_ids "
+                f"for {len(self._ids)} atoms."
             )
 
         for reg_coord, trap_id in zip(
@@ -229,7 +239,9 @@ class BaseRegister(ABC, CoordsCollection):
             if np.any(reg_coord != trap_coords[trap_id]):
                 raise ValueError(
                     "The chosen traps from the RegisterLayout don't match this"
-                    " register's coordinates."
+                    f" register's coordinates; trap {trap_id} is at "
+                    f"{trap_coords[trap_id].tolist()} but the register "
+                    f"has {reg_coord.tolist()}."
                 )
 
     def define_detuning_map(
@@ -251,7 +263,9 @@ class BaseRegister(ABC, CoordsCollection):
         if not set(detuning_weights.keys()) <= set(self.qubit_ids):
             raise ValueError(
                 "The qubit ids linked to detuning weights have to be defined"
-                " in the register."
+                " in the register. Got "
+                f"{sorted(set(detuning_weights) - set(self.qubit_ids))}, "
+                f"which are not in {list(self.qubit_ids)}."
             )
         return DetuningMap(
             pm.vstack(

--- a/pulser-core/pulser/register/base_register.py
+++ b/pulser-core/pulser/register/base_register.py
@@ -70,7 +70,7 @@ class BaseRegister(ABC, CoordsCollection):
             raise TypeError(
                 "The qubits have to be stored in a dictionary "
                 "matching qubit ids to position coordinates; "
-                f"got {type(qubits)} ({qubits})."
+                f"got {type(qubits)}: {qubits}."
             )
         if not qubits:
             raise ValueError(

--- a/pulser-core/pulser/register/base_register.py
+++ b/pulser-core/pulser/register/base_register.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import warnings
 from abc import ABC, abstractmethod
+from collections import Counter
 from collections.abc import Iterable, Mapping
 from collections.abc import Sequence as abcSequence
 from typing import (
@@ -99,7 +100,7 @@ class BaseRegister(ABC, CoordsCollection):
             if kwargs.keys() != {"layout", "trap_ids"}:
                 raise ValueError(
                     "If specifying 'kwargs', they must only be 'layout' and "
-                    f"'trap_ids'; got {sorted(kwargs)}."
+                    f"'trap_ids'; got {list(kwargs)}."
                 )
             layout: RegisterLayout = kwargs["layout"]
             trap_ids: tuple[int, ...] = tuple(kwargs["trap_ids"])
@@ -151,7 +152,7 @@ class BaseRegister(ABC, CoordsCollection):
             raise ValueError(
                 "The IDs list must be selected among the IDs of the register's"
                 " qubits; "
-                f"{sorted(set(id_list) - set(self.qubit_ids))} not in "
+                f"{list(set(id_list) - set(self.qubit_ids))} not in "
                 f"{list(self.qubit_ids)}."
             )
         return [self.qubit_ids.index(id_) for id_ in id_list]
@@ -201,7 +202,8 @@ class BaseRegister(ABC, CoordsCollection):
             if len(coords_) != len(labels):
                 raise ValueError(
                     f"Label length ({len(labels)}) does not "
-                    f"match number of coordinates ({len(coords_)})."
+                    f"match number of coordinates ({len(coords_)}); "
+                    f"got coords {coords!r} and labels {labels!r}."
                 )
             qubits = dict(zip(cast(Iterable, labels), coords_))
         else:
@@ -215,12 +217,13 @@ class BaseRegister(ABC, CoordsCollection):
         trap_coords = register_layout.coords
         if register_layout.dimensionality != self.dimensionality:
             raise ValueError(
-                "The RegisterLayout dimensionality is not the same as this "
-                f"register's; layout is {register_layout.dimensionality}D "
-                f"and register is {self.dimensionality}D."
+                "The RegisterLayout dimensionality "
+                f"({register_layout.dimensionality}D) is not the same as this "
+                f"register's ({self.dimensionality}D); got layout "
+                f"{register_layout} on register {self}."
             )
         if len(set(trap_ids)) != len(trap_ids):
-            repeated = sorted({t for t in trap_ids if trap_ids.count(t) > 1})
+            repeated = [t for t, freq in Counter(trap_ids).items() if freq > 1]
             raise ValueError(
                 "Every 'trap_id' must be a unique integer; "
                 f"found repeated ids {repeated} in {list(trap_ids)}."
@@ -228,11 +231,15 @@ class BaseRegister(ABC, CoordsCollection):
 
         if len(trap_ids) != len(self._ids):
             raise ValueError(
-                "The amount of 'trap_ids' must be equal to the number of atoms"
-                f" in the register; got {len(trap_ids)} trap_ids "
-                f"for {len(self._ids)} atoms."
+                f"The amount of 'trap_ids' {len(trap_ids)} is not equal to "
+                f"the number of atoms {len(self._ids)}. Got trap ids "
+                f"{trap_ids} for atoms {self._ids}."
             )
-
+        if not set(trap_ids).issubset(register_layout.traps_dict):
+            raise ValueError(
+                "All 'trap_ids' must correspond to the ID of a trap; "
+                f"got {trap_ids}."
+            )
         for reg_coord, trap_id in zip(
             self._coords_arr.as_array(detach=True), trap_ids
         ):
@@ -264,7 +271,7 @@ class BaseRegister(ABC, CoordsCollection):
             raise ValueError(
                 "The qubit ids linked to detuning weights have to be defined"
                 " in the register. Got "
-                f"{sorted(set(detuning_weights) - set(self.qubit_ids))}, "
+                f"{list(set(detuning_weights) - set(self.qubit_ids))}, "
                 f"which are not in {list(self.qubit_ids)}."
             )
         return DetuningMap(

--- a/pulser-core/pulser/register/base_register.py
+++ b/pulser-core/pulser/register/base_register.py
@@ -219,8 +219,9 @@ class BaseRegister(ABC, CoordsCollection):
             raise ValueError(
                 "The RegisterLayout dimensionality "
                 f"({register_layout.dimensionality}D) is not the same as this "
-                f"register's ({self.dimensionality}D); got layout "
-                f"{register_layout} on register {self}."
+                f"register's ({self.dimensionality}D); Layout's coordinates "
+                f"are {register_layout.coords} and register's "
+                f"{self.sorted_coords}."
             )
         if len(set(trap_ids)) != len(trap_ids):
             repeated = [t for t, freq in Counter(trap_ids).items() if freq > 1]
@@ -232,13 +233,14 @@ class BaseRegister(ABC, CoordsCollection):
         if len(trap_ids) != len(self._ids):
             raise ValueError(
                 f"The amount of 'trap_ids' {len(trap_ids)} is not equal to "
-                f"the number of atoms {len(self._ids)}. Got trap ids "
-                f"{trap_ids} for atoms {self._ids}."
+                f"the number of atoms {len(self._ids)} in the register. Got "
+                f"trap ids {trap_ids} for atoms {self._ids}."
             )
         if not set(trap_ids).issubset(register_layout.traps_dict):
             raise ValueError(
-                "All 'trap_ids' must correspond to the ID of a trap; "
-                f"got {trap_ids}."
+                "All 'trap_ids' must correspond to the ID of a trap in the "
+                f"layout; got {trap_ids}, must be among "
+                f"{list(register_layout.traps_dict)}."
             )
         for reg_coord, trap_id in zip(
             self._coords_arr.as_array(detach=True), trap_ids

--- a/pulser-core/pulser/register/base_register.py
+++ b/pulser-core/pulser/register/base_register.py
@@ -203,7 +203,7 @@ class BaseRegister(ABC, CoordsCollection):
                 raise ValueError(
                     f"Label length ({len(labels)}) does not "
                     f"match number of coordinates ({len(coords_)}); "
-                    f"got coords {coords!r} and labels {labels!r}."
+                    f"got coords {coords!r} and labels {list(labels)}."
                 )
             qubits = dict(zip(cast(Iterable, labels), coords_))
         else:

--- a/pulser-core/pulser/register/base_register.py
+++ b/pulser-core/pulser/register/base_register.py
@@ -148,12 +148,12 @@ class BaseRegister(ABC, CoordsCollection):
             Indices of the qubits to denote, only valid for the
             given mapping.
         """
-        if not set(id_list) <= set(self.qubit_ids):
+        valid_ids = set(self.qubit_ids)
+        if not set(id_list) <= valid_ids:
+            invalid = [id_ for id_ in id_list if id_ not in valid_ids]
             raise ValueError(
                 "The IDs list must be selected among the IDs of the register's"
-                " qubits; "
-                f"{list(set(id_list) - set(self.qubit_ids))} not in "
-                f"{list(self.qubit_ids)}."
+                f" qubits; {invalid} not in {list(self.qubit_ids)}."
             )
         return [self.qubit_ids.index(id_) for id_ in id_list]
 
@@ -269,12 +269,13 @@ class BaseRegister(ABC, CoordsCollection):
             A DetuningMap associating detuning weights to the trap coordinates
             of the targeted qubits.
         """
-        if not set(detuning_weights.keys()) <= set(self.qubit_ids):
+        valid_ids = set(self.qubit_ids)
+        if not set(detuning_weights.keys()) <= valid_ids:
+            invalid = [id_ for id_ in detuning_weights if id_ not in valid_ids]
             raise ValueError(
                 "The qubit ids linked to detuning weights have to be defined"
-                " in the register. Got "
-                f"{list(set(detuning_weights) - set(self.qubit_ids))}, "
-                f"which are not in {list(self.qubit_ids)}."
+                f" in the register. Got {invalid}, which are not in "
+                f"{list(self.qubit_ids)}."
             )
         return DetuningMap(
             pm.vstack(

--- a/pulser-core/pulser/register/base_register.py
+++ b/pulser-core/pulser/register/base_register.py
@@ -70,7 +70,7 @@ class BaseRegister(ABC, CoordsCollection):
             raise TypeError(
                 "The qubits have to be stored in a dictionary "
                 "matching qubit ids to position coordinates; "
-                f"got {type(qubits)}."
+                f"got {type(qubits)} ({qubits})."
             )
         if not qubits:
             raise ValueError(

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -33,8 +33,21 @@ def test_creation():
     coords = [(0, 0), (1, 0)]
     ids = ("q0", "q1")
     qubits = dict(zip(ids, coords))
-    with pytest.raises(TypeError):
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "The qubits have to be stored in a dictionary matching qubit ids "
+            "to position coordinates; got <class 'list'>: [(0, 0), (1, 0)]."
+        ),
+    ):
         Register(coords)
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "The qubits have to be stored in a dictionary matching qubit ids "
+            "to position coordinates; got <class 'tuple'>: ('q0', 'q1')."
+        ),
+    ):
         Register(ids)
 
     with pytest.raises(ValueError, match="vectors of size 2"):

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -41,7 +41,11 @@ def test_creation():
         Register.from_coordinates([(0, 1, 0, 1)], prefix="q")
 
     with pytest.raises(
-        NotImplementedError, match="a prefix and a set of labels"
+        NotImplementedError,
+        match=re.escape(
+            "a prefix and a set of labels at the same time; got prefix='a' "
+            "and labels=['a', 'b']."
+        ),
     ):
         Register.from_coordinates(coords, prefix="a", labels=["a", "b"])
 
@@ -57,7 +61,13 @@ def test_creation():
     reg2b = Register.from_coordinates(coords, center=False, labels=["a", "b"])
     assert reg2b._ids == ("a", "b")
 
-    with pytest.raises(ValueError, match="Label length"):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Label length (3) does not match number of coordinates (2); "
+            "got coords [(0, 0), (1, 0)] and labels ['a', 'b', 'c']."
+        ),
+    ):
         Register.from_coordinates(coords, center=False, labels=["a", "b", "c"])
 
     reg3 = Register.from_coordinates(

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import dataclasses
+import re
 from unittest.mock import patch
 
 import numpy as np
@@ -466,8 +467,10 @@ def test_find_indices():
 
     with pytest.raises(
         ValueError,
-        match="IDs list must be selected among the IDs of the register's "
-        "qubits",
+        match=re.escape(
+            "IDs list must be selected among the IDs of the register's "
+            "qubits; ['e', 'd'] not in ['a', 'c', 'b']."
+        ),
     ):
         reg.find_indices(["c", "e", "d"])
 

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -98,16 +98,20 @@ def test_register_definition(layout, layout3d):
 
     reg2d = layout.define_register(0, 2)
     assert reg2d._layout_info == (layout, (0, 2))
-    with pytest.raises(ValueError, match="dimensionality is not the same"):
+    with pytest.raises(ValueError, match="dimensionality .* is not the same"):
         reg2d._validate_layout(layout3d, (0, 2))
     with pytest.raises(
         ValueError, match="Every 'trap_id' must be a unique integer"
     ):
         reg2d._validate_layout(layout, (0, 2, 2))
     with pytest.raises(
-        ValueError, match="must be equal to the number of atoms"
+        ValueError, match="is not equal to the number of atoms"
     ):
         reg2d._validate_layout(layout, (0,))
+    with pytest.raises(
+        ValueError, match="All 'trap_ids' must correspond to the ID of a trap"
+    ):
+        reg2d._validate_layout(layout, (0, 99))
     with pytest.raises(
         ValueError, match="don't match this register's coordinates"
     ):

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -103,7 +103,11 @@ def test_register_definition(layout, layout3d):
     ):
         reg2d._validate_layout(layout3d, (0, 2))
     with pytest.raises(
-        ValueError, match="Every 'trap_id' must be a unique integer"
+        ValueError,
+        match=re.escape(
+            "Every 'trap_id' must be a unique integer; found repeated ids "
+            "[2] in [0, 2, 2]."
+        ),
     ):
         reg2d._validate_layout(layout, (0, 2, 2))
     with pytest.raises(
@@ -111,15 +115,27 @@ def test_register_definition(layout, layout3d):
     ):
         reg2d._validate_layout(layout, (0,))
     with pytest.raises(
-        ValueError, match="All 'trap_ids' must correspond to the ID of a trap"
+        ValueError,
+        match=re.escape(
+            "All 'trap_ids' must correspond to the ID of a trap in the "
+            "layout; got (0, 99), must be among [0, 1, 2, 3]."
+        ),
     ):
         reg2d._validate_layout(layout, (0, 99))
     with pytest.raises(
-        ValueError, match="All 'trap_ids' must correspond to the ID of a trap"
+        ValueError,
+        match=re.escape(
+            "All 'trap_ids' must correspond to the ID of a trap in the "
+            "layout; got (0, -1), must be among [0, 1, 2, 3]."
+        ),
     ):
         reg2d._validate_layout(layout, (0, -1))
     with pytest.raises(
-        ValueError, match="don't match this register's coordinates"
+        ValueError,
+        match=re.escape(
+            "don't match this register's coordinates; trap 1 is at "
+            "[0.0, 1.0] but the register has [1.0, 0.0]."
+        ),
     ):
         reg2d._validate_layout(layout, (0, 1))
 

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -98,7 +98,9 @@ def test_register_definition(layout, layout3d):
 
     reg2d = layout.define_register(0, 2)
     assert reg2d._layout_info == (layout, (0, 2))
-    with pytest.raises(ValueError, match="dimensionality .* is not the same"):
+    with pytest.raises(
+        ValueError, match=re.escape("dimensionality (3D) is not the same")
+    ):
         reg2d._validate_layout(layout3d, (0, 2))
     with pytest.raises(
         ValueError, match="Every 'trap_id' must be a unique integer"

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -115,6 +115,10 @@ def test_register_definition(layout, layout3d):
     ):
         reg2d._validate_layout(layout, (0, 99))
     with pytest.raises(
+        ValueError, match="All 'trap_ids' must correspond to the ID of a trap"
+    ):
+        reg2d._validate_layout(layout, (0, -1))
+    with pytest.raises(
         ValueError, match="don't match this register's coordinates"
     ):
         reg2d._validate_layout(layout, (0, 1))


### PR DESCRIPTION
Same as #1094, applied to `base_register.py`.

Nine messages updated: `__init__`, `_init_kwargs`, `find_indices`,
`from_coordinates`, four in `_validate_layout`, and `define_detuning_map`.

Also fixed a missing space that printed as `Label length (3) does notmatch
number of coordinates (2)`.

I left `"Cannot create a Register with an empty qubit dictionary."` alone. The
dictionary is empty, so there's nothing to print.

One thing I noticed: `trap_coords[trap_id]` on line 229 isn't bounds checked, so
a bad trap id gives a numpy error instead of a Pulser one.

```
>>> Register(qubits, layout=layout, trap_ids=(0, 99))
IndexError: index 99 is out of bounds for axis 0 with size 4
```

`RegisterLayout.define_register` catches this but the `Register` constructor
skips that check. I didn't fix it here since it changes behaviour, not wording.

Partially addresses #1057.