### PR TITLE
Support standalone DetuningMap serialization

### DIFF
--- a/pulser-core/MANIFEST.in
+++ b/pulser-core/MANIFEST.in
@@ -4,6 +4,7 @@ include pulser/devices/interaction_coefficients/C3_coeffs.json
 include pulser/devices/interaction_coefficients/C6_coeffs.json
 include pulser/json/abstract_repr/schemas/device-schema.json
 include pulser/json/abstract_repr/schemas/sequence-schema.json
+include pulser/json/abstract_repr/schemas/weight-map-schema.json
 include pulser/json/abstract_repr/schemas/register-schema.json
 include pulser/json/abstract_repr/schemas/layout-schema.json
 include pulser/json/abstract_repr/schemas/noise-schema.json

--- a/pulser-core/pulser/json/abstract_repr/deserializer.py
+++ b/pulser-core/pulser/json/abstract_repr/deserializer.py
@@ -581,6 +581,20 @@ def _deserialize_det_map(ser_det_map: dict) -> DetuningMap:
     )
 
 
+def deserialize_abstract_weight_map(obj_str: str) -> DetuningMap:
+    """Deserialize a weight map from an abstract JSON object.
+
+    Args:
+        obj_str: The JSON string representing the weight map encoded in the
+            abstract JSON format.
+
+    Returns:
+        The DetuningMap instance.
+    """
+    validate_abstract_repr(obj_str, "weight-map")
+    return _deserialize_det_map(json.loads(obj_str))
+
+
 def deserialize_abstract_sequence(obj_str: str) -> Sequence:
     """Deserialize a sequence from an abstract JSON object.
 

--- a/pulser-core/pulser/json/abstract_repr/deserializer.py
+++ b/pulser-core/pulser/json/abstract_repr/deserializer.py
@@ -581,11 +581,11 @@ def _deserialize_det_map(ser_det_map: dict) -> DetuningMap:
     )
 
 
-def deserialize_abstract_weight_map(obj_str: str) -> DetuningMap:
-    """Deserialize a weight map from an abstract JSON object.
+def deserialize_detuning_map(obj_str: str) -> DetuningMap:
+    """Deserialize a detuning map from an abstract JSON object.
 
     Args:
-        obj_str: The JSON string representing the weight map encoded in the
+        obj_str: The JSON string representing the detuning map encoded in the
             abstract JSON format.
 
     Returns:

--- a/pulser-core/pulser/json/abstract_repr/schemas/sequence-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/sequence-schema.json
@@ -517,7 +517,7 @@
       "additionalProperties": false,
       "properties": {
         "detuning_map": {
-          "$ref": "#/definitions/WeightMap",
+          "$ref": "weight-map-schema.json",
           "description": "DetuningMap to associate with the DMM channel."
         },
         "dmm_id": {
@@ -1461,48 +1461,6 @@
         }
       ],
       "description": "Modulation waveform of any kind"
-    },
-    "WeightMap": {
-      "additionalProperties": false,
-      "description": "Associates weights to trap coordinates. The sum of the provided weights must be equal to 1.",
-      "properties": {
-        "slug": {
-          "type": "string"
-        },
-        "traps": {
-          "items": {
-            "$ref": "#/definitions/WeightedTrap"
-          },
-          "type": "array"
-        }
-      },
-      "required": [
-        "traps"
-      ],
-      "type": "object"
-    },
-    "WeightedTrap": {
-      "additionalProperties": false,
-      "properties": {
-        "weight": {
-          "description": "The weight on the site.",
-          "type": "number"
-        },
-        "x": {
-          "description": "x-position in µm",
-          "type": "number"
-        },
-        "y": {
-          "description": "y-position in µm",
-          "type": "number"
-        }
-      },
-      "required": [
-        "weight",
-        "x",
-        "y"
-      ],
-      "type": "object"
     }
   }
 }

--- a/pulser-core/pulser/json/abstract_repr/schemas/weight-map-schema.json
+++ b/pulser-core/pulser/json/abstract_repr/schemas/weight-map-schema.json
@@ -1,0 +1,49 @@
+{
+  "$id": "weight-map-schema.json",
+  "$ref": "#/definitions/WeightMap",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "WeightMap": {
+      "additionalProperties": false,
+      "description": "Associates weights to trap coordinates. The sum of the provided weights must be equal to 1.",
+      "properties": {
+        "slug": {
+          "type": "string"
+        },
+        "traps": {
+          "items": {
+            "$ref": "#/definitions/WeightedTrap"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "traps"
+      ],
+      "type": "object"
+    },
+    "WeightedTrap": {
+      "additionalProperties": false,
+      "properties": {
+        "weight": {
+          "description": "The weight on the site.",
+          "type": "number"
+        },
+        "x": {
+          "description": "x-position in µm",
+          "type": "number"
+        },
+        "y": {
+          "description": "y-position in µm",
+          "type": "number"
+        }
+      },
+      "required": [
+        "weight",
+        "x",
+        "y"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/pulser-core/pulser/json/utils.py
+++ b/pulser-core/pulser/json/utils.py
@@ -123,6 +123,7 @@ ObjectType = Literal[
     "device",
     "layout",
     "register",
+    "weight-map",
     "noise",
     "results",
     "config",

--- a/pulser-core/pulser/register/weight_maps.py
+++ b/pulser-core/pulser/register/weight_maps.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import typing
 import warnings
 from dataclasses import dataclass
@@ -35,7 +36,10 @@ if TYPE_CHECKING:
 
 from scipy.spatial.distance import cdist
 
+import pulser.json.abstract_repr as pulser_abstract_repr
 import pulser.math as pm
+from pulser.json.abstract_repr.serializer import AbstractReprEncoder
+from pulser.json.abstract_repr.validation import validate_abstract_repr
 
 WEIGHT_PRECISION = 6
 
@@ -213,6 +217,38 @@ class WeightMap(Traps, RegDrawer):
         if self.slug is not None:
             d["slug"] = self.slug
         return d
+
+    def to_abstract_repr(self) -> str:
+        """Serialize the weight map into an abstract JSON object."""
+        abstr_str = json.dumps(self, cls=AbstractReprEncoder)
+        validate_abstract_repr(abstr_str, "weight-map")
+        return abstr_str
+
+    @classmethod
+    def from_abstract_repr(
+        cls: type[WeightMapType], obj_str: str
+    ) -> WeightMapType:
+        """Deserialize a weight map from an abstract JSON object.
+
+        Args:
+            obj_str: The JSON string representing the weight map encoded in
+                the abstract JSON format.
+        """
+        if not isinstance(obj_str, str):
+            raise TypeError(
+                "The serialized weight map must be given as a string. "
+                f"Instead, got object of type {type(obj_str)}."
+            )
+        detuning_map = (
+            pulser_abstract_repr.deserializer.deserialize_abstract_weight_map(
+                obj_str
+            )
+        )
+        return cls(
+            detuning_map.trap_coordinates,
+            detuning_map.weights,
+            detuning_map.slug,
+        )
 
 
 @dataclass(init=False, repr=False, eq=False, frozen=True)

--- a/pulser-core/pulser/register/weight_maps.py
+++ b/pulser-core/pulser/register/weight_maps.py
@@ -218,38 +218,6 @@ class WeightMap(Traps, RegDrawer):
             d["slug"] = self.slug
         return d
 
-    def to_abstract_repr(self) -> str:
-        """Serialize the weight map into an abstract JSON object."""
-        abstr_str = json.dumps(self, cls=AbstractReprEncoder)
-        validate_abstract_repr(abstr_str, "weight-map")
-        return abstr_str
-
-    @classmethod
-    def from_abstract_repr(
-        cls: type[WeightMapType], obj_str: str
-    ) -> WeightMapType:
-        """Deserialize a weight map from an abstract JSON object.
-
-        Args:
-            obj_str: The JSON string representing the weight map encoded in
-                the abstract JSON format.
-        """
-        if not isinstance(obj_str, str):
-            raise TypeError(
-                "The serialized weight map must be given as a string. "
-                f"Instead, got object of type {type(obj_str)}."
-            )
-        detuning_map = (
-            pulser_abstract_repr.deserializer.deserialize_abstract_weight_map(
-                obj_str
-            )
-        )
-        return cls(
-            detuning_map.trap_coordinates,
-            detuning_map.weights,
-            detuning_map.slug,
-        )
-
 
 @dataclass(init=False, repr=False, eq=False, frozen=True)
 class DetuningMap(WeightMap):
@@ -265,3 +233,26 @@ class DetuningMap(WeightMap):
         weights: A list of detuning weights (between 0 and 1) to associate
             to the traps.
     """
+
+    def to_abstract_repr(self) -> str:
+        """Serialize the detuning map into an abstract JSON object."""
+        abstr_str = json.dumps(self, cls=AbstractReprEncoder)
+        validate_abstract_repr(abstr_str, "weight-map")
+        return abstr_str
+
+    @staticmethod
+    def from_abstract_repr(obj_str: str) -> DetuningMap:
+        """Deserialize a detuning map from an abstract JSON object.
+
+        Args:
+            obj_str: The JSON string representing the detuning map encoded in
+                the abstract JSON format.
+        """
+        if not isinstance(obj_str, str):
+            raise TypeError(
+                "The serialized detuning map must be given as a string. "
+                f"Instead, got object of type {type(obj_str)}."
+            )
+        return pulser_abstract_repr.deserializer.deserialize_detuning_map(
+            obj_str
+        )

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -68,6 +68,7 @@ from pulser.register.special_layouts import (
     SquareLatticeLayout,
     TriangularLatticeLayout,
 )
+from pulser.register.weight_maps import DetuningMap, WeightMap
 from pulser.sequence import (
     store_extra_metadata,
     store_package_version_metadata,
@@ -191,6 +192,31 @@ def test_layout(layout: RegisterLayout):
             [0, 0, 0] if layout.dimensionality == 2 else [0, 0]
         )
         RegisterLayout.from_abstract_repr(json.dumps(ser_layout_obj))
+
+
+@pytest.mark.parametrize(
+    "weight_map",
+    [
+        WeightMap([[0, 0], [1, 1]], [0.2, 0.8]),
+        DetuningMap([[0, 0], [1, 1]], [0.2, 0.8]),
+        DetuningMap([[2, 1], [-1, 3]], [1.0, 0.0], slug="map"),
+    ],
+)
+def test_weight_map(weight_map: WeightMap):
+    ser_weight_map_str = weight_map.to_abstract_repr()
+    ser_weight_map_obj = json.loads(ser_weight_map_str)
+    assert ser_weight_map_obj.get("slug") == weight_map.slug
+
+    re_weight_map = type(weight_map).from_abstract_repr(ser_weight_map_str)
+    assert re_weight_map == weight_map
+    assert type(re_weight_map) is type(weight_map)
+
+    with pytest.raises(TypeError, match="must be given as a string"):
+        DetuningMap.from_abstract_repr(ser_weight_map_obj)
+
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        ser_weight_map_obj["traps"][0]["z"] = 0
+        DetuningMap.from_abstract_repr(json.dumps(ser_weight_map_obj))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -68,7 +68,7 @@ from pulser.register.special_layouts import (
     SquareLatticeLayout,
     TriangularLatticeLayout,
 )
-from pulser.register.weight_maps import DetuningMap, WeightMap
+from pulser.register.weight_maps import DetuningMap
 from pulser.sequence import (
     store_extra_metadata,
     store_package_version_metadata,
@@ -197,12 +197,11 @@ def test_layout(layout: RegisterLayout):
 @pytest.mark.parametrize(
     "weight_map",
     [
-        WeightMap([[0, 0], [1, 1]], [0.2, 0.8]),
         DetuningMap([[0, 0], [1, 1]], [0.2, 0.8]),
         DetuningMap([[2, 1], [-1, 3]], [1.0, 0.0], slug="map"),
     ],
 )
-def test_weight_map(weight_map: WeightMap):
+def test_detuning_map(weight_map: DetuningMap):
     ser_weight_map_str = weight_map.to_abstract_repr()
     ser_weight_map_obj = json.loads(ser_weight_map_str)
     assert ser_weight_map_obj.get("slug") == weight_map.slug


### PR DESCRIPTION
## Summary

- move the weight map definition into its own schema
- make the sequence schema reference the new schema
- add standalone serialization and deserialization methods to `DetuningMap`
- include the new schema in source distributions

Existing sequence JSON remains unchanged.

## Testing

- 244 abstract representation and detuning map tests
- Black 24.4.0
- isort 5.12.0
- Flake8 7.1.1
- Ruff 0.11.1
- JSON parsing and schema reference checks

Closes #1065