### PR TITLE
Report offending input in register module error messages

### DIFF
--- a/pulser-core/pulser/register/mappable_reg.py
+++ b/pulser-core/pulser/register/mappable_reg.py
@@ -42,7 +42,8 @@ class MappableRegister:
         if len(qubit_ids) > self._layout.number_of_traps:
             raise ValueError(
                 "The number of required qubits is greater than the number of "
-                f"traps in this layout ({self._layout.number_of_traps})."
+                f"traps in this layout ({self._layout.number_of_traps}); got "
+                f"{len(qubit_ids)} qubit ids {list(qubit_ids)}."
             )
         self._qubit_ids = qubit_ids
 
@@ -70,8 +71,10 @@ class MappableRegister:
         """
         chosen_ids = tuple(qubits.keys())
         if not set(chosen_ids) <= set(self._qubit_ids):
+            unknown = [id_ for id_ in chosen_ids if id_ not in self._qubit_ids]
             raise ValueError(
-                "All qubits must be labeled with pre-declared qubit IDs."
+                "All qubits must be labeled with pre-declared qubit IDs; "
+                f"{unknown} not in {list(self._qubit_ids)}."
             )
         elif set(chosen_ids) != set(self.qubit_ids[: len(chosen_ids)]):
             raise ValueError(
@@ -118,8 +121,10 @@ class MappableRegister:
             given mapping.
         """
         if not set(id_list) <= set(self._qubit_ids):
+            unknown = [id_ for id_ in id_list if id_ not in self._qubit_ids]
             raise ValueError(
-                "The IDs list must be selected among pre-declared qubit IDs."
+                "The IDs list must be selected among pre-declared qubit IDs; "
+                f"{unknown} not in {list(self._qubit_ids)}."
             )
         return [self.qubit_ids.index(id) for id in id_list]
 

--- a/pulser-core/pulser/register/mappable_reg.py
+++ b/pulser-core/pulser/register/mappable_reg.py
@@ -43,7 +43,7 @@ class MappableRegister:
             raise ValueError(
                 "The number of required qubits is greater than the number of "
                 f"traps in this layout ({self._layout.number_of_traps}); got "
-                f"{len(qubit_ids)} qubit ids {list(qubit_ids)}."
+                f"qubit ids ({len(qubit_ids)}): {list(qubit_ids)}."
             )
         self._qubit_ids = qubit_ids
 
@@ -80,7 +80,8 @@ class MappableRegister:
             raise ValueError(
                 f"To declare {len(qubits.keys())} qubits, 'qubits' should "
                 f"contain the first {len(qubits.keys())} elements of the "
-                "'qubit_ids'."
+                f"'qubit_ids'; got {list(chosen_ids)}, expected "
+                f"{list(self.qubit_ids[: len(chosen_ids)])}."
             )
         register_ordered_qubits = {
             id: qubits[id] for id in self._qubit_ids if id in chosen_ids

--- a/pulser-core/pulser/register/mappable_reg.py
+++ b/pulser-core/pulser/register/mappable_reg.py
@@ -43,7 +43,7 @@ class MappableRegister:
             raise ValueError(
                 "The number of required qubits is greater than the number of "
                 f"traps in this layout ({self._layout.number_of_traps}); got "
-                f"qubit ids ({len(qubit_ids)}): {list(qubit_ids)}."
+                f"{len(qubit_ids)} qubit ids: {list(qubit_ids)}."
             )
         self._qubit_ids = qubit_ids
 

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -293,7 +293,8 @@ class Register(BaseRegister, RegDrawer):
         # Check device
         if not isinstance(device, pulser.devices._device_datacls.BaseDevice):
             raise TypeError(
-                f"'device' must be of type 'BaseDevice', not {type(device)}."
+                "'device' must be of type 'BaseDevice', not "
+                f"{type(device)} ({device})."
             )
 
         # Check number of qubits (1 or above)

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -294,7 +294,7 @@ class Register(BaseRegister, RegDrawer):
         if not isinstance(device, pulser.devices._device_datacls.BaseDevice):
             raise TypeError(
                 "'device' must be of type 'BaseDevice', not "
-                f"{type(device)} ({device})."
+                f"{type(device)}: {device}."
             )
 
         # Check number of qubits (1 or above)

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -60,8 +60,12 @@ class Register(BaseRegister, RegDrawer):
             any(c.shape != (self.dimensionality,) for c in self._coords_arr)
             or self.dimensionality != 2
         ):
+            shapes = list(
+                dict.fromkeys(tuple(c.shape) for c in self._coords_arr)
+            )
             raise ValueError(
-                "All coordinates must be specified as vectors of size 2."
+                "All coordinates must be specified as vectors of size 2; got "
+                f"{self.dimensionality}D coordinates with shapes {shapes}."
             )
 
     @classmethod
@@ -158,7 +162,11 @@ class Register(BaseRegister, RegDrawer):
 
         # Check spacing
         if row_spacing_ <= 0.0 or col_spacing_ <= 0.0:
-            raise ValueError("Spacing between atoms must be greater than 0.")
+            raise ValueError(
+                f"Spacing between atoms (`row_spacing` = {row_spacing},"
+                f" `col_spacing` = {col_spacing})"
+                " must be greater than 0."
+            )
 
         coords = pm.AbstractArray(patterns.square_rect(rows, columns))
         coords[:, 0] = coords[:, 0] * col_spacing_
@@ -288,7 +296,9 @@ class Register(BaseRegister, RegDrawer):
         """
         # Check device
         if not isinstance(device, pulser.devices._device_datacls.BaseDevice):
-            raise TypeError("'device' must be of type 'BaseDevice'.")
+            raise TypeError(
+                f"'device' must be of type 'BaseDevice', not {type(device)}."
+            )
 
         # Check number of qubits (1 or above)
         if n_qubits < 1:
@@ -313,7 +323,7 @@ class Register(BaseRegister, RegDrawer):
             spacing_ := pm.AbstractArray(spacing)
         ) < device.min_atom_distance:
             raise ValueError(
-                f"Spacing between atoms (`spacing = `{spacing})"
+                f"Spacing between atoms (`spacing` = {spacing})"
                 " must be greater than or equal to the minimal"
                 " distance supported by this device"
                 f" ({device.min_atom_distance})."

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -293,7 +293,7 @@ class Register(BaseRegister, RegDrawer):
         # Check device
         if not isinstance(device, pulser.devices._device_datacls.BaseDevice):
             raise TypeError(
-                "'device' must be of type 'BaseDevice', not "
+                "'device' must be an instance of 'BaseDevice', not "
                 f"{type(device)}: {device}."
             )
 
@@ -361,7 +361,8 @@ class Register(BaseRegister, RegDrawer):
         """
         if not isinstance(device, pulser.devices.Device):
             raise TypeError(
-                f"'device' must be of type Device, not {type(device)}."
+                "'device' must be an instance of 'Device', not "
+                f"{type(device)}."
             )
         if self._coords_arr.requires_grad:
             raise NotImplementedError(

--- a/pulser-core/pulser/register/register.py
+++ b/pulser-core/pulser/register/register.py
@@ -60,12 +60,9 @@ class Register(BaseRegister, RegDrawer):
             any(c.shape != (self.dimensionality,) for c in self._coords_arr)
             or self.dimensionality != 2
         ):
-            shapes = list(
-                dict.fromkeys(tuple(c.shape) for c in self._coords_arr)
-            )
             raise ValueError(
-                "All coordinates must be specified as vectors of size 2; got "
-                f"{self.dimensionality}D coordinates with shapes {shapes}."
+                "All coordinates must be specified as vectors of size 2; "
+                f"got {self.dimensionality}D coordinates."
             )
 
     @classmethod
@@ -163,9 +160,8 @@ class Register(BaseRegister, RegDrawer):
         # Check spacing
         if row_spacing_ <= 0.0 or col_spacing_ <= 0.0:
             raise ValueError(
-                f"Spacing between atoms (`row_spacing` = {row_spacing},"
-                f" `col_spacing` = {col_spacing})"
-                " must be greater than 0."
+                "Spacing between atoms must be greater than 0; got row "
+                f"spacing {row_spacing} and column spacing {col_spacing}."
             )
 
         coords = pm.AbstractArray(patterns.square_rect(rows, columns))

--- a/pulser-core/pulser/register/register3d.py
+++ b/pulser-core/pulser/register/register3d.py
@@ -52,8 +52,12 @@ class Register3D(BaseRegister, RegDrawer):
             any(c.shape != (self.dimensionality,) for c in self._coords_arr)
             or self.dimensionality != 3
         ):
+            shapes = list(
+                dict.fromkeys(tuple(c.shape) for c in self._coords_arr)
+            )
             raise ValueError(
-                "All coordinates must be specified as vectors of size 3."
+                "All coordinates must be specified as vectors of size 3; got "
+                f"{self.dimensionality}D coordinates with shapes {shapes}."
             )
 
     @classmethod

--- a/pulser-core/pulser/register/register3d.py
+++ b/pulser-core/pulser/register/register3d.py
@@ -52,12 +52,9 @@ class Register3D(BaseRegister, RegDrawer):
             any(c.shape != (self.dimensionality,) for c in self._coords_arr)
             or self.dimensionality != 3
         ):
-            shapes = list(
-                dict.fromkeys(tuple(c.shape) for c in self._coords_arr)
-            )
             raise ValueError(
-                "All coordinates must be specified as vectors of size 3; got "
-                f"{self.dimensionality}D coordinates with shapes {shapes}."
+                "All coordinates must be specified as vectors of size 3; "
+                f"got {self.dimensionality}D coordinates."
             )
 
     @classmethod

--- a/pulser-core/pulser/register/register_layout.py
+++ b/pulser-core/pulser/register/register_layout.py
@@ -144,8 +144,8 @@ class RegisterLayout(Traps, RegDrawer):
             invalid = [t for t in detuning_weights if t not in self.traps_dict]
             raise ValueError(
                 "The trap ids of detuning weights have to be integers"
-                f" in [0, {self.number_of_traps-1}];"
-                f" got invalid ids {invalid}."
+                f" in [0, {self.number_of_traps-1}]."
+                f" Got invalid ids {invalid}."
             )
         return DetuningMap(
             [self.traps_dict[trap_id] for trap_id in detuning_weights],

--- a/pulser-core/pulser/register/register_layout.py
+++ b/pulser-core/pulser/register/register_layout.py
@@ -109,7 +109,7 @@ class RegisterLayout(Traps, RegDrawer):
                 raise ValueError(
                     "'qubit_ids' must have the same size as the number of "
                     f"provided 'trap_ids' ({len(trap_ids)}); got "
-                    f"{len(qubit_ids)} qubit ids {list(qubit_ids)}."
+                    f"qubit ids {list(qubit_ids)}."
                 )
 
         ids = (

--- a/pulser-core/pulser/register/register_layout.py
+++ b/pulser-core/pulser/register/register_layout.py
@@ -108,8 +108,8 @@ class RegisterLayout(Traps, RegDrawer):
             if len(qubit_ids) != len(trap_ids):
                 raise ValueError(
                     "'qubit_ids' must have the same size as the number of "
-                    f"provided 'trap_ids' ({len(trap_ids)}); got "
-                    f"qubit ids {list(qubit_ids)}."
+                    f"provided 'trap_ids' ({len(trap_ids)}); got qubit ids "
+                    f"({len(qubit_ids)}): {list(qubit_ids)}."
                 )
 
         ids = (
@@ -144,8 +144,8 @@ class RegisterLayout(Traps, RegDrawer):
             invalid = [t for t in detuning_weights if t not in self.traps_dict]
             raise ValueError(
                 "The trap ids of detuning weights have to be integers"
-                f" in [0, {self.number_of_traps-1}]."
-                f" Got invalid ids {invalid}."
+                f" in [0, {self.number_of_traps-1}]; "
+                f"got invalid ids {invalid} in {list(detuning_weights)}."
             )
         return DetuningMap(
             [self.traps_dict[trap_id] for trap_id in detuning_weights],

--- a/pulser-core/pulser/register/register_layout.py
+++ b/pulser-core/pulser/register/register_layout.py
@@ -108,8 +108,8 @@ class RegisterLayout(Traps, RegDrawer):
             if len(qubit_ids) != len(trap_ids):
                 raise ValueError(
                     "'qubit_ids' must have the same size as the number of "
-                    f"provided 'trap_ids' ({len(trap_ids)}); got qubit ids "
-                    f"({len(qubit_ids)}): {list(qubit_ids)}."
+                    f"provided 'trap_ids'; got {len(trap_ids)} 'trap_ids' vs. "
+                    f"{len(qubit_ids)} 'qubit_ids'."
                 )
 
         ids = (

--- a/pulser-core/pulser/register/register_layout.py
+++ b/pulser-core/pulser/register/register_layout.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections import Counter
 from collections.abc import Mapping
 from collections.abc import Sequence as abcSequence
 from dataclasses import dataclass
@@ -80,23 +81,35 @@ class RegisterLayout(Traps, RegDrawer):
         trap_ids_set = set(trap_ids)
 
         if len(trap_ids_set) != len(trap_ids):
-            raise ValueError("Every 'trap_id' must be a unique integer.")
+            repeated = [t for t, freq in Counter(trap_ids).items() if freq > 1]
+            raise ValueError(
+                "Every 'trap_id' must be a unique integer; "
+                f"found repeated ids {repeated} in {list(trap_ids)}."
+            )
 
         if not trap_ids_set.issubset(self.traps_dict):
             # This check makes it redundant to check # qubits <= # traps
+            invalid = [t for t in trap_ids if t not in self.traps_dict]
             raise ValueError(
-                "All 'trap_ids' must correspond to the ID of a trap."
+                "All 'trap_ids' must correspond to the ID of a trap; got "
+                f"invalid ids {invalid} in {list(trap_ids)}, must be "
+                f"integers in [0, {self.number_of_traps - 1}]."
             )
 
         if qubit_ids:
             if len(set(qubit_ids)) != len(qubit_ids):
+                repeated_ids = [
+                    q for q, freq in Counter(qubit_ids).items() if freq > 1
+                ]
                 raise ValueError(
-                    "'qubit_ids' must be a sequence of unique IDs."
+                    "'qubit_ids' must be a sequence of unique IDs; found "
+                    f"repeated ids {repeated_ids} in {list(qubit_ids)}."
                 )
             if len(qubit_ids) != len(trap_ids):
                 raise ValueError(
                     "'qubit_ids' must have the same size as the number of "
-                    f"provided 'trap_ids' ({len(trap_ids)})."
+                    f"provided 'trap_ids' ({len(trap_ids)}); got "
+                    f"{len(qubit_ids)} qubit ids {list(qubit_ids)}."
                 )
 
         ids = (
@@ -128,9 +141,11 @@ class RegisterLayout(Traps, RegDrawer):
             of the targeted traps.
         """
         if not set(detuning_weights.keys()) <= set(self.traps_dict):
+            invalid = [t for t in detuning_weights if t not in self.traps_dict]
             raise ValueError(
                 "The trap ids of detuning weights have to be integers"
-                f" in [0, {self.number_of_traps-1}]."
+                f" in [0, {self.number_of_traps-1}];"
+                f" got invalid ids {invalid}."
             )
         return DetuningMap(
             [self.traps_dict[trap_id] for trap_id in detuning_weights],

--- a/pulser-core/pulser/register/traps.py
+++ b/pulser-core/pulser/register/traps.py
@@ -51,14 +51,14 @@ class Traps(ABC, CoordsCollection):
         except ValueError as e:
             raise ValueError(
                 "'trap_coordinates' must be an array or list of coordinates;"
-                f" got {type(trap_coordinates)} ({trap_coordinates!r})."
+                f" got {type(trap_coordinates)}: {trap_coordinates!r}."
             ) from e
 
         shape = np.shape(coords_arr)
         if len(shape) != 2:
             raise ValueError(
                 "'trap_coordinates' must be an array or list of coordinates;"
-                f" got an array of shape {shape}."
+                f" got an array of shape {shape}: {trap_coordinates!r}."
             )
 
         if shape[1] not in (2, 3):

--- a/pulser-core/pulser/register/traps.py
+++ b/pulser-core/pulser/register/traps.py
@@ -51,7 +51,7 @@ class Traps(ABC, CoordsCollection):
         except ValueError as e:
             raise ValueError(
                 "'trap_coordinates' must be an array or list of coordinates;"
-                f" got {type(trap_coordinates)}."
+                f" got {type(trap_coordinates)} ({trap_coordinates!r})."
             ) from e
 
         shape = np.shape(coords_arr)

--- a/pulser-core/pulser/register/traps.py
+++ b/pulser-core/pulser/register/traps.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import hashlib
 from abc import ABC, abstractmethod
+from collections import Counter
 from dataclasses import dataclass
 from functools import cached_property
 from typing import Any
@@ -43,20 +44,22 @@ class Traps(ABC, CoordsCollection):
 
     def __init__(self, trap_coordinates: ArrayLike, slug: str | None = None):
         """Initializes a set of traps."""
-        array_type_error_msg = ValueError(
-            "'trap_coordinates' must be an array or list of coordinates."
-        )
-
         try:
             coords_arr = pm.AbstractArray(
                 trap_coordinates, dtype=float
             ).as_array(detach=True)
         except ValueError as e:
-            raise array_type_error_msg from e
+            raise ValueError(
+                "'trap_coordinates' must be an array or list of coordinates;"
+                f" got {type(trap_coordinates)}."
+            ) from e
 
         shape = np.shape(coords_arr)
         if len(shape) != 2:
-            raise array_type_error_msg
+            raise ValueError(
+                "'trap_coordinates' must be an array or list of coordinates;"
+                f" got an array of shape {shape}."
+            )
 
         if shape[1] not in (2, 3):
             raise ValueError(
@@ -64,8 +67,13 @@ class Traps(ABC, CoordsCollection):
             )
 
         if len(np.unique(coords_arr, axis=0)) != shape[0]:
+            coord_counts = Counter(map(tuple, coords_arr.tolist()))
+            repeated = [
+                list(coord) for coord, freq in coord_counts.items() if freq > 1
+            ]
             raise ValueError(
-                "All trap coordinates of a register layout must be unique."
+                "All trap coordinates of a register layout must be unique;"
+                f" found repeated coordinates {repeated}."
             )
         object.__setattr__(self, "_coords", trap_coordinates)
         object.__setattr__(self, "slug", slug)

--- a/pulser-core/pulser/register/weight_maps.py
+++ b/pulser-core/pulser/register/weight_maps.py
@@ -64,8 +64,8 @@ class WeightMap(Traps, RegDrawer):
         if len(cast(list, trap_coordinates)) != len(weights):
             raise ValueError(
                 "Number of traps and weights don't match; got "
-                f"{len(cast(list, trap_coordinates))} traps and "
-                f"weights {list(weights)}."
+                f"{len(cast(list, trap_coordinates))} traps and weights "
+                f"{pm.AbstractArray(weights).as_array(detach=True).tolist()}."
             )
         weights_arr = np.array(weights)
         if not (np.all(weights_arr >= 0) and np.all(weights_arr <= 1)):
@@ -74,7 +74,7 @@ class WeightMap(Traps, RegDrawer):
             ].tolist()
             raise ValueError(
                 "All weights must be between 0 and 1; found out-of-range "
-                f"weights {out_of_range} in {list(weights)}."
+                f"weights {out_of_range} in {weights_arr.tolist()}."
             )
         if np.count_nonzero(weights) == 0:
             warnings.warn(

--- a/pulser-core/pulser/register/weight_maps.py
+++ b/pulser-core/pulser/register/weight_maps.py
@@ -64,8 +64,7 @@ class WeightMap(Traps, RegDrawer):
         if len(cast(list, trap_coordinates)) != len(weights):
             raise ValueError(
                 f"Number of traps ({len(cast(list, trap_coordinates))}) and "
-                f"weights ({len(weights)}) don't match; got weights "
-                f"{pm.AbstractArray(weights).as_array(detach=True).tolist()}."
+                f"weights ({len(weights)}) don't match."
             )
         weights_arr = np.array(weights)
         if not (np.all(weights_arr >= 0) and np.all(weights_arr <= 1)):

--- a/pulser-core/pulser/register/weight_maps.py
+++ b/pulser-core/pulser/register/weight_maps.py
@@ -62,11 +62,20 @@ class WeightMap(Traps, RegDrawer):
         """Initializes a new weight map."""
         super().__init__(trap_coordinates, slug)
         if len(cast(list, trap_coordinates)) != len(weights):
-            raise ValueError("Number of traps and weights don't match.")
-        if not (
-            np.all(np.array(weights) >= 0) and np.all(np.array(weights) <= 1)
-        ):
-            raise ValueError("All weights must be between 0 and 1.")
+            raise ValueError(
+                "Number of traps and weights don't match; got "
+                f"{len(cast(list, trap_coordinates))} traps and "
+                f"{len(weights)} weights {list(weights)}."
+            )
+        weights_arr = np.array(weights)
+        if not (np.all(weights_arr >= 0) and np.all(weights_arr <= 1)):
+            out_of_range = weights_arr[
+                (weights_arr < 0) | (weights_arr > 1)
+            ].tolist()
+            raise ValueError(
+                "All weights must be between 0 and 1; found out-of-range "
+                f"weights {out_of_range} in {list(weights)}."
+            )
         if np.count_nonzero(weights) == 0:
             warnings.warn(
                 "A WeightMap should have at least one non-zero weight.",

--- a/pulser-core/pulser/register/weight_maps.py
+++ b/pulser-core/pulser/register/weight_maps.py
@@ -63,8 +63,8 @@ class WeightMap(Traps, RegDrawer):
         super().__init__(trap_coordinates, slug)
         if len(cast(list, trap_coordinates)) != len(weights):
             raise ValueError(
-                "Number of traps and weights don't match; got "
-                f"{len(cast(list, trap_coordinates))} traps and weights "
+                f"Number of traps ({len(cast(list, trap_coordinates))}) and "
+                f"weights ({len(weights)}) don't match; got weights "
                 f"{pm.AbstractArray(weights).as_array(detach=True).tolist()}."
             )
         weights_arr = np.array(weights)

--- a/pulser-core/pulser/register/weight_maps.py
+++ b/pulser-core/pulser/register/weight_maps.py
@@ -65,12 +65,12 @@ class WeightMap(Traps, RegDrawer):
             raise ValueError(
                 "Number of traps and weights don't match; got "
                 f"{len(cast(list, trap_coordinates))} traps and "
-                f"{len(weights)} weights {list(weights)}."
+                f"weights {list(weights)}."
             )
         weights_arr = np.array(weights)
         if not (np.all(weights_arr >= 0) and np.all(weights_arr <= 1)):
             out_of_range = weights_arr[
-                (weights_arr < 0) | (weights_arr > 1)
+                ~((weights_arr >= 0) & (weights_arr <= 1))
             ].tolist()
             raise ValueError(
                 "All weights must be between 0 and 1; found out-of-range "

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -82,7 +82,7 @@ class TestDetuningMap:
                 ValueError,
                 match=re.escape(
                     "The trap ids of detuning weights have to be integers"
-                    " in [0, 3]."
+                    " in [0, 3]. Got invalid ids "
                 ),
             ):
                 reg.define_detuning_map(bad_key)
@@ -204,9 +204,23 @@ class TestDetuningMap:
         map_reg: MappableRegister,
     ):
         with pytest.raises(
-            ValueError, match="Number of traps and weights don't match."
+            ValueError,
+            match=re.escape(
+                "Number of traps and weights don't match; got 2 traps and "
+                "weights [0]."
+            ),
         ):
             DetuningMap([(0, 0), (1, 0)], [0])
+
+        # NaN is out of range but is caught by neither `< 0` nor `> 1`
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "All weights must be between 0 and 1; found out-of-range "
+                "weights [nan, -0.2] in [0.5, nan, -0.2]."
+            ),
+        ):
+            DetuningMap([(0, 0), (1, 0), (2, 0)], [0.5, float("nan"), -0.2])
 
         for reg in (layout, map_reg, register):
             bad_weights: dict[int | str, float]
@@ -218,7 +232,11 @@ class TestDetuningMap:
                 bad_weights = {0: -1.0, 1: 1.0, 2: 1.0}
                 zero_weights = {0: 0.0}
             with pytest.raises(
-                ValueError, match="All weights must be between 0 and 1."
+                ValueError,
+                match=re.escape(
+                    "All weights must be between 0 and 1; found out-of-range "
+                    "weights [-1.0] in [-1.0, 1.0, 1.0]."
+                ),
             ):
                 reg.define_detuning_map(bad_weights)  # type: ignore
             with pytest.warns(

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -82,7 +82,7 @@ class TestDetuningMap:
                 ValueError,
                 match=re.escape(
                     "The trap ids of detuning weights have to be integers"
-                    " in [0, 3]. Got invalid ids "
+                    " in [0, 3]; got invalid ids "
                 ),
             ):
                 reg.define_detuning_map(bad_key)
@@ -206,7 +206,7 @@ class TestDetuningMap:
         with pytest.raises(
             ValueError,
             match=re.escape(
-                "Number of traps and weights don't match; got 2 traps and "
+                "Number of traps (2) and weights (1) don't match; got "
                 "weights [0]."
             ),
         ):
@@ -241,8 +241,8 @@ class TestDetuningMap:
             with pytest.raises(
                 ValueError,
                 match=re.escape(
-                    "Number of traps and weights don't match; got 3 traps "
-                    "and weights [0.5, 1.5]."
+                    "Number of traps (3) and weights (2) don't match; got "
+                    "weights [0.5, 1.5]."
                 ),
             ):
                 DetuningMap(

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -222,6 +222,34 @@ class TestDetuningMap:
         ):
             DetuningMap([(0, 0), (1, 0), (2, 0)], [0.5, float("nan"), -0.2])
 
+        # array-like weights are reported as plain numbers, not as the
+        # repr of each scalar (eg "np.float64(0.5)")
+        for array_weights in (
+            np.array([0.5, 1.5]),
+            np.array([0.5, 1.5], dtype=np.float32),
+        ):
+            with pytest.raises(
+                ValueError,
+                match=re.escape(
+                    "All weights must be between 0 and 1; found out-of-range "
+                    "weights [1.5] in [0.5, 1.5]."
+                ),
+            ):
+                DetuningMap(
+                    [(0, 0), (1, 0)], array_weights  # type: ignore[arg-type]
+                )
+            with pytest.raises(
+                ValueError,
+                match=re.escape(
+                    "Number of traps and weights don't match; got 3 traps "
+                    "and weights [0.5, 1.5]."
+                ),
+            ):
+                DetuningMap(
+                    [(0, 0), (1, 0), (2, 0)],
+                    array_weights,  # type: ignore[arg-type]
+                )
+
         for reg in (layout, map_reg, register):
             bad_weights: dict[int | str, float]
             zero_weights: dict[int | str, float]

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -206,8 +206,7 @@ class TestDetuningMap:
         with pytest.raises(
             ValueError,
             match=re.escape(
-                "Number of traps (2) and weights (1) don't match; got "
-                "weights [0]."
+                "Number of traps (2) and weights (1) don't match."
             ),
         ):
             DetuningMap([(0, 0), (1, 0)], [0])
@@ -241,8 +240,7 @@ class TestDetuningMap:
             with pytest.raises(
                 ValueError,
                 match=re.escape(
-                    "Number of traps (3) and weights (2) don't match; got "
-                    "weights [0.5, 1.5]."
+                    "Number of traps (3) and weights (2) don't match."
                 ),
             ):
                 DetuningMap(

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -50,7 +50,10 @@ def test_creation():
     ):
         Register(ids)
 
-    with pytest.raises(ValueError, match="vectors of size 2"):
+    with pytest.raises(
+        ValueError,
+        match=re.escape("vectors of size 2; got 4D coordinates."),
+    ):
         Register.from_coordinates([(0, 1, 0, 1)], prefix="q")
 
     with pytest.raises(
@@ -62,7 +65,10 @@ def test_creation():
     ):
         Register.from_coordinates(coords, prefix="a", labels=["a", "b"])
 
-    with pytest.raises(ValueError, match="vectors of size 3"):
+    with pytest.raises(
+        ValueError,
+        match=re.escape("vectors of size 3; got 2D coordinates."),
+    ):
         Register3D.from_coordinates([((1, 0),), ((-1, 0),)], prefix="q")
 
     reg1 = Register(qubits)
@@ -148,12 +154,36 @@ def test_rectangular_lattice():
         Register.rectangular_lattice(2, 0, 3, 4)
 
     # Check row spacing
-    with pytest.raises(ValueError, match="Spacing"):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Spacing between atoms must be greater than 0; got row spacing "
+            "0.0 and column spacing 5."
+        ),
+    ):
         Register.rectangular_lattice(2, 2, 0.0, 5)
 
     # Check col spacing
-    with pytest.raises(ValueError, match="Spacing"):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Spacing between atoms must be greater than 0; got row spacing "
+            "3 and column spacing 0.0."
+        ),
+    ):
         Register.rectangular_lattice(2, 2, 3, 0.0)
+
+    # `square` and `rectangle` forward a single `spacing`, so the message
+    # must not name parameters those signatures don't have
+    with pytest.raises(ValueError, match="Spacing") as exc_info:
+        Register.square(2, spacing=0)
+    assert "row_spacing" not in str(exc_info.value)
+    assert "col_spacing" not in str(exc_info.value)
+
+    with pytest.raises(ValueError, match="Spacing") as exc_info:
+        Register.rectangle(2, 2, spacing=0)
+    assert "row_spacing" not in str(exc_info.value)
+    assert "col_spacing" not in str(exc_info.value)
 
 
 def test_rectangle():

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -270,7 +270,7 @@ def test_max_connectivity():
         TypeError,
         match=re.escape(
             "'device' must be of type 'BaseDevice', not "
-            "<class 'NoneType'> (None)."
+            "<class 'NoneType'>: None."
         ),
     ):
         reg = Register.max_connectivity(2, None)

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -266,7 +266,13 @@ def test_max_connectivity():
     crest_y = np.sqrt(3) / 2.0
 
     # Check device type
-    with pytest.raises(TypeError):
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "'device' must be of type 'BaseDevice', not "
+            "<class 'NoneType'> (None)."
+        ),
+    ):
         reg = Register.max_connectivity(2, None)
 
     # Check min number of atoms

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -269,7 +269,7 @@ def test_max_connectivity():
     with pytest.raises(
         TypeError,
         match=re.escape(
-            "'device' must be of type 'BaseDevice', not "
+            "'device' must be an instance of 'BaseDevice', not "
             "<class 'NoneType'>: None."
         ),
     ):
@@ -802,7 +802,7 @@ def test_automatic_layout(optimal_filling, reg, max_atom_num):
             == trap_num
         )
 
-    with pytest.raises(TypeError, match="must be of type Device"):
+    with pytest.raises(TypeError, match="must be an instance of 'Device'"):
         reg.with_automatic_layout(MockDevice)
 
     # Minimum number of traps is too high

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -116,8 +116,8 @@ def test_register_definition(layout, layout3d):
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "must have the same size as the number of provided 'trap_ids' "
-            "(2); got qubit ids (3): ['a', 'b', 'c']."
+            "must have the same size as the number of provided 'trap_ids'; "
+            "got 2 'trap_ids' vs. 3 'qubit_ids'."
         ),
     ):
         layout.define_register(0, 1, qubit_ids=["a", "b", "c"])
@@ -304,7 +304,7 @@ def test_mappable_register_creation():
         ValueError,
         match=re.escape(
             "greater than the number of traps in this layout (50); got "
-            "qubit ids (51): ['q0', 'q1',"
+            "51 qubit ids: ['q0', 'q1',"
         ),
     ):
         tri.make_mappable_register(51)

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -42,8 +42,8 @@ def test_creation(layout, layout3d):
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "must be an array or list of coordinates; got <class 'list'> "
-            "([[0, 0, 0], [1, 1], [1, 0], [0, 1]])."
+            "must be an array or list of coordinates; got <class 'list'>: "
+            "[[0, 0, 0], [1, 1], [1, 0], [0, 1]]."
         ),
     ):
         RegisterLayout([[0, 0, 0], [1, 1], [1, 0], [0, 1]])
@@ -52,7 +52,7 @@ def test_creation(layout, layout3d):
         ValueError,
         match=re.escape(
             "must be an array or list of coordinates; got an array of "
-            "shape (3,)."
+            "shape (3,): [0, 1, 2]."
         ),
     ):
         RegisterLayout([0, 1, 2])
@@ -117,7 +117,7 @@ def test_register_definition(layout, layout3d):
         ValueError,
         match=re.escape(
             "must have the same size as the number of provided 'trap_ids' "
-            "(2); got qubit ids ['a', 'b', 'c']."
+            "(2); got qubit ids (3): ['a', 'b', 'c']."
         ),
     ):
         layout.define_register(0, 1, qubit_ids=["a", "b", "c"])
@@ -300,7 +300,13 @@ def test_triangular_lattice_layout():
 
 def test_mappable_register_creation():
     tri = TriangularLatticeLayout(50, 5)
-    with pytest.raises(ValueError, match="greater than the number of traps"):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "greater than the number of traps in this layout (50); got "
+            "qubit ids (51): ['q0', 'q1',"
+        ),
+    ):
         tri.make_mappable_register(51)
 
     mapp_reg = tri.make_mappable_register(5)
@@ -312,16 +318,27 @@ def test_mappable_register_creation():
         ValueError,
         match=re.escape(
             "must be selected among pre-declared qubit IDs; ['q5'] not in "
+            "['q0', 'q1', 'q2', 'q3', 'q4']."
         ),
     ):
         mapp_reg.find_indices(["q4", "q2", "q1", "q5"])
 
     with pytest.raises(
         ValueError,
-        match=re.escape("labeled with pre-declared qubit IDs; ['q5'] not in "),
+        match=re.escape(
+            "labeled with pre-declared qubit IDs; ['q5'] not in "
+            "['q0', 'q1', 'q2', 'q3', 'q4']."
+        ),
     ):
         mapp_reg.build_register({"q0": 0, "q5": 2})
-    with pytest.raises(ValueError, match="To declare 2 qubits"):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "To declare 2 qubits, 'qubits' should contain the first 2 "
+            "elements of the 'qubit_ids'; got ['q0', 'q2'], expected "
+            "['q0', 'q1']."
+        ),
+    ):
         mapp_reg.build_register({"q0": 0, "q2": 2})
 
     qubit_map = {"q0": 10, "q1": 49}

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -45,7 +45,11 @@ def test_creation(layout, layout3d):
         RegisterLayout([[0, 0, 0], [1, 1], [1, 0], [0, 1]])
 
     with pytest.raises(
-        ValueError, match="must be an array or list of coordinates"
+        ValueError,
+        match=re.escape(
+            "must be an array or list of coordinates; got an array of "
+            "shape (3,)."
+        ),
     ):
         RegisterLayout([0, 1, 2])
 
@@ -54,7 +58,10 @@ def test_creation(layout, layout3d):
 
     with pytest.raises(
         ValueError,
-        match="All trap coordinates of a register layout must be unique.",
+        match=re.escape(
+            "All trap coordinates of a register layout must be unique; "
+            "found repeated coordinates [[0.0, 1.0]]."
+        ),
     ):
         RegisterLayout([[0, 1], [0.0, 1.0]])
 
@@ -76,16 +83,39 @@ def test_slug(layout, layout3d):
 
 
 def test_register_definition(layout, layout3d):
-    with pytest.raises(ValueError, match="must be a unique integer"):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "must be a unique integer; found repeated ids [1] in [0, 1, 1]."
+        ),
+    ):
         layout.define_register(0, 1, 1)
 
-    with pytest.raises(ValueError, match="correspond to the ID of a trap"):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "correspond to the ID of a trap; got invalid ids [4] in "
+            "[0, 4, 3], must be integers in [0, 3]."
+        ),
+    ):
         layout.define_register(0, 4, 3)
 
-    with pytest.raises(ValueError, match="must be a sequence of unique IDs"):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "must be a sequence of unique IDs; found repeated ids ['b'] in "
+            "['a', 'b', 'b']."
+        ),
+    ):
         layout.define_register(0, 1, qubit_ids=["a", "b", "b"])
 
-    with pytest.raises(ValueError, match="must have the same size"):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "must have the same size as the number of provided 'trap_ids' "
+            "(2); got qubit ids ['a', 'b', 'c']."
+        ),
+    ):
         layout.define_register(0, 1, qubit_ids=["a", "b", "c"])
 
     assert layout.define_register(0, 1) == Register.from_coordinates(
@@ -275,12 +305,16 @@ def test_mappable_register_creation():
     assert mapp_reg.find_indices(["q4", "q2", "q1", "q2"]) == [4, 2, 1, 2]
 
     with pytest.raises(
-        ValueError, match="must be selected among pre-declared qubit IDs"
+        ValueError,
+        match=re.escape(
+            "must be selected among pre-declared qubit IDs; ['q5'] not in "
+        ),
     ):
         mapp_reg.find_indices(["q4", "q2", "q1", "q5"])
 
     with pytest.raises(
-        ValueError, match="labeled with pre-declared qubit IDs"
+        ValueError,
+        match=re.escape("labeled with pre-declared qubit IDs; ['q5'] not in "),
     ):
         mapp_reg.build_register({"q0": 0, "q5": 2})
     with pytest.raises(ValueError, match="To declare 2 qubits"):

--- a/tests/test_register_layout.py
+++ b/tests/test_register_layout.py
@@ -40,7 +40,11 @@ def layout3d():
 
 def test_creation(layout, layout3d):
     with pytest.raises(
-        ValueError, match="must be an array or list of coordinates"
+        ValueError,
+        match=re.escape(
+            "must be an array or list of coordinates; got <class 'list'> "
+            "([[0, 0, 0], [1, 1], [1, 0], [0, 1]])."
+        ),
     ):
         RegisterLayout([[0, 0, 0], [1, 1], [1, 0], [0, 1]])
 


### PR DESCRIPTION
Hi @a-corni,

Following on from #1095, this covers the rest of the register module.

| File | Messages | What they report now |
|---|---|---|
| `traps.py` | 3 | the coordinates given, their shape, the repeated ones |
| `weight_maps.py` | 2 | the weights given and which are out of `[0, 1]` |
| `register_layout.py` | 5 | repeated / invalid trap ids, repeated / mismatched qubit ids |
| `mappable_reg.py` | 4 | the qubit ids given and which were pre-declared |
| `register.py` | 3 | the dimensionality, the spacings, the device type |
| `register3d.py` | 1 | the dimensionality |
| **Total** | **18** | |

Two of them turned out to be more than wording:

- `Traps` raised the same message whether the coordinates couldn't be read as numbers at all or were merely the wrong shape, so `"abc"` and `[0, 1, 2]` were indistinguishable. Split into two.
- Weights outside `[0, 1]` were selected with `< 0 | > 1`. NaN satisfies neither, but does trigger the error — so a NaN weight raised an error whose list of offending weights was empty. Selecting by the negation of the accepted range fixes it.
