### PR TITLE
Report the offending input in the devices module error messages

### DIFF
--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -292,8 +292,8 @@ class BaseDevice(ABC):
             ):
                 raise TypeError(
                     "When defined, 'channel_ids' must be a tuple or a list "
-                    "of strings; "
-                    f"got {type(self.channel_ids)}: {self.channel_ids}."
+                    "of strings, not "
+                    f"{type(self.channel_ids)}: {self.channel_ids}."
                 )
             if len(self.channel_ids) != len(set(self.channel_ids)):
                 repeated_ids = [
@@ -309,10 +309,9 @@ class BaseDevice(ABC):
             if len(self.channel_ids) != len(self.channel_objects):
                 raise PulserValueError(
                     "When defined, the number of channel IDs must"
-                    " match the number of channel objects; "
-                    f"got {len(self.channel_ids)} channel ids for "
-                    f"{len(self.channel_objects)} channel objects: "
-                    f"{self.channel_ids}."
+                    " match the number of channel objects; got "
+                    f"{len(self.channel_ids)} 'channel_ids' vs. "
+                    f"{len(self.channel_objects)} 'channel_objects'."
                 )
             conflicting_ids = [
                 ch_id
@@ -322,8 +321,8 @@ class BaseDevice(ABC):
             if conflicting_ids:
                 raise PulserValueError(
                     "When defined, the names of channel IDs must be different"
-                    " than the names of DMM channels 'dmm_0', 'dmm_1', ... ; "
-                    f"got {conflicting_ids}."
+                    " than the names of DMM channels 'dmm_0', 'dmm_1', "
+                    f"...; got {conflicting_ids}."
                 )
 
         else:
@@ -452,9 +451,8 @@ class BaseDevice(ABC):
         """
         if not isinstance(register, BaseRegister):
             raise TypeError(
-                "'register' must be a pulser.Register or "
-                "a pulser.Register3D instance; "
-                f"got {type(register)}."
+                "'register' must be an instance of 'Register' or "
+                f"'Register3D', not {type(register)}."
             )
 
         if register.dimensionality > self.dimensions:
@@ -484,8 +482,8 @@ class BaseDevice(ABC):
         """
         if not isinstance(layout, RegisterLayout):
             raise TypeError(
-                "'layout' must be a RegisterLayout instance; "
-                f"got {type(layout)}."
+                "'layout' must be an instance of 'RegisterLayout', not "
+                f"{type(layout)}."
             )
 
         if layout.dimensionality > self.dimensions:
@@ -522,9 +520,7 @@ class BaseDevice(ABC):
         if register.layout is None:
             raise TypeError(
                 "'validate_layout_filling' can only be called for"
-                " registers with a register layout; got a "
-                f"{type(register).__name__} with "
-                f"{len(register.qubit_ids)} qubits and no layout."
+                " registers with a register layout."
             )
         n_qubits = len(register.qubit_ids)
         min_qubits = int(
@@ -606,8 +602,8 @@ class BaseDevice(ABC):
     def _validate_rydberg_level(self, ryd_lvl: int) -> None:
         if not isinstance(ryd_lvl, int):
             raise TypeError(
-                "Rydberg level has to be an int; "
-                f"got {type(ryd_lvl)}: {ryd_lvl}."
+                "'rydberg_level' must be an instance of 'int', not "
+                f"{type(ryd_lvl)}: {ryd_lvl}."
             )
         if not 49 < ryd_lvl < 101:
             raise RydbergLevelError(
@@ -1032,9 +1028,8 @@ class Device(BaseDevice):
         """
         if not isinstance(register, (BaseRegister, MappableRegister)):
             raise TypeError(
-                "The register to check must be an instance of "
-                "'BaseRegister' or 'MappableRegister'; "
-                f"got {type(register)}."
+                "'register' must be an instance of 'BaseRegister' or "
+                f"'MappableRegister', not {type(register)}."
             )
         if isinstance(register, BaseRegister) and register.layout is None:
             return False

--- a/pulser-core/pulser/devices/_device_datacls.py
+++ b/pulser-core/pulser/devices/_device_datacls.py
@@ -292,22 +292,38 @@ class BaseDevice(ABC):
             ):
                 raise TypeError(
                     "When defined, 'channel_ids' must be a tuple or a list "
-                    "of strings."
+                    "of strings; "
+                    f"got {type(self.channel_ids)}: {self.channel_ids}."
                 )
             if len(self.channel_ids) != len(set(self.channel_ids)):
+                repeated_ids = [
+                    ch_id
+                    for ch_id, freq in Counter(self.channel_ids).items()
+                    if freq > 1
+                ]
                 raise PulserValueError(
                     "When defined, 'channel_ids' can't have "
-                    "repeated elements."
+                    "repeated elements; "
+                    f"got repeated ids {repeated_ids}."
                 )
             if len(self.channel_ids) != len(self.channel_objects):
                 raise PulserValueError(
                     "When defined, the number of channel IDs must"
-                    " match the number of channel objects."
+                    " match the number of channel objects; "
+                    f"got {len(self.channel_ids)} channel ids for "
+                    f"{len(self.channel_objects)} channel objects: "
+                    f"{self.channel_ids}."
                 )
-            if set(self.channel_ids) & set(self.dmm_channels.keys()):
+            conflicting_ids = [
+                ch_id
+                for ch_id in self.channel_ids
+                if ch_id in self.dmm_channels
+            ]
+            if conflicting_ids:
                 raise PulserValueError(
                     "When defined, the names of channel IDs must be different"
-                    " than the names of DMM channels 'dmm_0', 'dmm_1', ... ."
+                    " than the names of DMM channels 'dmm_0', 'dmm_1', ... ; "
+                    f"got {conflicting_ids}."
                 )
 
         else:
@@ -437,7 +453,8 @@ class BaseDevice(ABC):
         if not isinstance(register, BaseRegister):
             raise TypeError(
                 "'register' must be a pulser.Register or "
-                "a pulser.Register3D instance."
+                "a pulser.Register3D instance; "
+                f"got {type(register)}."
             )
 
         if register.dimensionality > self.dimensions:
@@ -466,7 +483,10 @@ class BaseDevice(ABC):
             layout: The RegisterLayout to validate.
         """
         if not isinstance(layout, RegisterLayout):
-            raise TypeError("'layout' must be a RegisterLayout instance.")
+            raise TypeError(
+                "'layout' must be a RegisterLayout instance; "
+                f"got {type(layout)}."
+            )
 
         if layout.dimensionality > self.dimensions:
             raise DimensionTooHighError(self, invalid=layout.dimensionality)
@@ -502,7 +522,9 @@ class BaseDevice(ABC):
         if register.layout is None:
             raise TypeError(
                 "'validate_layout_filling' can only be called for"
-                " registers with a register layout."
+                " registers with a register layout; got a "
+                f"{type(register).__name__} with "
+                f"{len(register.qubit_ids)} qubits and no layout."
             )
         n_qubits = len(register.qubit_ids)
         min_qubits = int(
@@ -583,7 +605,10 @@ class BaseDevice(ABC):
 
     def _validate_rydberg_level(self, ryd_lvl: int) -> None:
         if not isinstance(ryd_lvl, int):
-            raise TypeError("Rydberg level has to be an int.")
+            raise TypeError(
+                "Rydberg level has to be an int; "
+                f"got {type(ryd_lvl)}: {ryd_lvl}."
+            )
         if not 49 < ryd_lvl < 101:
             raise RydbergLevelError(
                 device=self, min=50, max=100, invalid=ryd_lvl
@@ -1007,8 +1032,9 @@ class Device(BaseDevice):
         """
         if not isinstance(register, (BaseRegister, MappableRegister)):
             raise TypeError(
-                "The register to check must be of type "
-                "BaseRegister or MappableRegister."
+                "The register to check must be an instance of "
+                "'BaseRegister' or 'MappableRegister'; "
+                f"got {type(register)}."
             )
         if isinstance(register, BaseRegister) and register.layout is None:
             return False

--- a/pulser-core/pulser/exceptions/sequence.py
+++ b/pulser-core/pulser/exceptions/sequence.py
@@ -56,7 +56,7 @@ class DimensionTooHighError(DimensionError):
     def __str__(self) -> str:
         return (
             "The device supports register layouts of at most "
-            f"{self.device.dimensions} dimensions."
+            f"{self.device.dimensions} dimensions, not {self.invalid}."
         )
 
 
@@ -67,7 +67,7 @@ class DimensionPositionsTooHighError(DimensionError):
     def __str__(self) -> str:
         return (
             f"All qubit positions must be at most {self.device.dimensions}D "
-            "vectors"
+            f"vectors, not {self.invalid}D."
         )
 
 
@@ -240,7 +240,10 @@ class RydbergLevelError(InvalidSequenceError):
     max: int
 
     def __str__(self) -> str:
-        return f"Rydberg level should be between {self.min} and {self.max}."
+        return (
+            f"Rydberg level should be between {self.min} and {self.max}, "
+            f"not {self.invalid}."
+        )
 
 
 @dataclass

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -81,18 +81,28 @@ def test_params():
         ("reusable_channels", "true", None),
         ("max_atom_num", 1e9, None),
         ("max_radial_distance", 100.4, None),
-        ("rydberg_level", 70.0, "Rydberg level has to be an int."),
+        (
+            "rydberg_level",
+            70.0,
+            re.escape(
+                "Rydberg level has to be an int; got <class 'float'>: 70.0."
+            ),
+        ),
         (
             "channel_ids",
             {"fake_channel"},
-            "When defined, 'channel_ids' must be a tuple or a list "
-            "of strings.",
+            re.escape(
+                "When defined, 'channel_ids' must be a tuple or a list "
+                "of strings; got <class 'set'>: {'fake_channel'}."
+            ),
         ),
         (
             "channel_ids",
             ("ch1", 2),
-            "When defined, 'channel_ids' must be a tuple or a list "
-            "of strings.",
+            re.escape(
+                "When defined, 'channel_ids' must be a tuple or a list "
+                "of strings; got <class 'tuple'>: ('ch1', 2)."
+            ),
         ),
         (
             "channel_objects",
@@ -123,8 +133,16 @@ def test_post_init_type_checks(test_params, param, value, msg):
             1,
             re.escape("'dimensions' must be one of (2, 3), not 1."),
         ),
-        ("rydberg_level", 49, "Rydberg level should be between 50 and 100."),
-        ("rydberg_level", 101, "Rydberg level should be between 50 and 100."),
+        (
+            "rydberg_level",
+            49,
+            re.escape("Rydberg level should be between 50 and 100, not 49."),
+        ),
+        (
+            "rydberg_level",
+            101,
+            re.escape("Rydberg level should be between 50 and 100, not 101."),
+        ),
         (
             "min_atom_distance",
             -0.001,
@@ -183,13 +201,20 @@ def test_post_init_type_checks(test_params, param, value, msg):
         (
             "channel_ids",
             ("rydberg_global", "rydberg_global"),
-            "When defined, 'channel_ids' can't have repeated elements.",
+            re.escape(
+                "When defined, 'channel_ids' can't have repeated elements; "
+                "got repeated ids ['rydberg_global']."
+            ),
         ),
         (
             "channel_ids",
             ("rydberg_global",),
-            "When defined, the number of channel IDs must"
-            " match the number of channel objects.",
+            re.escape(
+                "When defined, the number of channel IDs must"
+                " match the number of channel objects; "
+                "got 1 channel ids for 0 channel objects: "
+                "('rydberg_global',)."
+            ),
         ),
         ("max_sequence_duration", 0, None),
         ("max_runs", 0, None),
@@ -396,7 +421,12 @@ def test_change_rydberg_level(helpers):
     # Both interaction coefficients follow the new Rydberg level
     assert dev.interaction_coeff == c6_dict[60]
     assert dev.interaction_coeff_xy == c3_dict[60]
-    with pytest.raises(TypeError, match="Rydberg level has to be an int."):
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Rydberg level has to be an int; got <class 'float'>: 70.5."
+        ),
+    ):
         dev.change_rydberg_level(70.5)
     with helpers.raises_all(
         [
@@ -405,7 +435,9 @@ def test_change_rydberg_level(helpers):
             RydbergLevelError,
             InvalidSequenceError,
         ],
-        match="Rydberg level should be between 50 and 100.",
+        match=re.escape(
+            "Rydberg level should be between 50 and 100, not 110."
+        ),
     ):
         dev.change_rydberg_level(110)
     dev.change_rydberg_level(70)
@@ -502,7 +534,13 @@ def test_validate_register(helpers, with_diff):
     ):
         DigitalAnalogDevice.validate_register(Register.square(50, prefix="q"))
 
-    with pytest.raises(TypeError):
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "'register' must be a pulser.Register or "
+            f"a pulser.Register3D instance; got {type(bad_coords1)}."
+        ),
+    ):
         DigitalAnalogDevice.validate_register(bad_coords1)
     with helpers.raises_all(
         [ValueError, PulserValueError, InvalidSequenceError, RadiusError],
@@ -520,7 +558,9 @@ def test_validate_register(helpers, with_diff):
             DimensionError,
             DimensionPositionsTooHighError,
         ],
-        match="at most 2D vectors",
+        match=re.escape(
+            "All qubit positions must be at most 2D vectors, not 3D."
+        ),
     ):
         DigitalAnalogDevice.validate_register(
             Register3D.from_coordinates(bad_coords2, prefix="q")
@@ -552,10 +592,15 @@ def test_validate_register(helpers, with_diff):
 
 def test_validate_layout(helpers):
     coords = [(100, 0), (-100, 0)]
-    with pytest.raises(TypeError):
-        DigitalAnalogDevice.validate_layout(
-            Register.from_coordinates(coords, prefix="q")
-        )
+    not_a_layout = Register.from_coordinates(coords, prefix="q")
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "'layout' must be a RegisterLayout instance; "
+            f"got {type(not_a_layout)}."
+        ),
+    ):
+        DigitalAnalogDevice.validate_layout(not_a_layout)
     with helpers.raises_all(
         [ValueError, PulserValueError, InvalidSequenceError, RadiusError],
         match="at most 50 μm away from the center",
@@ -570,7 +615,10 @@ def test_validate_layout(helpers):
             DimensionError,
             DimensionTooHighError,
         ],
-        match="at most 2 dimensions",
+        match=re.escape(
+            "The device supports register layouts of at most 2 dimensions, "
+            "not 3."
+        ),
     ):
         coords = [(-10, 4, 0), (0, 0, 0)]
         DigitalAnalogDevice.validate_layout(RegisterLayout(coords))
@@ -691,14 +739,16 @@ def test_layout_filling_min_traps():
 
 
 def test_layout_filling_fail():
+    register = Register.square(5, prefix="q")
     with pytest.raises(
         TypeError,
-        match="'validate_layout_filling' can only be called for"
-        " registers with a register layout.",
+        match=re.escape(
+            "'validate_layout_filling' can only be called for"
+            " registers with a register layout; got a Register with "
+            f"{len(register.qubit_ids)} qubits and no layout."
+        ),
     ):
-        DigitalAnalogDevice.validate_layout_filling(
-            Register.square(5, prefix="q")
-        )
+        DigitalAnalogDevice.validate_layout_filling(register)
 
 
 def test_calibrated_layouts(helpers):
@@ -735,7 +785,11 @@ def test_calibrated_layouts(helpers):
     }
     with pytest.raises(
         TypeError,
-        match="The register to check must be of type ",
+        match=re.escape(
+            "The register to check must be an instance of "
+            "'BaseRegister' or 'MappableRegister'; "
+            f"got {type(layout100)}."
+        ),
     ):
         TestDevice.register_is_from_calibrated_layout(layout100)
     assert TestDevice.is_calibrated_layout(layout100)
@@ -861,9 +915,10 @@ def test_dmm_channels():
     assert device.dmm_channels["dmm_0"] == dmm
     with pytest.raises(
         ValueError,
-        match=(
+        match=re.escape(
             "When defined, the names of channel IDs must be different"
-            " than the names of DMM channels 'dmm_0', 'dmm_1', ... ."
+            " than the names of DMM channels 'dmm_0', 'dmm_1', ... ; "
+            "got ['dmm_0']."
         ),
     ):
         device = replace(

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -85,7 +85,8 @@ def test_params():
             "rydberg_level",
             70.0,
             re.escape(
-                "Rydberg level has to be an int; got <class 'float'>: 70.0."
+                "'rydberg_level' must be an instance of 'int', not "
+                "<class 'float'>: 70.0."
             ),
         ),
         (
@@ -93,7 +94,7 @@ def test_params():
             {"fake_channel"},
             re.escape(
                 "When defined, 'channel_ids' must be a tuple or a list "
-                "of strings; got <class 'set'>: {'fake_channel'}."
+                "of strings, not <class 'set'>: {'fake_channel'}."
             ),
         ),
         (
@@ -101,7 +102,7 @@ def test_params():
             ("ch1", 2),
             re.escape(
                 "When defined, 'channel_ids' must be a tuple or a list "
-                "of strings; got <class 'tuple'>: ('ch1', 2)."
+                "of strings, not <class 'tuple'>: ('ch1', 2)."
             ),
         ),
         (
@@ -211,9 +212,8 @@ def test_post_init_type_checks(test_params, param, value, msg):
             ("rydberg_global",),
             re.escape(
                 "When defined, the number of channel IDs must"
-                " match the number of channel objects; "
-                "got 1 channel ids for 0 channel objects: "
-                "('rydberg_global',)."
+                " match the number of channel objects; got "
+                "1 'channel_ids' vs. 0 'channel_objects'."
             ),
         ),
         ("max_sequence_duration", 0, None),
@@ -424,7 +424,8 @@ def test_change_rydberg_level(helpers):
     with pytest.raises(
         TypeError,
         match=re.escape(
-            "Rydberg level has to be an int; got <class 'float'>: 70.5."
+            "'rydberg_level' must be an instance of 'int', not "
+            "<class 'float'>: 70.5."
         ),
     ):
         dev.change_rydberg_level(70.5)
@@ -537,8 +538,8 @@ def test_validate_register(helpers, with_diff):
     with pytest.raises(
         TypeError,
         match=re.escape(
-            "'register' must be a pulser.Register or "
-            f"a pulser.Register3D instance; got {type(bad_coords1)}."
+            "'register' must be an instance of 'Register' or "
+            f"'Register3D', not {type(bad_coords1)}."
         ),
     ):
         DigitalAnalogDevice.validate_register(bad_coords1)
@@ -596,8 +597,8 @@ def test_validate_layout(helpers):
     with pytest.raises(
         TypeError,
         match=re.escape(
-            "'layout' must be a RegisterLayout instance; "
-            f"got {type(not_a_layout)}."
+            "'layout' must be an instance of 'RegisterLayout', not "
+            f"{type(not_a_layout)}."
         ),
     ):
         DigitalAnalogDevice.validate_layout(not_a_layout)
@@ -744,8 +745,7 @@ def test_layout_filling_fail():
         TypeError,
         match=re.escape(
             "'validate_layout_filling' can only be called for"
-            " registers with a register layout; got a Register with "
-            f"{len(register.qubit_ids)} qubits and no layout."
+            " registers with a register layout."
         ),
     ):
         DigitalAnalogDevice.validate_layout_filling(register)
@@ -786,9 +786,8 @@ def test_calibrated_layouts(helpers):
     with pytest.raises(
         TypeError,
         match=re.escape(
-            "The register to check must be an instance of "
-            "'BaseRegister' or 'MappableRegister'; "
-            f"got {type(layout100)}."
+            "'register' must be an instance of 'BaseRegister' or "
+            f"'MappableRegister', not {type(layout100)}."
         ),
     ):
         TestDevice.register_is_from_calibrated_layout(layout100)
@@ -917,8 +916,8 @@ def test_dmm_channels():
         ValueError,
         match=re.escape(
             "When defined, the names of channel IDs must be different"
-            " than the names of DMM channels 'dmm_0', 'dmm_1', ... ; "
-            "got ['dmm_0']."
+            " than the names of DMM channels 'dmm_0', 'dmm_1', "
+            "...; got ['dmm_0']."
         ),
     ):
         device = replace(


### PR DESCRIPTION
Hi @a-corni, @HGSilveri,

This covers the whole devices module (11 messages: 8 in `_device_datacls.py`, 3 in `exceptions/sequence.py`).

Left unchanged: SLM without a DMM, the incompatible-layout wrapper (the original error is still chained), specifying both `noise_model` and `default_noise_model`, and `validate_layout_filling` on a register with no layout. Those describe a config/state, not a useful extra value to dump.

Partially addresses #1057.
