### PR TITLE
Report offending input in parametrized module error messages

### DIFF
--- a/pulser-core/pulser/parametrized/paramobj.py
+++ b/pulser-core/pulser/parametrized/paramobj.py
@@ -289,8 +289,9 @@ class ParamObj(Parametrized, OpSupport):
                 args[0] = class_to_dict(self.args[0])
             else:
                 raise NotImplementedError(
-                    "Instance or static method "
-                    "serialization is not supported."
+                    "Instance or static method serialization is not "
+                    "supported; got "
+                    f"'{type(self.args[0]).__name__}.{self.cls.__name__}'."
                 )
         else:
             cls_dict = class_to_dict(self.cls)
@@ -344,7 +345,8 @@ class ParamObj(Parametrized, OpSupport):
                 else:
                     return abstract_repr(name, **all_args)
             raise NotImplementedError(
-                "Instance or static method serialization is not supported."
+                "Instance or static method serialization is not supported; "
+                f"got '{type(self.args[0]).__name__}.{op_name}'."
             )
         elif op_name in SIGNATURES:
             signature = SIGNATURES[op_name]

--- a/pulser-core/pulser/parametrized/variable.py
+++ b/pulser-core/pulser/parametrized/variable.py
@@ -45,13 +45,21 @@ class Variable(Parametrized, OpSupport):
 
     def __post_init__(self) -> None:
         if not isinstance(self.name, str):
-            raise TypeError("Variable's 'name' has to be of type 'str'.")
+            raise TypeError(
+                "Variable's 'name' has to be of type 'str', not "
+                f"{type(self.name)}."
+            )
         if self.dtype not in [int, float]:
             raise TypeError(f"Invalid data type '{self.dtype}' for Variable.")
         if not isinstance(self.size, int):
-            raise TypeError("Given variable 'size' is not of type 'int'.")
+            raise TypeError(
+                "Variable's 'size' has to be of type 'int', not "
+                f"{type(self.size)}."
+            )
         elif self.size < 1:
-            raise ValueError("Variables must be of size 1 or larger.")
+            raise ValueError(
+                f"Variables must be of size 1 or larger; got {self.size}."
+            )
 
         self._count: int
         object.__setattr__(self, "_count", -1)  # Counts the updates

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -1189,7 +1189,10 @@ class TestSerialization:
         method_call = parametrize(BlackmanWaveform.with_new_duration)(wf, var)
         with pytest.raises(
             NotImplementedError,
-            match="Instance or static method serialization is not supported.",
+            match=re.escape(
+                "Instance or static method serialization is not supported; "
+                "got 'BlackmanWaveform.with_new_duration'."
+            ),
         ):
             method_call._to_abstract_repr()
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -218,7 +218,10 @@ def test_rare_cases(patch_plt_show, helpers):
     rotated_reg = parametrize(Register.rotated)(reg, var)
     with pytest.raises(
         NotImplementedError,
-        match="Instance or static method serialization is not supported.",
+        match=re.escape(
+            "Instance or static method serialization is not supported; "
+            "got 'Register.rotated'."
+        ),
     ):
         encode(rotated_reg)
 

--- a/tests/test_parametrized.py
+++ b/tests/test_parametrized.py
@@ -56,13 +56,26 @@ def bwf(t, a):
 
 
 def test_var(a, b):
-    with pytest.raises(TypeError, match="'name' has to be of type 'str'"):
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Variable's 'name' has to be of type 'str', not <class 'int'>."
+        ),
+    ):
         Variable(1, dtype=int)
     with pytest.raises(TypeError, match="Invalid data type"):
         Variable("x", dtype=list, size=4)
-    with pytest.raises(TypeError, match="'size' is not of type 'int'"):
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Variable's 'size' has to be of type 'int', not <class 'tuple'>."
+        ),
+    ):
         Variable("x", dtype=float, size=(2, 2))
-    with pytest.raises(ValueError, match="size 1 or larger"):
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Variables must be of size 1 or larger; got 0."),
+    ):
         Variable("x", dtype=int, size=0)
     x = Variable("x", dtype=float)
     assert x.value is None


### PR DESCRIPTION
Hi @a-corni, @HGSilveri,

Following on from #1095, #1097, #1098 and #1102, this covers the parametrized module: 5 messages, 3 in `variable.py` and 2 in `paramobj.py`.

The two in `paramobj.py` are the same message raised from `_to_dict` and `_to_abstract_repr`. Both now name the method that couldn't be serialized, e.g. `got 'Register.rotated'`.

I left the `Serialization of calls to parametrized objects is not supported` pair unchanged. Calling a parametrized object already warns at that line, and the warning includes the same object, so repeating it in the error adds nothing.

Partially addresses #1057.
