### PR TITLE
Preserve specialized layout types in abstract deserialization

### DIFF
--- a/pulser-core/pulser/json/abstract_repr/deserializer.py
+++ b/pulser-core/pulser/json/abstract_repr/deserializer.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import re
 from typing import TYPE_CHECKING, Any, Literal, Type, Union, cast, overload
 
 import jsonschema
@@ -47,6 +48,11 @@ from pulser.parametrized import ParamObj, Variable
 from pulser.pulse import Pulse
 from pulser.register.mappable_reg import MappableRegister
 from pulser.register.register_layout import RegisterLayout
+from pulser.register.special_layouts import (
+    RectangularLatticeLayout,
+    SquareLatticeLayout,
+    TriangularLatticeLayout,
+)
 from pulser.register.weight_maps import DetuningMap
 from pulser.waveforms import (
     BlackmanWaveform,
@@ -66,6 +72,18 @@ if TYPE_CHECKING:
 
 
 VARIABLE_TYPE_MAP = {"int": int, "float": float}
+
+_FLOAT_PATTERN = r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?"
+_RECTANGULAR_LAYOUT_PATTERN = re.compile(
+    rf"RectangularLatticeLayout\((\d+)x(\d+), "
+    rf"({_FLOAT_PATTERN})x({_FLOAT_PATTERN})µm\)"
+)
+_SQUARE_LAYOUT_PATTERN = re.compile(
+    rf"SquareLatticeLayout\((\d+)x(\d+), ({_FLOAT_PATTERN})µm\)"
+)
+_TRIANGULAR_LAYOUT_PATTERN = re.compile(
+    rf"TriangularLatticeLayout\((\d+), ({_FLOAT_PATTERN})µm\)"
+)
 
 ExpReturnType = Union[int, float, list, ParamObj]
 
@@ -389,13 +407,47 @@ def _deserialize_channel(obj: dict[str, Any]) -> Channel:
 
 def _deserialize_layout(layout_obj: dict[str, Any]) -> RegisterLayout:
     try:
-        return RegisterLayout(
+        layout = RegisterLayout(
             layout_obj["coordinates"], slug=layout_obj.get("slug")
         )
     except ValueError as e:
         raise AbstractReprError(
             "Register layout deserialization failed."
         ) from e
+
+    if layout.slug is None:
+        return layout
+
+    special_layout: RegisterLayout
+    try:
+        match = _RECTANGULAR_LAYOUT_PATTERN.fullmatch(layout.slug)
+        if match:
+            rows, columns = map(int, match.group(1, 2))
+            if rows * columns == layout.number_of_traps:
+                special_layout = RectangularLatticeLayout(
+                    rows, columns, float(match[3]), float(match[4])
+                )
+                return special_layout if special_layout == layout else layout
+
+        match = _SQUARE_LAYOUT_PATTERN.fullmatch(layout.slug)
+        if match:
+            rows, columns = map(int, match.group(1, 2))
+            if rows * columns == layout.number_of_traps:
+                special_layout = SquareLatticeLayout(
+                    rows, columns, float(match[3])
+                )
+                return special_layout if special_layout == layout else layout
+
+        match = _TRIANGULAR_LAYOUT_PATTERN.fullmatch(layout.slug)
+        if match and int(match[1]) == layout.number_of_traps:
+            special_layout = TriangularLatticeLayout(
+                int(match[1]), float(match[2])
+            )
+            return special_layout if special_layout == layout else layout
+    except ValueError:
+        pass
+
+    return layout
 
 
 def _deserialize_register(

--- a/pulser-core/pulser/json/abstract_repr/deserializer.py
+++ b/pulser-core/pulser/json/abstract_repr/deserializer.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import dataclasses
 import json
-import re
 from typing import TYPE_CHECKING, Any, Literal, Type, Union, cast, overload
 
 import jsonschema
@@ -48,11 +47,7 @@ from pulser.parametrized import ParamObj, Variable
 from pulser.pulse import Pulse
 from pulser.register.mappable_reg import MappableRegister
 from pulser.register.register_layout import RegisterLayout
-from pulser.register.special_layouts import (
-    RectangularLatticeLayout,
-    SquareLatticeLayout,
-    TriangularLatticeLayout,
-)
+from pulser.register.special_layouts import _parse_special_layout_slug
 from pulser.register.weight_maps import DetuningMap
 from pulser.waveforms import (
     BlackmanWaveform,
@@ -72,18 +67,6 @@ if TYPE_CHECKING:
 
 
 VARIABLE_TYPE_MAP = {"int": int, "float": float}
-
-_FLOAT_PATTERN = r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?"
-_RECTANGULAR_LAYOUT_PATTERN = re.compile(
-    rf"RectangularLatticeLayout\((\d+)x(\d+), "
-    rf"({_FLOAT_PATTERN})x({_FLOAT_PATTERN})µm\)"
-)
-_SQUARE_LAYOUT_PATTERN = re.compile(
-    rf"SquareLatticeLayout\((\d+)x(\d+), ({_FLOAT_PATTERN})µm\)"
-)
-_TRIANGULAR_LAYOUT_PATTERN = re.compile(
-    rf"TriangularLatticeLayout\((\d+), ({_FLOAT_PATTERN})µm\)"
-)
 
 ExpReturnType = Union[int, float, list, ParamObj]
 
@@ -415,39 +398,10 @@ def _deserialize_layout(layout_obj: dict[str, Any]) -> RegisterLayout:
             "Register layout deserialization failed."
         ) from e
 
-    if layout.slug is None:
-        return layout
-
-    special_layout: RegisterLayout
-    try:
-        match = _RECTANGULAR_LAYOUT_PATTERN.fullmatch(layout.slug)
-        if match:
-            rows, columns = map(int, match.group(1, 2))
-            if rows * columns == layout.number_of_traps:
-                special_layout = RectangularLatticeLayout(
-                    rows, columns, float(match[3]), float(match[4])
-                )
-                return special_layout if special_layout == layout else layout
-
-        match = _SQUARE_LAYOUT_PATTERN.fullmatch(layout.slug)
-        if match:
-            rows, columns = map(int, match.group(1, 2))
-            if rows * columns == layout.number_of_traps:
-                special_layout = SquareLatticeLayout(
-                    rows, columns, float(match[3])
-                )
-                return special_layout if special_layout == layout else layout
-
-        match = _TRIANGULAR_LAYOUT_PATTERN.fullmatch(layout.slug)
-        if match and int(match[1]) == layout.number_of_traps:
-            special_layout = TriangularLatticeLayout(
-                int(match[1]), float(match[2])
-            )
-            return special_layout if special_layout == layout else layout
-    except ValueError:
-        pass
-
-    return layout
+    special_layout = (
+        _parse_special_layout_slug(layout.slug) if layout.slug else None
+    )
+    return special_layout if special_layout == layout else layout
 
 
 def _deserialize_register(

--- a/pulser-core/pulser/register/special_layouts.py
+++ b/pulser-core/pulser/register/special_layouts.py
@@ -15,6 +15,8 @@
 
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 import pulser
@@ -24,6 +26,39 @@ from pulser.register.register_layout import RegisterLayout
 
 if TYPE_CHECKING:
     from pulser.register import Register
+
+
+_FLOAT_PATTERN = r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?"
+
+
+@dataclass(frozen=True)
+class _LayoutSlug:
+    template: str
+    pattern: re.Pattern[str]
+
+    def format(self, *values: int | float) -> str:
+        return self.template.format(*values)
+
+    def parse(self, slug: str) -> tuple[str, ...] | None:
+        match = self.pattern.fullmatch(slug)
+        return match.groups() if match else None
+
+
+_RECTANGULAR_LAYOUT_SLUG = _LayoutSlug(
+    "RectangularLatticeLayout({}x{}, {}x{}µm)",
+    re.compile(
+        rf"RectangularLatticeLayout\((\d+)x(\d+), "
+        rf"({_FLOAT_PATTERN})x({_FLOAT_PATTERN})µm\)"
+    ),
+)
+_SQUARE_LAYOUT_SLUG = _LayoutSlug(
+    "SquareLatticeLayout({}x{}, {}µm)",
+    re.compile(rf"SquareLatticeLayout\((\d+)x(\d+), ({_FLOAT_PATTERN})µm\)"),
+)
+_TRIANGULAR_LAYOUT_SLUG = _LayoutSlug(
+    "TriangularLatticeLayout({}, {}µm)",
+    re.compile(rf"TriangularLatticeLayout\((\d+), ({_FLOAT_PATTERN})µm\)"),
+)
 
 
 class RectangularLatticeLayout(RegisterLayout):
@@ -44,9 +79,11 @@ class RectangularLatticeLayout(RegisterLayout):
         self._columns = int(columns)
         self._col_spacing = float(col_spacing)
         self._row_spacing = float(row_spacing)
-        slug = (
-            f"RectangularLatticeLayout({self._rows}x{self._columns}, "
-            f"{self._col_spacing}x{self._row_spacing}µm)"
+        slug = _RECTANGULAR_LAYOUT_SLUG.format(
+            self._rows,
+            self._columns,
+            self._col_spacing,
+            self._row_spacing,
         )
         self._traps = patterns.square_rect(self._rows, self._columns)
         self._traps[:, 0] = self._traps[:, 0] * self._col_spacing
@@ -132,9 +169,8 @@ class SquareLatticeLayout(RectangularLatticeLayout):
         super().__init__(
             self._rows, self._columns, self._spacing, self._spacing
         )
-        slug = (
-            f"SquareLatticeLayout({self._rows}x{self._columns}, "
-            f"{self._spacing}µm)"
+        slug = _SQUARE_LAYOUT_SLUG.format(
+            self._rows, self._columns, self._spacing
         )
         object.__setattr__(self, "slug", slug)
 
@@ -153,7 +189,7 @@ class TriangularLatticeLayout(RegisterLayout):
     def __init__(self, n_traps: int, spacing: float):
         """Initializes a TriangularLatticeLayout."""
         self._spacing = float(spacing)
-        slug = f"TriangularLatticeLayout({int(n_traps)}, {self._spacing}µm)"
+        slug = _TRIANGULAR_LAYOUT_SLUG.format(int(n_traps), self._spacing)
         super().__init__(
             patterns.triangular_hex(int(n_traps)) * self._spacing, slug=slug
         )
@@ -215,3 +251,31 @@ class TriangularLatticeLayout(RegisterLayout):
 
     def _to_dict(self) -> dict[str, Any]:
         return obj_to_dict(self, self.number_of_traps, self._spacing)
+
+
+def _parse_special_layout_slug(slug: str) -> RegisterLayout | None:
+    """Create a special layout from its slug, when recognized."""
+    try:
+        values = _RECTANGULAR_LAYOUT_SLUG.parse(slug)
+        if values:
+            rows, columns, col_spacing, row_spacing = values
+            return RectangularLatticeLayout(
+                int(rows),
+                int(columns),
+                float(col_spacing),
+                float(row_spacing),
+            )
+
+        values = _SQUARE_LAYOUT_SLUG.parse(slug)
+        if values:
+            rows, columns, spacing = values
+            return SquareLatticeLayout(int(rows), int(columns), float(spacing))
+
+        values = _TRIANGULAR_LAYOUT_SLUG.parse(slug)
+        if values:
+            n_traps, spacing = values
+            return TriangularLatticeLayout(int(n_traps), float(spacing))
+    except ValueError:
+        return None
+
+    return None

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -63,7 +63,11 @@ from pulser.parametrized.decorators import parametrize
 from pulser.parametrized.paramobj import ParamObj
 from pulser.parametrized.variable import Variable, VariableItem
 from pulser.register.register_layout import RegisterLayout
-from pulser.register.special_layouts import TriangularLatticeLayout
+from pulser.register.special_layouts import (
+    RectangularLatticeLayout,
+    SquareLatticeLayout,
+    TriangularLatticeLayout,
+)
 from pulser.sequence import (
     store_extra_metadata,
     store_package_version_metadata,
@@ -151,7 +155,17 @@ def test_abstract_repr_encoder_torch():
     [
         RegisterLayout([[0, 0], [1, 1]]),
         TriangularLatticeLayout(10, 10),
+        SquareLatticeLayout(3, 4, 2.5),
+        RectangularLatticeLayout(3, 4, 2.5, 5),
         RegisterLayout([[10, 0], [1, 10]], slug="foo"),
+        RegisterLayout(
+            [[0, 0], [1, 1]],
+            slug="TriangularLatticeLayout(2, 1.0µm)",
+        ),
+        RegisterLayout(
+            [[0, 0], [0, 1], [1, 0], [1, 1]],
+            slug="SquareLatticeLayout(2x2, 0.0µm)",
+        ),
         RegisterLayout([[0.0, 1.0, 2.0], [-0.4, 1.6, 35.0]]),
     ],
 )
@@ -162,6 +176,7 @@ def test_layout(layout: RegisterLayout):
 
     re_layout = RegisterLayout.from_abstract_repr(ser_layout_str)
     assert layout == re_layout
+    assert type(re_layout) is type(layout)
 
     with pytest.raises(TypeError, match="must be given as a string"):
         RegisterLayout.from_abstract_repr(ser_layout_obj)
@@ -411,6 +426,15 @@ class TestDevice:
             assert json.loads(device.to_abstract_repr()) == abstract_device
 
         _roundtrip(abstract_device)
+
+    def test_special_layout_roundtrip(self):
+        device = Device.from_abstract_repr(AnalogDevice.to_abstract_repr())
+        layout = next(iter(device.pre_calibrated_layouts))
+        assert type(layout) is TriangularLatticeLayout
+        register = layout.rectangular_register(
+            rows=1, atoms_per_row=3, prefix="q"
+        )
+        assert register.qubit_ids == ("q0", "q1", "q2")
 
     def test_interaction_coeff_xy_serialization(self, abstract_device):
         # The abstract repr always carries 'interaction_coeff_xy' (schema
@@ -1004,7 +1028,6 @@ class TestSerialization:
         assert abstract["measurement"] == "digital"
 
     def test_exceptions(self, sequence):
-
         with pytest.raises(
             ValueError, match="No signature found for 'FakeWaveform'"
         ):

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -159,6 +159,10 @@ def test_abstract_repr_encoder_torch():
         RectangularLatticeLayout(3, 4, 2.5, 5),
         RegisterLayout([[10, 0], [1, 10]], slug="foo"),
         RegisterLayout(
+            SquareLatticeLayout(2, 2, 1).coords,
+            slug="SquareLatticeLayout(2x2, 1.0)",
+        ),
+        RegisterLayout(
             [[0, 0], [1, 1]],
             slug="TriangularLatticeLayout(2, 1.0µm)",
         ),
@@ -427,14 +431,19 @@ class TestDevice:
 
         _roundtrip(abstract_device)
 
-    def test_special_layout_roundtrip(self):
-        device = Device.from_abstract_repr(AnalogDevice.to_abstract_repr())
-        layout = next(iter(device.pre_calibrated_layouts))
-        assert type(layout) is TriangularLatticeLayout
-        register = layout.rectangular_register(
-            rows=1, atoms_per_row=3, prefix="q"
-        )
-        assert register.qubit_ids == ("q0", "q1", "q2")
+    @pytest.mark.parametrize(
+        "layout",
+        [
+            TriangularLatticeLayout(61, 5),
+            SquareLatticeLayout(3, 4, 5),
+            RectangularLatticeLayout(3, 4, 5, 6),
+        ],
+    )
+    def test_special_layout_roundtrip(self, layout):
+        device = replace(AnalogDevice, pre_calibrated_layouts=(layout,))
+        device = Device.from_abstract_repr(device.to_abstract_repr())
+        deserialized_layout = next(iter(device.pre_calibrated_layouts))
+        assert type(deserialized_layout) is type(layout)
 
     def test_interaction_coeff_xy_serialization(self, abstract_device):
         # The abstract repr always carries 'interaction_coeff_xy' (schema

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -444,6 +444,12 @@ class TestDevice:
         device = Device.from_abstract_repr(device.to_abstract_repr())
         deserialized_layout = next(iter(device.pre_calibrated_layouts))
         assert type(deserialized_layout) is type(layout)
+        assert deserialized_layout == layout
+
+        register = layout.define_register(0)
+        register = Register.from_abstract_repr(register.to_abstract_repr())
+        assert type(register.layout) is type(layout)
+        assert register.layout == layout
 
     def test_interaction_coeff_xy_serialization(self, abstract_device):
         # The abstract repr always carries 'interaction_coeff_xy' (schema


### PR DESCRIPTION
## What changed

Abstract deserialization now reconstructs `RectangularLatticeLayout`, `SquareLatticeLayout`, and `TriangularLatticeLayout` when the serialized slug matches a built-in format and its coordinates match the generated layout.

Layouts with a similar slug but different geometry remain plain `RegisterLayout` objects. This avoids changing arbitrary user-defined layouts.

Tests cover all three specialized classes, generic fallback cases, and the `AnalogDevice` example from #848.

## Testing

- `python3 -m pytest tests/test_abstract_repr.py -q`
- `python3 -m pytest tests/test_abstract_repr.py tests/test_register_layout.py tests/test_devices.py tests/test_sequence.py -q`
- Black, isort, Flake8, and Ruff
- Mypy on the changed module

Fixes #848