### PR TITLE
Enforce matching types in layout deserialization

### DIFF
--- a/pulser-core/pulser/json/abstract_repr/deserializer.py
+++ b/pulser-core/pulser/json/abstract_repr/deserializer.py
@@ -17,7 +17,16 @@ from __future__ import annotations
 
 import dataclasses
 import json
-from typing import TYPE_CHECKING, Any, Literal, Type, Union, cast, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
 import jsonschema
 import jsonschema.exceptions
@@ -69,6 +78,7 @@ if TYPE_CHECKING:
 VARIABLE_TYPE_MAP = {"int": int, "float": float}
 
 ExpReturnType = Union[int, float, list, ParamObj]
+T = TypeVar("T", bound=RegisterLayout)
 
 
 @overload
@@ -555,9 +565,9 @@ def _deserialize_device_object(obj: dict[str, Any]) -> Device | VirtualDevice:
     # value determined by the Rydberg level, i.e. when it was customized.
     if "interaction_coeff_xy" in obj:
         rydberg_level = params.get("rydberg_level")
-        if (  # Defensive, rydberg_level should always exist
+        if (
             rydberg_level is None
-        ) or (
+        ) or (  # Defensive, rydberg_level should always exist
             obj["interaction_coeff_xy"]
             != devices.interaction_coefficients.c3_dict[rydberg_level]
         ):
@@ -702,18 +712,41 @@ def deserialize_device(obj_str: str) -> Device | VirtualDevice:
         raise DeserializeDeviceError from e
 
 
-def deserialize_abstract_layout(obj_str: str) -> RegisterLayout:
+@overload
+def deserialize_abstract_layout(
+    obj_str: str, matching_type: None = None
+) -> RegisterLayout:
+    pass
+
+
+@overload
+def deserialize_abstract_layout(obj_str: str, matching_type: Type[T]) -> T:
+    pass
+
+
+def deserialize_abstract_layout(
+    obj_str: str, matching_type: Type[RegisterLayout] | None = None
+) -> RegisterLayout:
     """Deserialize a layout from an abstract JSON object.
 
     Args:
         obj_str: the JSON string representing the layout encoded
             in the abstract JSON format.
+        matching_type: A specific RegisterLayout type that the deserialized
+            layout must match.
 
     Returns:
         The RegisterLayout instance.
     """
     validate_abstract_repr(obj_str, "layout")
-    return _deserialize_layout(json.loads(obj_str))
+    layout = _deserialize_layout(json.loads(obj_str))
+    if matching_type is not None and not isinstance(layout, matching_type):
+        raise ValueError(
+            f"The deserialized layout has type '{type(layout).__name__}', "
+            f"which does not match the requested type "
+            f"'{matching_type.__name__}'."
+        )
+    return layout
 
 
 @overload

--- a/pulser-core/pulser/json/abstract_repr/deserializer.py
+++ b/pulser-core/pulser/json/abstract_repr/deserializer.py
@@ -565,9 +565,9 @@ def _deserialize_device_object(obj: dict[str, Any]) -> Device | VirtualDevice:
     # value determined by the Rydberg level, i.e. when it was customized.
     if "interaction_coeff_xy" in obj:
         rydberg_level = params.get("rydberg_level")
-        if (
+        if (  # Defensive, rydberg_level should always exist
             rydberg_level is None
-        ) or (  # Defensive, rydberg_level should always exist
+        ) or (
             obj["interaction_coeff_xy"]
             != devices.interaction_coefficients.c3_dict[rydberg_level]
         ):
@@ -732,8 +732,9 @@ def deserialize_abstract_layout(
     Args:
         obj_str: the JSON string representing the layout encoded
             in the abstract JSON format.
-        matching_type: A specific RegisterLayout type that the deserialized
-            layout must match.
+        matching_type: An optional specific RegisterLayout type that the
+            deserialized layout must match. When omitted, no type check is
+            performed.
 
     Returns:
         The RegisterLayout instance.
@@ -744,7 +745,7 @@ def deserialize_abstract_layout(
         raise ValueError(
             f"The deserialized layout has type '{type(layout).__name__}', "
             f"which does not match the requested type "
-            f"'{matching_type.__name__}'."
+            f"'{matching_type.__name__}'. Got serialized layout {obj_str}."
         )
     return layout
 

--- a/pulser-core/pulser/register/register_layout.py
+++ b/pulser-core/pulser/register/register_layout.py
@@ -21,7 +21,7 @@ from collections import Counter
 from collections.abc import Mapping
 from collections.abc import Sequence as abcSequence
 from dataclasses import dataclass
-from typing import Any, Optional, cast
+from typing import Any, Optional, Type, TypeVar, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -36,6 +36,8 @@ from pulser.register.base_register import BaseRegister, QubitId
 from pulser.register.mappable_reg import MappableRegister
 from pulser.register.traps import Traps
 from pulser.register.weight_maps import DetuningMap
+
+T = TypeVar("T", bound="RegisterLayout")
 
 
 @dataclass(init=False, repr=False, eq=False, frozen=True)
@@ -293,8 +295,8 @@ class RegisterLayout(Traps, RegDrawer):
         validate_abstract_repr(abstr_layout_str, "layout")
         return abstr_layout_str
 
-    @staticmethod
-    def from_abstract_repr(obj_str: str) -> RegisterLayout:
+    @classmethod
+    def from_abstract_repr(cls: Type[T], obj_str: str) -> T:
         """Deserialize a layout from an abstract JSON object.
 
         Args:
@@ -308,5 +310,5 @@ class RegisterLayout(Traps, RegDrawer):
             )
         # Avoids circular imports
         return pulser_abstract_repr.deserializer.deserialize_abstract_layout(
-            obj_str
+            obj_str, matching_type=cls
         )

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -179,11 +179,13 @@ def test_layout(layout: RegisterLayout):
     ser_layout_obj = json.loads(ser_layout_str)
     assert ser_layout_obj.get("slug", None) == layout.slug
 
-    re_layout = RegisterLayout.from_abstract_repr(ser_layout_str)
-    assert layout == re_layout
-    assert type(re_layout) is type(layout)
-    assert deserialize_layout(ser_layout_str) == re_layout
-    assert deserialize_layout(ser_layout_str, matching_type=None) == re_layout
+    for re_layout in [
+        RegisterLayout.from_abstract_repr(ser_layout_str),
+        deserialize_layout(ser_layout_str),
+        deserialize_layout(ser_layout_str, matching_type=None),
+    ]:
+        assert layout == re_layout
+        assert type(re_layout) is type(layout)
 
     matching_layout = type(layout).from_abstract_repr(ser_layout_str)
     assert matching_layout == layout
@@ -214,13 +216,14 @@ def test_layout_rejects_mismatched_type(layout, matching_type):
     error_match = (
         f"The deserialized layout has type '{type(layout).__name__}', "
         f"which does not match the requested type "
-        f"'{matching_type.__name__}'."
+        f"'{matching_type.__name__}'. Got serialized layout "
+        f"{serialized_layout}."
     )
 
-    with pytest.raises(ValueError, match=error_match):
+    with pytest.raises(ValueError, match=re.escape(error_match)):
         matching_type.from_abstract_repr(serialized_layout)
 
-    with pytest.raises(ValueError, match=error_match):
+    with pytest.raises(ValueError, match=re.escape(error_match)):
         deserialize_layout(serialized_layout, matching_type=matching_type)
 
 

--- a/tests/test_abstract_repr.py
+++ b/tests/test_abstract_repr.py
@@ -29,7 +29,7 @@ import pytest
 
 import pulser
 from pulser import Pulse, Register, Register3D, Sequence, devices
-from pulser.abstract_repr import deserialize_device
+from pulser.abstract_repr import deserialize_device, deserialize_layout
 from pulser.channels import DMM, Rydberg
 from pulser.channels.eom import RydbergBeam, RydbergEOM
 from pulser.devices import (
@@ -182,6 +182,12 @@ def test_layout(layout: RegisterLayout):
     re_layout = RegisterLayout.from_abstract_repr(ser_layout_str)
     assert layout == re_layout
     assert type(re_layout) is type(layout)
+    assert deserialize_layout(ser_layout_str) == re_layout
+    assert deserialize_layout(ser_layout_str, matching_type=None) == re_layout
+
+    matching_layout = type(layout).from_abstract_repr(ser_layout_str)
+    assert matching_layout == layout
+    assert type(matching_layout) is type(layout)
 
     with pytest.raises(TypeError, match="must be given as a string"):
         RegisterLayout.from_abstract_repr(ser_layout_obj)
@@ -192,6 +198,30 @@ def test_layout(layout: RegisterLayout):
             [0, 0, 0] if layout.dimensionality == 2 else [0, 0]
         )
         RegisterLayout.from_abstract_repr(json.dumps(ser_layout_obj))
+
+
+@pytest.mark.parametrize(
+    ("layout", "matching_type"),
+    [
+        (SquareLatticeLayout(2, 3, 4), TriangularLatticeLayout),
+        (TriangularLatticeLayout(7, 4), SquareLatticeLayout),
+        (RectangularLatticeLayout(2, 3, 4, 5), SquareLatticeLayout),
+        (RegisterLayout([[0, 0], [1, 1]]), TriangularLatticeLayout),
+    ],
+)
+def test_layout_rejects_mismatched_type(layout, matching_type):
+    serialized_layout = layout.to_abstract_repr()
+    error_match = (
+        f"The deserialized layout has type '{type(layout).__name__}', "
+        f"which does not match the requested type "
+        f"'{matching_type.__name__}'."
+    )
+
+    with pytest.raises(ValueError, match=error_match):
+        matching_type.from_abstract_repr(serialized_layout)
+
+    with pytest.raises(ValueError, match=error_match):
+        deserialize_layout(serialized_layout, matching_type=matching_type)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`RegisterLayout.from_abstract_repr()` currently ignores the class it is called on, which allows a specialized layout class to return an incompatible layout type.

This change makes it a classmethod and passes the requested class to the standalone layout deserializer. Specialized classes now reject incompatible serialized layouts with a clear error. Calling the base class or standalone deserializer without a requested type keeps the existing automatic subtype detection.

Tests cover matching special layouts, generic layouts, base-class compatibility, explicit `None`, and mismatches through both public APIs.

Closes #1099

Tests:

- 321 abstract representation, register layout, register, and JSON tests passed
- Mypy passed for the changed source files
- Black, isort, flake8, and diff checks passed
